### PR TITLE
[JENKINS-29922] Display single-argument metasteps inline in Snippetizer

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
@@ -399,6 +399,14 @@ import org.kohsuke.stapler.StaplerRequest;
             return getSymbol().compareTo(o.getSymbol());
         }
 
+        @Override public boolean equals(Object obj) {
+            return obj instanceof QuasiDescriptor && real == ((QuasiDescriptor) obj).real;
+        }
+
+        @Override public int hashCode() {
+            return real.hashCode();
+        }
+
         @Override public String toString() {
             return getSymbol() + "=" + real.clazz.getSimpleName();
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
@@ -33,6 +33,7 @@ import hudson.model.DescriptorByNameOwner;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.RootAction;
+import hudson.tasks.BuildStepDescriptor;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -46,6 +47,7 @@ import javax.annotation.CheckForNull;
 import javax.lang.model.SourceVersion;
 import jenkins.model.Jenkins;
 import jenkins.model.TransientActionFactory;
+import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
@@ -381,7 +383,15 @@ import org.kohsuke.stapler.StaplerRequest;
         return t;
     }
 
-    /** Similar to {@link StepDescriptor} but could also represent a metastep’s delegate. */
+    /**
+     * Represents a step or other step-like objects that should appear in {@link Snippetizer}’s main dropdown list
+     * and can generate some fragment of Pipeline script.
+     * {@link #real} can be a {@link StepDescriptor}, in which case we generate an invocation of that step.
+     * Or it can be any {@link Descriptor} that can be run by a {@linkplain StepDescriptor#isMetaStep meta step},
+     * such as a {@link BuildStepDescriptor} of a {@link SimpleBuildStep} (from {@code CoreStep}) with a {@link Symbol},
+     * because from the user point of view a regular {@link Describable} run via a metastep
+     * is syntactically indistinguishable from a true {@link Step}.
+     */
     @Restricted(NoExternalUse.class)
     public static final class QuasiDescriptor implements Comparable<QuasiDescriptor> {
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/gdsl.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/gdsl.groovy
@@ -5,10 +5,12 @@ import hudson.Functions
 import org.jenkinsci.plugins.structs.describable.DescribableModel
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable
 import org.jenkinsci.plugins.workflow.cps.Snippetizer
+import org.jenkinsci.plugins.workflow.steps.Step
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor
 
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
+import jenkins.model.Jenkins
 
 Snippetizer snippetizer = my;
 
@@ -17,16 +19,20 @@ Map<StepDescriptor,DescribableModel> steps = new LinkedHashMap<StepDescriptor, D
 def errorSteps = [:]
 
 [false, true].each { isAdvanced ->
-    snippetizer.getStepDescriptors(isAdvanced).each { d ->
+    snippetizer.getQuasiDescriptors(isAdvanced).each { d ->
+        if (!Step.isAssignableFrom(d.real.clazz)) {
+            return // TODO JENKINS-37215
+        }
+        StepDescriptor step = Jenkins.instance.getDescriptor(d.real.clazz)
         DescribableModel schema
         try {
-            schema = new DescribableModel(d.clazz)
+            schema = new DescribableModel(d.real.clazz)
         } catch (Exception e) {
-            println "Error on ${d.clazz}: ${Functions.printThrowable(e)}"
-            errorSteps.put(d.clazz, e.message)
+            println "Error on ${d.real.clazz}: ${Functions.printThrowable(e)}"
+            errorSteps.put(d.real.clazz, e.message)
         }
         if (schema != null) {
-            steps.put(d, schema)
+            steps.put(step, schema)
         }
 
     }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/html.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/html.groovy
@@ -36,7 +36,7 @@ div(class:'dsl-reference'){
   div(class:'steps-box basic'){
     h2(_("Steps"))
     dl(class:'steps basic root'){
-      for (StepDescriptor d : snippetizer.getStepDescriptors(false)) {
+      for (Snippetizer.QuasiDescriptor d : snippetizer.getQuasiDescriptors(false)) {
         generateStepHelp(d);
       }
     }
@@ -45,7 +45,7 @@ div(class:'dsl-reference'){
   div(class:'steps-box advanced'){
     h2(_("Advanced/Deprecated Steps"))
     dl(class:'steps advanced root'){
-      for (StepDescriptor d : snippetizer.getStepDescriptors(true)) {
+      for (Snippetizer.QuasiDescriptor d : snippetizer.getQuasiDescriptors(true)) {
         generateStepHelp(d);
       }
     }
@@ -55,15 +55,15 @@ div(class:'dsl-reference'){
     }
 }
 
-def generateStepHelp(StepDescriptor d) throws Exception {
+def generateStepHelp(Snippetizer.QuasiDescriptor d) throws Exception {
   return {
     dt(class:'step-title'){
-      code(d.getFunctionName())
-      raw(": ${d.getDisplayName()}")
+      code(d.getSymbol())
+      raw(": ${d.real.getDisplayName()}")
     }
     dd(class:'step-body'){
       try {
-        generateHelp(new DescribableModel(d.clazz), 3);
+        generateHelp(new DescribableModel(d.real.clazz), 3);
       } catch (Exception x) {
         pre { code(x) }
       }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -43,12 +43,12 @@ THE SOFTWARE.
                 <j:set var="item" value="${it.getItem(request)}"/>
                 <d:taglib uri="local">
                     <d:tag name="listSteps">
-                        <j:forEach var="stepDescriptor" items="${stepDescriptors}">
-                            <f:dropdownListBlock title="${stepDescriptor.functionName}: ${stepDescriptor.displayName}" staplerClass="${stepDescriptor.clazz.name}" lazy="stepDescriptor,item">
+                        <j:forEach var="quasiDescriptor" items="${quasiDescriptors}">
+                            <j:set var="descriptor" value="${quasiDescriptor.real}"/>
+                            <f:dropdownListBlock title="${quasiDescriptor.symbol}: ${descriptor.displayName}" staplerClass="${descriptor.clazz.name}" lazy="descriptor,item">
                                 <l:ajax>
                                     <j:set var="it" value="${item}"/>
                                     <j:set var="instance" value="${null}"/>
-                                    <j:set var="descriptor" value="${stepDescriptor}"/>
                                     <j:set var="help" value="${descriptor.helpFile}"/>
                                     <j:if test="${help != null}">
                                         <tr>
@@ -68,9 +68,9 @@ THE SOFTWARE.
                     </d:tag>
                 </d:taglib>
                 <f:dropdownList name="prototype" title="Sample Step">
-                    <local:listSteps stepDescriptors="${it.getStepDescriptors(false)}"/>
+                    <local:listSteps quasiDescriptors="${it.getQuasiDescriptors(false)}"/>
                     <f:dropdownListBlock title="${%— Advanced/Deprecated —}"/>
-                    <local:listSteps stepDescriptors="${it.getStepDescriptors(true)}"/>
+                    <local:listSteps quasiDescriptors="${it.getQuasiDescriptors(true)}"/>
                 </f:dropdownList>
                 <j:set var="id" value="${h.generateId()}"/>
                 <f:block>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
@@ -58,6 +58,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockFolder;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.logging.Level;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -163,8 +164,20 @@ public class SnippetizerTest {
         st.assertRoundTrip(new InputStep("Ready?"), "input 'Ready?'");
     }
 
+    @Issue("JENKINS-29922")
+    @Test public void getQuasiDescriptors() throws Exception {
+        String quasiDescriptors = new Snippetizer().getQuasiDescriptors(false).toString();
+        assertThat(quasiDescriptors, containsString("circle=Circle"));
+        assertThat(quasiDescriptors, containsString("polygon=Polygon"));
+        assertThat(quasiDescriptors, containsString("CO=CarbonMonoxide"));
+        assertThat("State.moderate currently disqualifies this metastep", quasiDescriptors, not(containsString("california=California")));
+    }
+
     @Test public void generateSnippet() throws Exception {
         st.assertGenerateSnippet("{'stapler-class':'" + EchoStep.class.getName() + "', 'message':'hello world'}", "echo 'hello world'", null);
+        st.assertGenerateSnippet("{'stapler-class':'" + Circle.class.getName() + "'}", "circle {\n    // some block\n}", null);
+        st.assertGenerateSnippet("{'stapler-class':'" + Polygon.class.getName() + "', 'n':5}", "polygon(5) {\n    // some block\n}", null);
+        st.assertGenerateSnippet("{'stapler-class':'" + CarbonMonoxide.class.getName() + "'}", "detect CO()", null);
     }
 
     @Issue("JENKINS-26093")

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTester.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTester.java
@@ -81,7 +81,7 @@ public class SnippetizerTester {
      *      Expected snippet to be generated.
      */
     public void assertRoundTrip(Step step, String expected) throws Exception {
-        assertEquals(expected, Snippetizer.object2Groovy(step));
+        assertEquals(expected, Snippetizer.step2Groovy(step));
         CompilerConfiguration cc = new CompilerConfiguration();
         cc.setScriptBaseClass(DelegatingScript.class.getName());
         GroovyShell shell = new GroovyShell(r.jenkins.getPluginManager().uberClassLoader,new Binding(),cc);


### PR DESCRIPTION
[JENKINS-29922](https://issues.jenkins-ci.org/browse/JENKINS-29922)

Means that plugins which offer `SimpleBuildStep`s or `SimpleBuildWrapper`s with `@Symbol`s will have those extensions be displayed like native steps in _Snippet Generator_:

![snippetizer](https://cloud.githubusercontent.com/assets/154109/17450690/b8b7a216-5b2f-11e6-8c42-9f473f721077.png)

Also solves one component of [JENKINS-37215](https://issues.jenkins-ci.org/browse/JENKINS-37215), mainly because I had to do _something_ just to make the existing content generators compile again: the static HTML reference (but not GDSL/DSLD) now shows such extensions like top-level steps:

![html](https://cloud.githubusercontent.com/assets/154109/17450737/f6af6842-5b2f-11e6-911d-39547c54c4c8.png)

@reviewbybees esp. @kohsuke