### PR TITLE
Include the running node count in Pipeline thread dumps in support bundles

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -117,6 +117,7 @@ import org.jboss.marshalling.reflect.SerializableClassRegistry;
 
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.*;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
 /**
@@ -408,7 +409,13 @@ public class CpsFlowExecution extends FlowExecution {
         return iota.incrementAndGet();
     }
 
-    int currentNodeCount() {
+    /**
+     * Returns an approximate size of the flow graph, based on the heuristic that the iota is incremented once per new node.
+     * The exact count may be a little different due to special cases.
+     * ({@link FlowNodeStorage} does not currently offer a size, or a set of all nodes.
+     * An exact count could be obtained with {@link FlowGraphWalker}, but this could be more overhead.)
+     */
+    int approximateNodeCount() {
         return iota.get();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -408,6 +408,10 @@ public class CpsFlowExecution extends FlowExecution {
         return iota.incrementAndGet();
     }
 
+    int currentNodeCount() {
+        return iota.get();
+    }
+
     protected void initializeStorage() throws IOException {
         storage = createStorage();
         synchronized (this) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
@@ -75,6 +75,7 @@ public final class CpsThreadDumpAction implements Action {
                         if (flow instanceof CpsFlowExecution) {
                             pw.println("Build: " + flow.getOwner().getExecutable());
                             ((CpsFlowExecution) flow).getThreadDump().print(pw);
+                            pw.println("Current graph size: " + ((CpsFlowExecution) flow).currentNodeCount());
                             pw.println();
                         }
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
@@ -75,7 +75,7 @@ public final class CpsThreadDumpAction implements Action {
                         if (flow instanceof CpsFlowExecution) {
                             pw.println("Build: " + flow.getOwner().getExecutable());
                             ((CpsFlowExecution) flow).getThreadDump().print(pw);
-                            pw.println("Current graph size: " + ((CpsFlowExecution) flow).currentNodeCount());
+                            pw.println("Approximate graph size: " + ((CpsFlowExecution) flow).approximateNodeCount());
                             pw.println();
                         }
                     }


### PR DESCRIPTION
Useful to be able to see if very large graphs are being encountered, which can have performance implications.

@reviewbybees esp. @svanoort & @fbelzunc