### PR TITLE
[JENKINS-26481] More clearly report problem passing closures to binary methods

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/GroovyClassLoaderWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/GroovyClassLoaderWhitelist.java
@@ -1,24 +1,38 @@
 package org.jenkinsci.plugins.workflow.cps;
 
+import com.cloudbees.groovy.cps.impl.CpsClosure;
 import groovy.lang.GroovyClassLoader;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.EnumeratingWhitelist;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
 
 /**
  * Allow any calls into the scripted compiled in the sandbox.
  *
  * IOW, allow the user to call his own methods.
- *
- * @author Kohsuke Kawaguchi
  */
 class GroovyClassLoaderWhitelist extends Whitelist {
+
     private final ClassLoader scriptLoader;
 
-    public GroovyClassLoaderWhitelist(GroovyClassLoader scriptLoader) {
+    /**
+     * {@link ProxyWhitelist} has an optimization which bypasses {@code permits*} calls
+     * when it detects {@link EnumeratingWhitelist} delegates,
+     * so we must do delegation manually.
+     * For the same reason, doing this check inside {@link CpsWhitelist} is tricky.
+     */
+    private final Whitelist delegate;
+
+    GroovyClassLoaderWhitelist(GroovyClassLoader scriptLoader, Whitelist delegate) {
         this.scriptLoader = scriptLoader;
+        this.delegate = delegate;
     }
 
     private boolean permits(Class<?> declaringClass) {
@@ -30,30 +44,48 @@ class GroovyClassLoaderWhitelist extends Whitelist {
     }
 
     @Override public boolean permitsMethod(Method method, Object receiver, Object[] args) {
-        return permits(method.getDeclaringClass());
+        return checkJenkins26481(args, method) || delegate.permitsMethod(method, receiver, args);
     }
 
     @Override public boolean permitsConstructor(Constructor<?> constructor, Object[] args) {
-        return permits(constructor.getDeclaringClass());
+        return checkJenkins26481(args, constructor) || delegate.permitsConstructor(constructor, args);
     }
 
     @Override public boolean permitsStaticMethod(Method method, Object[] args) {
-        return permits(method.getDeclaringClass());
+        return checkJenkins26481(args, method) || delegate.permitsStaticMethod(method, args);
     }
 
     @Override public boolean permitsFieldGet(Field field, Object receiver) {
-        return permits(field.getDeclaringClass());
+        return permits(field.getDeclaringClass()) || delegate.permitsFieldGet(field, receiver);
     }
 
     @Override public boolean permitsFieldSet(Field field, Object receiver, Object value) {
-        return permits(field.getDeclaringClass());
+        return permits(field.getDeclaringClass()) || delegate.permitsFieldSet(field, receiver, value);
     }
 
     @Override public boolean permitsStaticFieldGet(Field field) {
-        return permits(field.getDeclaringClass());
+        return permits(field.getDeclaringClass()) || delegate.permitsStaticFieldGet(field);
     }
 
     @Override public boolean permitsStaticFieldSet(Field field, Object value) {
-        return permits(field.getDeclaringClass());
+        return permits(field.getDeclaringClass()) || delegate.permitsStaticFieldSet(field, value);
     }
+
+    /**
+     * Blocks accesses to some {@link DefaultGroovyMethods}, or any other binary method taking a closure, until JENKINS-26481 is fixed.
+     * Only improves diagnostics for scripts using the sandbox.
+     * Note that we do not simply return false for these cases, as that would throw {@link RejectedAccessException} without a meaningful explanation.
+     */
+    private boolean checkJenkins26481(Object[] args, Executable method) throws UnsupportedOperationException {
+        if (permits(method.getDeclaringClass())) { // fine for source-defined methods to take closures
+            return true;
+        }
+        for (Object arg : args) {
+            if (arg instanceof CpsClosure) {
+                throw new UnsupportedOperationException("Calling " + method + " on a CPS-transformed closure is not yet supported (JENKINS-26481); encapsulate in a @NonCPS method, or use Java-style loops");
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/GroovyClassLoaderWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/GroovyClassLoaderWhitelist.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.workflow.cps;
 
 import com.cloudbees.groovy.cps.impl.CpsClosure;
+import groovy.lang.Closure;
 import groovy.lang.GroovyClassLoader;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
 
@@ -80,8 +81,9 @@ class GroovyClassLoaderWhitelist extends Whitelist {
         if (permits(method.getDeclaringClass())) { // fine for source-defined methods to take closures
             return true;
         }
-        for (Object arg : args) {
-            if (arg instanceof CpsClosure) {
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        for (int i = 0; i < args.length; i++) {
+            if (args[i] instanceof CpsClosure && parameterTypes.length > i && parameterTypes[i] == Closure.class) {
                 throw new UnsupportedOperationException("Calling " + method + " on a CPS-transformed closure is not yet supported (JENKINS-26481); encapsulate in a @NonCPS method, or use Java-style loops");
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/SandboxContinuable.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/SandboxContinuable.java
@@ -4,7 +4,6 @@ import com.cloudbees.groovy.cps.Continuable;
 import com.cloudbees.groovy.cps.Outcome;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 
@@ -37,7 +36,7 @@ class SandboxContinuable extends Continuable {
                     }
                     return outcome;
                 }
-            }, new ProxyWhitelist(new GroovyClassLoaderWhitelist(thread.group.getExecution().getShell().getClassLoader()),CpsWhitelist.get()));
+            }, new GroovyClassLoaderWhitelist(thread.group.getExecution().getShell().getClassLoader(), CpsWhitelist.get()));
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/SerializationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/SerializationTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow;
 
+import groovy.lang.Closure;
 import hudson.model.Result;
 import hudson.slaves.DumbSlave;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
@@ -234,6 +235,15 @@ public class SerializationTest extends SingleJobTestBase {
         });
     }
 
+    /**
+     * Verifies that we are not throwing {@link UnsupportedOperationException} too aggressively.
+     * In particular:
+     * <ul>
+     * <li>on non-CPS-transformed {@link Closure}s
+     * <li>on closures passed to methods defined in Pipeline script
+     * <li>on closures passed to methods which did not declare {@link Closure} as a parameter type and so presumably are not going to try to call them
+     * </ul>
+     */
     @Issue("JENKINS-26481")
     @Test public void eachClosureNonCps() {
         story.addStep(new Statement() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/SerializationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/SerializationTest.java
@@ -237,6 +237,7 @@ public class SerializationTest extends SingleJobTestBase {
     @Test public void eachClosureNonCps() {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
+                ScriptApproval.get().approveSignature("staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.Collection java.lang.Object");
                 p = jenkins().createProject(WorkflowJob.class, "demo");
                 p.setDefinition(new CpsFlowDefinition(
                     "@NonCPS def fine() {\n" +
@@ -246,7 +247,9 @@ public class SerializationTest extends SingleJobTestBase {
                     "}\n" +
                     "def takesMyOwnClosure(body) {\n" +
                     "  node {\n" +
-                    "    echo body()\n" +
+                    "    def list = []\n" +
+                    "    list += body\n" +
+                    "    echo list[0]()\n" +
                     "  }\n" +
                     "}\n" +
                     "takesMyOwnClosure {\n" +

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
@@ -7,9 +7,11 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import static org.junit.Assert.*;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
@@ -19,6 +21,8 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
  * @author Kohsuke Kawaguchi
  */
 public class RestartingLoadStepTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
 
     @Inject
@@ -34,8 +38,8 @@ public class RestartingLoadStepTest {
                 WorkflowJob p = jenkins.createProject(WorkflowJob.class, "p");
                 jenkins.getWorkspaceFor(p).child("test.groovy").write(
                     "def answer(i) { return i*2; }\n" +
-                    "def foo() {\n" +
-                    "    def i=21;\n" +
+                    "def foo(body) {\n" +
+                    "    def i = body()\n" +
                     "    semaphore 'watchA'\n" +
                     "    return answer(i);\n" +
                     "}\n" +
@@ -44,7 +48,7 @@ public class RestartingLoadStepTest {
                     "node {\n" +
                     "  println 'started'\n" +
                     "  def o = load 'test.groovy'\n" +
-                    "  println 'o=' + o.foo();\n" +
+                    "  println 'o=' + o.foo({21})\n" +
                     "}"));
 
                 // get the build going


### PR DESCRIPTION
[JENKINS-26481](https://issues.jenkins-ci.org/browse/JENKINS-26481)

Tries to improve diagnostics until https://github.com/cloudbees/groovy-cps/pull/24 can be fixed.

Before this patch, `SerializationTest.eachClosure` fails with cryptic script behavior:

```
Started
[Pipeline] node
Running on master in /tmp/junit3096297553890442745/junit8071484631883149575/workspace/demo
[Pipeline] {
[Pipeline] writeFile
[Pipeline] semaphore
[Pipeline] readFile
[Pipeline] echo
a
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```

Note that there is no error in the build, it just does not run correctly. After the patch, the build fails:

```
Started
[Pipeline] node
Running on master in /tmp/junit8559386618399120809/junit4301051117364074727/workspace/demo
[Pipeline] {
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
java.lang.UnsupportedOperationException: Calling public static java.lang.Object org.codehaus.groovy.runtime.DefaultGroovyMethods.each(java.lang.Object,groovy.lang.Closure) on a CPS-transformed closure is not yet supported (JENKINS-26481); encapsulate in a @NonCPS method, or use Java-style loops
	at org.jenkinsci.plugins.workflow.cps.GroovyClassLoaderWhitelist.checkJenkins26481(GroovyClassLoaderWhitelist.java:84)
	at org.jenkinsci.plugins.workflow.cps.GroovyClassLoaderWhitelist.permitsStaticMethod(GroovyClassLoaderWhitelist.java:54)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onMethodCall(SandboxInterceptor.java:83)
	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:149)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:146)
	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.methodCall(SandboxInvoker.java:15)
	at WorkflowScript.run(WorkflowScript:2)
	at ___cps.transform___(Native Method)
	at com.cloudbees.groovy.cps.impl.ContinuationGroup.methodCall(ContinuationGroup.java:55)
	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:106)
	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixArg(FunctionCallBlock.java:79)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
	at com.cloudbees.groovy.cps.impl.ClosureBlock.eval(ClosureBlock.java:40)
	at com.cloudbees.groovy.cps.Next.step(Next.java:58)
	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:154)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable$1.call(SandboxContinuable.java:32)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable$1.call(SandboxContinuable.java:29)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox.runInSandbox(GroovySandbox.java:106)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:29)
	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:164)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:276)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$000(CpsThreadGroup.java:78)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:185)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:183)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:47)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Finished: FAILURE
```

@reviewbybees esp. @kohsuke