### PR TITLE
[FIXED JENKINS-35395] Copy Global Variable docs into their own page.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/globals.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/globals.groovy
@@ -1,22 +1,10 @@
 package org.jenkinsci.plugins.workflow.cps.Snippetizer
 
-import org.jenkinsci.plugins.structs.describable.ArrayType
-import org.jenkinsci.plugins.structs.describable.AtomicType
-import org.jenkinsci.plugins.structs.describable.DescribableModel
-import org.jenkinsci.plugins.structs.describable.DescribableParameter
-import org.jenkinsci.plugins.structs.describable.EnumType
-import org.jenkinsci.plugins.structs.describable.ErrorType
-import org.jenkinsci.plugins.structs.describable.HeterogeneousObjectType
-import org.jenkinsci.plugins.structs.describable.HomogeneousObjectType
-import org.jenkinsci.plugins.structs.describable.ParameterType
+
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable
 import org.jenkinsci.plugins.workflow.cps.Snippetizer
-import org.jenkinsci.plugins.workflow.steps.StepDescriptor
 
 import javax.servlet.RequestDispatcher
-
-// keeps track of recursion inside generateHelp
-stack = new Stack();
 
 Snippetizer snippetizer = my;
 
@@ -30,140 +18,30 @@ l.layout(title:_("Pipeline Syntax: Global Variable Reference"), norefresh: true)
       h1(_("Overview"))
       st.include(page: 'globalsHelp')
 
