### PR TITLE
Show Snippetizer link also from ReplayAction

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction/index.jelly
@@ -18,7 +18,9 @@
                             <wfe:workflow-editor script="${loadedScript.value}" checkUrl="${rootURL}/${it.owner.url}${it.urlName}/checkScript" checkDependsOn=""/>
                         </f:entry>
                     </j:forEach>
-                    <!-- TODO snippetizer -->
+                    <f:block>
+                        <a href="${rootURL}/${it.owner.parent.url}/pipeline-syntax" target="_blank">${%Pipeline Syntax}</a>
+                    </f:block>
                     <f:bottomButtonBar>
                         <f:submit value="Run"/>
                     </f:bottomButtonBar>


### PR DESCRIPTION
Like #13, displays a link to _Pipeline Syntax_ from with the _Replay_ screen, one of the places you are most likely to need it.

![replay-syntax](https://cloud.githubusercontent.com/assets/154109/16161549/1a3717e8-349c-11e6-971a-25fab67f5b28.png)

@reviewbybees