### PR TITLE
[JENKINS-34064] Backing out JENKINS-26481 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>com.cloudbees</groupId>
             <artifactId>groovy-cps</artifactId>
-            <version>1.7</version>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/SerializationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/SerializationTest.java
@@ -202,6 +202,7 @@ public class SerializationTest extends SingleJobTestBase {
         });
     }
 
+    @Ignore("TODO backed out for JENKINS-34064")
     @Issue("JENKINS-26481")
     @Test public void eachClosure() {
         story.addStep(new Statement() {


### PR DESCRIPTION
[JENKINS-34064](https://issues.jenkins-ci.org/browse/JENKINS-34064)

Until https://github.com/cloudbees/groovy-cps/pull/24 can be finished, or at least merged & released in its current state, we have to revert to the earlier release.

@reviewbybees esp. @kohsuke