### PR TITLE
[JENKINS-26156] BodyInvoker.displayName was broken

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepEndNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepEndNode.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.workflow.cps.nodes;
 
 import hudson.model.Action;
-import org.jenkinsci.plugins.workflow.actions.BodyInvocationAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -39,12 +38,12 @@ public class StepEndNode extends BlockEndNode<StepStartNode> implements StepNode
 
     @Override
     protected String getTypeFunctionName() {
-        StepDescriptor d = getDescriptor();
         boolean isBody = getStartNode().isBody();
         if (isBody) {
             return "}";
         } else {
-            return "} // " + (d != null ? d.getFunctionName() : getStartNode().getStepName());
+            StepDescriptor d = getDescriptor();
+            return "// " + (d != null ? d.getFunctionName() : getStartNode().getStepName());
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepEndNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepEndNode.java
@@ -42,9 +42,9 @@ public class StepEndNode extends BlockEndNode<StepStartNode> implements StepNode
         StepDescriptor d = getDescriptor();
         boolean isBody = getStartNode().isBody();
         if (isBody) {
-            return "} //" + (d != null ? d.getFunctionName() : getStartNode().getStepName());
+            return "}";
         } else {
-            return getStartNode().getStepName() + " : End";
+            return "} // " + (d != null ? d.getFunctionName() : getStartNode().getStepName());
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -51,9 +51,9 @@ public class StepStartNode extends BlockStartNode implements StepNode {
     protected String getTypeFunctionName() {
         StepDescriptor d = getDescriptor();
         if (isBody()) {
-            return (d != null ? d.getFunctionName() : descriptorId) + " {";
+            return "{";
         } else {
-            return getStepName() + " : Start";
+            return (d != null ? d.getFunctionName() : descriptorId) + " {";
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -49,11 +49,11 @@ public class StepStartNode extends BlockStartNode implements StepNode {
 
     @Override
     protected String getTypeFunctionName() {
-        StepDescriptor d = getDescriptor();
         if (isBody()) {
             return "{";
         } else {
-            return (d != null ? d.getFunctionName() : descriptorId) + " {";
+            StepDescriptor d = getDescriptor();
+            return (d != null ? d.getFunctionName() : descriptorId);
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/DynamicEnvironmentExpanderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/DynamicEnvironmentExpanderTest.java
@@ -82,7 +82,7 @@ public class DynamicEnvironmentExpanderTest {
                 context.newBodyInvoker().
                         withContexts(EnvironmentExpander.merge(context.get(EnvironmentExpander.class), new ExpanderImpl(this))).
                         withCallback(BodyExecutionCallback.wrap(context)).
-                        withDisplayName(null).start();
+                        start();
                 return false;
             }
             @Override public void onResume() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/WorkflowJobNonRestartingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/WorkflowJobNonRestartingTest.java
@@ -155,14 +155,14 @@ public class WorkflowJobNonRestartingTest extends AbstractCpsFlowTest {
 
         idx = 0;
         for (String msg : new String[] {
-            "[Pipeline] retry {",
+            "[Pipeline] retry",
             "[Pipeline] {",
             "[Pipeline] }",
             "[Pipeline] {",
             "[Pipeline] }",
             "[Pipeline] {",
             "[Pipeline] }",
-            "[Pipeline] } // retry",
+            "[Pipeline] // retry",
         }) {
             idx = log.indexOf(msg, idx + 1);
             assertTrue(msg + " not found", idx != -1);

--- a/src/test/java/org/jenkinsci/plugins/workflow/WorkflowJobNonRestartingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/WorkflowJobNonRestartingTest.java
@@ -49,6 +49,8 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import javax.mail.Folder;
+import org.junit.ClassRule;
+import org.jvnet.hudson.test.BuildWatcher;
 
 /**
  * Test of {@link WorkflowJob} that doesn't involve Jenkins restarts.
@@ -56,6 +58,8 @@ import javax.mail.Folder;
  * @author Kohsuke Kawaguchi
  */
 public class WorkflowJobNonRestartingTest extends AbstractCpsFlowTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
 
     WorkflowJob p;
 
@@ -132,7 +136,6 @@ public class WorkflowJobNonRestartingTest extends AbstractCpsFlowTest {
 
         String log = JenkinsRule.getLog(b);
         jenkins.assertLogNotContains("\tat ", b);
-        System.err.println(log);
 
         int idx = 0;
         for (String msg : new String[] {
@@ -152,14 +155,14 @@ public class WorkflowJobNonRestartingTest extends AbstractCpsFlowTest {
 
         idx = 0;
         for (String msg : new String[] {
-            "[Pipeline] Retry the body up to N times : Start",
             "[Pipeline] retry {",
-            "[Pipeline] } //retry",
-            "[Pipeline] retry {",
-            "[Pipeline] } //retry",
-            "[Pipeline] retry {",
-            "[Pipeline] } //retry",
-            "[Pipeline] Retry the body up to N times : End",
+            "[Pipeline] {",
+            "[Pipeline] }",
+            "[Pipeline] {",
+            "[Pipeline] }",
+            "[Pipeline] {",
+            "[Pipeline] }",
+            "[Pipeline] } // retry",
         }) {
             idx = log.indexOf(msg, idx + 1);
             assertTrue(msg + " not found", idx != -1);


### PR DESCRIPTION
[JENKINS-26156](https://issues.jenkins-ci.org/browse/JENKINS-26156)

Before:
* if you passed null, or simply did not call it at all, there were body block nodes contrary to documentation
* if you passed non-null, you would get an `IllegalStateException` (!)

After:
* body block nodes are created unconditionally
* you may call it, with a non-null name, if you want a label on the body block

@kohsuke seems to have been trying to elide body block nodes when they contribute no interesting information, as in most steps accepting a closure (`node`, say, as opposed to `retry` which _might_ have something interesting to show like a retry count). But this was never actually implemented, and seems too dangerous to try anyway. What if a step asked to elide the body block nodes but then actually called its body twice? We would get a confused flow graph.

I _did_ clean up the log display a bit, from what @amuniz did in https://github.com/jenkinsci/pipeline-plugin/pull/215 (cf. [JENKINS-31595](https://issues.jenkins-ci.org/browse/JENKINS-31595)). Before:

```
[Pipeline] Some display name intended for GUI : Start
[Pipeline] theActualStepName {
body text…
[Pipeline] } //theActualStepName
[Pipeline] Some display name intended for GUI : End
```

After:

```
[Pipeline] theActualStepName {
[Pipeline] {
body text…
[Pipeline] }
[Pipeline] } // theActualStepName
```

With some more work in `WorkflowRun.logNodeMessage` this could probably be improved further, to check for `BodyInvocationAction` and `LabelAction` on `BlockStartNode`s, giving us a more streamlined

```
[Pipeline] theActualStepName {
body text…
[Pipeline] } // theActualStepName
```

plus some variants for bodies which are actually run >1 time and/or specify a label, but I will leave that for another day.

@reviewbybees