### PR TITLE
[JENKINS-31831] Amendment to display a link in the config form

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/config.jelly
@@ -30,4 +30,7 @@
   <f:entry field="sandbox">
     <f:checkbox title="${%Use Groovy Sandbox}" default="true"/>
   </f:entry>
+    <f:block>
+        <a href="pipeline-syntax" target="_blank">${%Pipeline Syntax}</a>
+    </f:block>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition/config.jelly
@@ -29,4 +29,7 @@ THE SOFTWARE.
     <f:entry field="scriptPath" title="${%Script Path}">
         <f:textbox default="Jenkinsfile"/>
     </f:entry>
+    <f:block>
+        <a href="pipeline-syntax" target="_blank">${%Pipeline Syntax}</a>
+    </f:block>
 </j:jelly>


### PR DESCRIPTION
@HRMPW noticed that #12 is not great in Jenkins 2.

Multibranch pipelines and organization folders are unaffected, at least until [JENKINS-33622](https://issues.jenkins-ci.org/browse/JENKINS-33622) is fixed.

@reviewbybees