### PR TITLE
Enable the sandbox by default

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/config.jelly
@@ -28,7 +28,7 @@
     <wfe:workflow-editor />
   </f:entry>
   <f:entry field="sandbox">
-    <f:checkbox title="${%Use Groovy Sandbox}" default="${!h.hasPermission(app.RUN_SCRIPTS)}" />
+    <f:checkbox title="${%Use Groovy Sandbox}" default="true"/>
   </f:entry>
   <st:include it="${descriptor.snippetizer}" page="block.jelly"/>
 </j:jelly>


### PR DESCRIPTION
@HRMPW suggested turning on sandbox mode by default in all cases, even for Jenkins administrators. (See https://github.com/jenkinsci/pipeline-plugin/pull/67 for the original conditional logic.) There are several arguments for doing this:

* At least pending [JENKINS-28178](https://issues.jenkins-ci.org/browse/JENKINS-28178), if you want to convert to `Jenkinsfile` (whether for multibranch support, or simply to keep single-project sources in SCM) you will need to have a sandboxable script anyway, so you might as well start learning Pipeline this way.
* The sandbox will catch certain common beginner mistakes, such as
```groovy
node('slave') {
  checkout …
  def text = new File('something-in-workspace').text
}
```
where `readFile` was in fact needed.

@reviewbybees