-div(class:'dsl-reference'){
-  h1(_("Global Variable Reference"))
-  
-  div(class:'steps-box variables'){
-  
-    h2(_("Variables"))
-    dl(class:'steps variables root'){
-      for (GlobalVariable v : snippetizer.getGlobalVariables()) {
-        dt {
-          code(v.getName())
-        }
-        dd{
-          RequestDispatcher rd = request.getView(v, "help");
-          div(class:"help", style:"display: block") {
-            if (rd != null) {
-              st.include(page: "help", it: v)
-            } else {
-              raw("(no help)")
-            }
-          }
-        }
-      }
-    }
-  }
-}
+      div(class:'dsl-reference'){
+        h1(_("Global Variable Reference"))
 
-    }
-}
+        div(class:'steps-box variables'){
 
-def generateHelp(DescribableModel model, int headerLevel) throws Exception {
-  return {
-    String help = model.help;
-    if (help != null && !help.equals("")) {
-      div(class:"help", style:"display: block") { raw(help) }
-    }
-    if (stack.contains(model.type))
-      return; // recursion. just show the title & cut the search
-
-    stack.push(model.type);
-    dl(class:'help-list mandatory'){
-      // TODO else could use RequestDispatcher (as in Descriptor.doHelp) to serve template-based help
-      model.parameters.findAll{ it.required }.each { p ->
-        dt(class:'help-title'){ code(p.name)     }
-        dd(class:'help-body'){
-          generateAttrHelp(p, headerLevel);
-        }
-      }
-    }
-    dl(class:'help-list optional'){
-      for (DescribableParameter p : model.parameters) {
-        if (p.required) {
-          continue;
-        }
-        dt(class:'help-title'){
-          code(p.name)
-          raw(" (optional)")
-
-        }
-        dd(class:'help-body'){
-          generateAttrHelp(p, headerLevel);
-        }
-      }
-    }
-    stack.pop();
-  }.call()
-}
-
-def generateAttrHelp(DescribableParameter param, int headerLevel) throws Exception {
-  return {
-    String help = param.help;
-    if (help != null && !help.equals("")) {
-      div(class:"help", style:"display: block") { raw(help) }
-    }
-    describeType(param.type, headerLevel);
-  }.call()
-}
-
-def describeType(ParameterType type, int headerLevel) throws Exception {
-  return {
-    int nextHeaderLevel = Math.min(6, headerLevel + 1);
-    if (type instanceof AtomicType) {
-      div {
-        strong(_("Type:"))
-        text(type)
-      }
-    } else if (type instanceof EnumType) {
-      div(class:'values-box nested'){
-        div(class:'marker-title value-title'){
-          span(_("Values:"))
-        }
-        for (String v : ((EnumType) type).getValues()) {
-          div(class:'value list-item') { code(v) }
-        }
-      }
-    } else if (type instanceof ArrayType) {
-      div(class:'array-list-box marker'){
-        div(class:'array-title marker-title'){
-          span(_("Array/List:"))
-        }
-        div(class:'array-list'){
-          describeType(((ArrayType) type).getElementType(), headerLevel)
-        }
-      }
-    } else if (type instanceof HomogeneousObjectType) {
-      dl(class:'nested-object-box nested') {
-        dt(_("Nested object"))
-        dd{
-          generateHelp(((HomogeneousObjectType) type).getSchemaType(), nextHeaderLevel);
-        }
-      }
-    } else if (type instanceof HeterogeneousObjectType) {
-      dl(class:'nested-choice-box nested') {
-        dt(_("Nested choice of objects"))
-        dd{
-
-          dl(class:'schema') {
-            for (Map.Entry<String, DescribableModel> entry : ((HeterogeneousObjectType) type).getTypes().entrySet()) {
+          h2(_("Variables"))
+          dl(class:'steps variables root'){
+            for (GlobalVariable v : snippetizer.getGlobalVariables()) {
               dt {
-                code(DescribableModel.CLAZZ + ": '" + entry.key + "'")
+                code(v.getName())
               }
               dd{
-                generateHelp(entry.value, nextHeaderLevel);
+                RequestDispatcher rd = request.getView(v, "help");
+                div(class:"help", style:"display: block") {
+                  if (rd != null) {
+                    st.include(page: "help", it: v)
+                  } else {
+                    raw("(no help)")
+                  }
+                }
               }
             }
           }
         }
       }
-    } else if (type instanceof ErrorType) {
-      Exception x = ((ErrorType) type).getError();
-      pre { code(x) }
-    } else {
-      assert false: type;
     }
-  }.call()
 }
-
-st.adjunct(includes: 'org.jenkinsci.plugins.workflow.cps.Snippetizer.workflow')

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/globals.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/globals.groovy
@@ -1,0 +1,169 @@
+package org.jenkinsci.plugins.workflow.cps.Snippetizer
+
+import org.jenkinsci.plugins.structs.describable.ArrayType
+import org.jenkinsci.plugins.structs.describable.AtomicType
+import org.jenkinsci.plugins.structs.describable.DescribableModel
+import org.jenkinsci.plugins.structs.describable.DescribableParameter
+import org.jenkinsci.plugins.structs.describable.EnumType
+import org.jenkinsci.plugins.structs.describable.ErrorType
+import org.jenkinsci.plugins.structs.describable.HeterogeneousObjectType
+import org.jenkinsci.plugins.structs.describable.HomogeneousObjectType
+import org.jenkinsci.plugins.structs.describable.ParameterType
+import org.jenkinsci.plugins.workflow.cps.GlobalVariable
+import org.jenkinsci.plugins.workflow.cps.Snippetizer
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor
+
+import javax.servlet.RequestDispatcher
+
+// keeps track of recursion inside generateHelp
+stack = new Stack();
+
+Snippetizer snippetizer = my;
+
+def l = namespace(lib.LayoutTagLib)
+def st = namespace("jelly:stapler")
+
+l.layout(title:_("Pipeline Syntax: Global Variable Reference"), norefresh: true) {
+    st.include(page: 'sidepanel')
+    l.main_panel {
+
+      h1(_("Overview"))
+      st.include(page: 'globalsHelp')
+
+div(class:'dsl-reference'){
+  h1(_("Global Variable Reference"))
+  
+  div(class:'steps-box variables'){
+  
+    h2(_("Variables"))
+    dl(class:'steps variables root'){
+      for (GlobalVariable v : snippetizer.getGlobalVariables()) {
+        dt {
+          code(v.getName())
+        }
+        dd{
+          RequestDispatcher rd = request.getView(v, "help");
+          div(class:"help", style:"display: block") {
+            if (rd != null) {
+              st.include(page: "help", it: v)
+            } else {
+              raw("(no help)")
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+    }
+}
+
+def generateHelp(DescribableModel model, int headerLevel) throws Exception {
+  return {
+    String help = model.help;
+    if (help != null && !help.equals("")) {
+      div(class:"help", style:"display: block") { raw(help) }
+    }
+    if (stack.contains(model.type))
+      return; // recursion. just show the title & cut the search
+
+    stack.push(model.type);
+    dl(class:'help-list mandatory'){
+      // TODO else could use RequestDispatcher (as in Descriptor.doHelp) to serve template-based help
+      model.parameters.findAll{ it.required }.each { p ->
+        dt(class:'help-title'){ code(p.name)     }
+        dd(class:'help-body'){
+          generateAttrHelp(p, headerLevel);
+        }
+      }
+    }
+    dl(class:'help-list optional'){
+      for (DescribableParameter p : model.parameters) {
+        if (p.required) {
+          continue;
+        }
+        dt(class:'help-title'){
+          code(p.name)
+          raw(" (optional)")
+
+        }
+        dd(class:'help-body'){
+          generateAttrHelp(p, headerLevel);
+        }
+      }
+    }
+    stack.pop();
+  }.call()
+}
+
+def generateAttrHelp(DescribableParameter param, int headerLevel) throws Exception {
+  return {
+    String help = param.help;
+    if (help != null && !help.equals("")) {
+      div(class:"help", style:"display: block") { raw(help) }
+    }
+    describeType(param.type, headerLevel);
+  }.call()
+}
+
+def describeType(ParameterType type, int headerLevel) throws Exception {
+  return {
+    int nextHeaderLevel = Math.min(6, headerLevel + 1);
+    if (type instanceof AtomicType) {
+      div {
+        strong(_("Type:"))
+        text(type)
+      }
+    } else if (type instanceof EnumType) {
+      div(class:'values-box nested'){
+        div(class:'marker-title value-title'){
+          span(_("Values:"))
+        }
+        for (String v : ((EnumType) type).getValues()) {
+          div(class:'value list-item') { code(v) }
+        }
+      }
+    } else if (type instanceof ArrayType) {
+      div(class:'array-list-box marker'){
+        div(class:'array-title marker-title'){
+          span(_("Array/List:"))
+        }
+        div(class:'array-list'){
+          describeType(((ArrayType) type).getElementType(), headerLevel)
+        }
+      }
+    } else if (type instanceof HomogeneousObjectType) {
+      dl(class:'nested-object-box nested') {
+        dt(_("Nested object"))
+        dd{
+          generateHelp(((HomogeneousObjectType) type).getSchemaType(), nextHeaderLevel);
+        }
+      }
+    } else if (type instanceof HeterogeneousObjectType) {
+      dl(class:'nested-choice-box nested') {
+        dt(_("Nested choice of objects"))
+        dd{
+
+          dl(class:'schema') {
+            for (Map.Entry<String, DescribableModel> entry : ((HeterogeneousObjectType) type).getTypes().entrySet()) {
+              dt {
+                code(DescribableModel.CLAZZ + ": '" + entry.key + "'")
+              }
+              dd{
+                generateHelp(entry.value, nextHeaderLevel);
+              }
+            }
+          }
+        }
+      }
+    } else if (type instanceof ErrorType) {
+      Exception x = ((ErrorType) type).getError();
+      pre { code(x) }
+    } else {
+      assert false: type;
+    }
+  }.call()
+}
+
+st.adjunct(includes: 'org.jenkinsci.plugins.workflow.cps.Snippetizer.workflow')

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/globalsHelp.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/globalsHelp.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2016 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<div>
+    <p>
+        Global variables are available in Pipeline directly, not as steps. They expose methods and variables to be accessed within your Pipeline script.
+    </p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/html.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/html.groovy
@@ -24,57 +24,34 @@ def l = namespace(lib.LayoutTagLib)
 def st = namespace("jelly:stapler")
 
 l.layout(title:_("Pipeline Syntax: Reference"), norefresh: true) {
-    st.include(page: 'sidepanel')
-    l.main_panel {
+  st.include(page: 'sidepanel')
+  l.main_panel {
 
-      h1(_("Overview"))
-      st.include(page: 'help')
+    h1(_("Overview"))
+    st.include(page: 'help')
 
-div(class:'dsl-reference'){
-  h1(_("DSL Reference"))
-  
-  div(class:'steps-box basic'){
-    h2(_("Steps"))
-    dl(class:'steps basic root'){
-      for (StepDescriptor d : snippetizer.getStepDescriptors(false)) {
-        generateStepHelp(d);
-      }
-    }
-  }
-  
-  div(class:'steps-box advanced'){
-    h2(_("Advanced/Deprecated Steps"))
-    dl(class:'steps advanced root'){
-      for (StepDescriptor d : snippetizer.getStepDescriptors(true)) {
-        generateStepHelp(d);
-      }
-    }
-  }
-  
-  div(class:'steps-box variables'){
-  
-    h2(_("Variables"))
-    dl(class:'steps variables root'){
-      for (GlobalVariable v : snippetizer.getGlobalVariables()) {
-        dt {
-          code(v.getName())
+    div(class: 'dsl-reference') {
+      h1(_("DSL Reference"))
+
+      div(class: 'steps-box basic') {
+        h2(_("Steps"))
+        dl(class: 'steps basic root') {
+          for (StepDescriptor d : snippetizer.getStepDescriptors(false)) {
+            generateStepHelp(d);
+          }
         }
-        dd{
-          RequestDispatcher rd = request.getView(v, "help");
-          div(class:"help", style:"display: block") {
-            if (rd != null) {
-              st.include(page: "help", it: v)
-            } else {
-              raw("(no help)")
-            }
+      }
+
+      div(class: 'steps-box advanced') {
+        h2(_("Advanced/Deprecated Steps"))
+        dl(class: 'steps advanced root') {
+          for (StepDescriptor d : snippetizer.getStepDescriptors(true)) {
+            generateStepHelp(d);
           }
         }
       }
     }
   }
-}
-
-    }
 }
 
 def generateStepHelp(StepDescriptor d) throws Exception {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/html.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/html.groovy
@@ -24,34 +24,35 @@ def l = namespace(lib.LayoutTagLib)
 def st = namespace("jelly:stapler")
 
 l.layout(title:_("Pipeline Syntax: Reference"), norefresh: true) {
-  st.include(page: 'sidepanel')
-  l.main_panel {
+    st.include(page: 'sidepanel')
+    l.main_panel {
 
-    h1(_("Overview"))
-    st.include(page: 'help')
+      h1(_("Overview"))
+      st.include(page: 'help')
 
-    div(class: 'dsl-reference') {
-      h1(_("DSL Reference"))
-
-      div(class: 'steps-box basic') {
-        h2(_("Steps"))
-        dl(class: 'steps basic root') {
-          for (StepDescriptor d : snippetizer.getStepDescriptors(false)) {
-            generateStepHelp(d);
-          }
-        }
-      }
-
-      div(class: 'steps-box advanced') {
-        h2(_("Advanced/Deprecated Steps"))
-        dl(class: 'steps advanced root') {
-          for (StepDescriptor d : snippetizer.getStepDescriptors(true)) {
-            generateStepHelp(d);
-          }
-        }
+div(class:'dsl-reference'){
+  h1(_("DSL Reference"))
+  
+  div(class:'steps-box basic'){
+    h2(_("Steps"))
+    dl(class:'steps basic root'){
+      for (StepDescriptor d : snippetizer.getStepDescriptors(false)) {
+        generateStepHelp(d);
       }
     }
   }
+  
+  div(class:'steps-box advanced'){
+    h2(_("Advanced/Deprecated Steps"))
+    dl(class:'steps advanced root'){
+      for (StepDescriptor d : snippetizer.getStepDescriptors(true)) {
+        generateStepHelp(d);
+      }
+    }
+  }
+}
+
+    }
 }
 
 def generateStepHelp(StepDescriptor d) throws Exception {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -29,12 +29,14 @@ THE SOFTWARE.
         <st:include page="sidepanel"/>
         <l:main-panel>
             <f:form name="config">
+                <f:section title="Overview"/>
                 <f:block>
-                    Utility to help you learn the Groovy code which can be used to define various steps.
-                    Pick a step you are interested in from the list, configure it, click <b>Generate Groovy</b>,
-                    and you will see a Groovy statement that would call the step with that configuration.
-                    You may copy and paste the whole statement into your script, or pick up just the options you care about.
-                    (Most parameters are optional and can be omitted in your script, leaving them at default values.)
+                    This <b>Snippet Generator</b> will help you learn the Groovy code which can be used to
+                    define various steps. Pick a step you are interested in from the list, configure it,
+                    click <b>Generate Groovy</b>, and you will see a Groovy statement that would call the
+                    step with that configuration. You may copy and paste the whole statement into your
+                    script, or pick up just the options you care about. (Most parameters are optional
+                    and can be omitted in your script, leaving them at default values.)
                 </f:block>
                 <f:section title="Steps"/>
                 <!-- Similar to f:dropdownDescriptorSelector, but adds fallback content to block, and JENKINS-25130 adds per-selection help: -->
@@ -90,8 +92,13 @@ THE SOFTWARE.
                         }
                     </script>
                 </f:block>
+                <f:section title="Global Variables"/>
+                <f:block>
+                    There are many features of the Pipeline that are not steps. These are often exposed
+                    via global variables, which are not supported by the snippet generator. See the
+                    <a href="globals">Global Variables Reference</a> for details.
+                </f:block>
             </f:form>
-            <a href="globals"><h3>Global Variable documentation</h3></a>
         </l:main-panel>
     </l:layout>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -91,6 +91,7 @@ THE SOFTWARE.
                     </script>
                 </f:block>
             </f:form>
+            <a href="globals"><h3>Global Variable documentation</h3></a>
         </l:main-panel>
     </l:layout>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/sidepanel.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/sidepanel.jelly
@@ -39,7 +39,8 @@ THE SOFTWARE.
             </d:taglib>
             <l:task href=".." icon="icon-up icon-md" title="${%Back}"/>
             <l:task href="." icon="icon-gear2 icon-md" title="${%Snippet Generator}"/>
-            <l:task href="html" icon="icon-help icon-md" title="${%Reference}"/>
+            <l:task href="html" icon="icon-help icon-md" title="${%Step Reference}"/>
+            <l:task href="globals" icon="icon-help icon-md" title="${%Variables Reference}"/>
             <local:taskWithTarget href="https://jenkins.io/doc/pipeline/" icon="icon-help icon-md" target="_blank" title="${%Online Documentation}"/>
             <local:taskWithTarget href="gdsl" icon="icon-package icon-md" target="_blank" title="${%IntelliJ IDEA GDSL}"/>
             <!-- TODO not yet ready: <local:taskWithTarget href="dsld" icon="icon-package icon-md" target="_blank" title="${%Eclipse DSLD}"/> -->

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/sidepanel.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/sidepanel.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
             <l:task href=".." icon="icon-up icon-md" title="${%Back}"/>
             <l:task href="." icon="icon-gear2 icon-md" title="${%Snippet Generator}"/>
             <l:task href="html" icon="icon-help icon-md" title="${%Step Reference}"/>
-            <l:task href="globals" icon="icon-help icon-md" title="${%Variables Reference}"/>
+            <l:task href="globals" icon="icon-help icon-md" title="${%Global Variables Reference}"/>
             <local:taskWithTarget href="https://jenkins.io/doc/pipeline/" icon="icon-help icon-md" target="_blank" title="${%Online Documentation}"/>
             <local:taskWithTarget href="gdsl" icon="icon-package icon-md" target="_blank" title="${%IntelliJ IDEA GDSL}"/>
             <!-- TODO not yet ready: <local:taskWithTarget href="dsld" icon="icon-package icon-md" target="_blank" title="${%Eclipse DSLD}"/> -->

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
@@ -211,6 +211,13 @@ public class SnippetizerTest {
         assertThat("text from LoadStep/help-path.html is included", html, containsString("the Groovy file to load"));
         assertThat("SubversionSCM.workspaceUpdater is mentioned as an attribute of a value of GenericSCMStep.delegate", html, containsString("workspaceUpdater"));
         assertThat("CheckoutUpdater is mentioned as an option", html, containsString("CheckoutUpdater"));
+        assertThat("content is written to the end", html, containsString("</body></html>"));
+    }
+
+    @Issue("JENKINS-35395")
+    @Test public void doGlobalsRef() throws Exception {
+        JenkinsRule.WebClient wc = r.createWebClient();
+        String html = wc.goTo(Snippetizer.ACTION_URL + "/globals").getWebResponse().getContentAsString();
         assertThat("text from RunWrapperBinder/help.jelly is included", html, containsString("may be used to refer to the currently running build"));
         assertThat("content is written to the end", html, containsString("</body></html>"));
     }


### PR DESCRIPTION
...and link to it from pipeline-syntax/index.jelly.

https://issues.jenkins-ci.org/browse/JENKINS-35395

Replaces #17 - I tried an anchor link to `pipeline-syntax/html#globalVariables` (after adding that anchor, of course) and it didn't work nicely - it always ended up focusing on a different location than it should have when rendering. So I split it out to a separate page instead.

cc @reviewbybees, esp. @jglick and @rtyler 