### PR TITLE
[JENKINS-36289] Added ReplayAction#run2

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
@@ -171,7 +171,7 @@ public class ReplayAction implements Action {
     }
 
     /**
-     * For use in projectis that want initiate a replay via the Java API.
+     * For use in projects that want initiate a replay via the Java API.
      *
      * @param replacementMainScript main script; replacement for {@link #getOriginalScript}
      * @param replacementLoadedScripts auxiliary scripts, keyed by class name; replacement for {@link #getOriginalLoadedScripts}


### PR DESCRIPTION
Added run2() to ReplayAction which returns Queue.Item rather than
QueueTaskFuture, so that Blue Ocean can reference the item in the
queue for its REST api.

Note: I'm not sure what the best way to do this was so I added run2 rather than modifying run's return signature.

@reviewbybees 