### PR TITLE
Memory leak introduced with the fix of JENKINS-36372

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
+        <jenkins-test-harness.version>2.15-SNAPSHOT</jenkins-test-harness.version>
         <npm.loglevel>--silent</npm.loglevel>
     </properties>
     <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -901,9 +901,11 @@ public class CpsFlowExecution extends FlowExecution {
     synchronized void cleanUpHeap() {
         shell = null;
         trusted = null;
-        SerializableClassRegistry.getInstance().release(scriptClass.getClassLoader());
-        Introspector.flushFromCaches(scriptClass); // does not handle other derived script classes, but this is only SoftReference anyway
-        scriptClass = null;
+        if (scriptClass != null) {
+            SerializableClassRegistry.getInstance().release(scriptClass.getClassLoader());
+            Introspector.flushFromCaches(scriptClass); // does not handle other derived script classes, but this is only SoftReference anyway
+            scriptClass = null;
+        }
     }
 
     synchronized FlowHead getFirstHead() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -587,6 +587,7 @@ public class CpsFlowExecution extends FlowExecution {
             @Override public void onFailure(Throwable t) {
                 LOGGER.log(Level.WARNING, "Failed to set program failure on " + owner, t);
                 onProgramEnd(new Outcome(null, t));
+                cleanUpHeap();
             }
         });
     }
@@ -895,8 +896,9 @@ public class CpsFlowExecution extends FlowExecution {
         first.setNewHead(head);
         heads.clear();
         heads.put(first.getId(),first);
+    }
 
-        // clean up heap
+    synchronized void cleanUpHeap() {
         shell = null;
         trusted = null;
         SerializableClassRegistry.getInstance().release(scriptClass.getClassLoader());

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -898,7 +898,7 @@ public class CpsFlowExecution extends FlowExecution {
         heads.put(first.getId(),first);
     }
 
-    synchronized void cleanUpHeap() {
+    void cleanUpHeap() {
         shell = null;
         trusted = null;
         if (scriptClass != null) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -104,10 +104,13 @@ import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import java.beans.Introspector;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 import jenkins.security.NotReallyRoleSensitiveCallable;
 
@@ -902,9 +905,56 @@ public class CpsFlowExecution extends FlowExecution {
         shell = null;
         trusted = null;
         if (scriptClass != null) {
-            SerializableClassRegistry.getInstance().release(scriptClass.getClassLoader());
+            ClassLoader loader = scriptClass.getClassLoader();
+            SerializableClassRegistry.getInstance().release(loader);
             Introspector.flushFromCaches(scriptClass); // does not handle other derived script classes, but this is only SoftReference anyway
+            try {
+                cleanUpGlobalClassValue(loader);
+            } catch (Exception x) {
+                LOGGER.log(Level.WARNING, "failed to clean up memory from " + owner, x);
+            }
             scriptClass = null;
+        }
+    }
+
+    private void cleanUpGlobalClassValue(@Nonnull ClassLoader loader) throws Exception {
+        Class<?> classInfoC = Class.forName("org.codehaus.groovy.reflection.ClassInfo");
+        Field globalClassValueF;
+        try {
+            globalClassValueF = classInfoC.getDeclaredField("globalClassValue");
+        } catch (NoSuchFieldException x) {
+            return; // Groovy 1, fine
+        }
+        globalClassValueF.setAccessible(true);
+        Object globalClassValue = globalClassValueF.get(null);
+        Class<?> groovyClassValuePreJava7C = Class.forName("org.codehaus.groovy.reflection.GroovyClassValuePreJava7");
+        if (!groovyClassValuePreJava7C.isInstance(globalClassValue)) {
+            return; // using GroovyClassValueJava7 due to -Dgroovy.use.classvalue or on IBM J9, fine
+        }
+        Field mapF = groovyClassValuePreJava7C.getDeclaredField("map");
+        mapF.setAccessible(true);
+        Object map = mapF.get(globalClassValue);
+        Class<?> groovyClassValuePreJava7Map = Class.forName("org.codehaus.groovy.reflection.GroovyClassValuePreJava7$GroovyClassValuePreJava7Map");
+        Collection entries = (Collection) groovyClassValuePreJava7Map.getMethod("values").invoke(map);
+        Field klazzF = classInfoC.getDeclaredField("klazz");
+        klazzF.setAccessible(true);
+        Method removeM = groovyClassValuePreJava7Map.getMethod("remove", Object.class);
+        Class<?> entryC = Class.forName("org.codehaus.groovy.util.AbstractConcurrentMapBase$Entry");
+        Method getValueM = entryC.getMethod("getValue");
+        List<Class<?>> toRemove = new ArrayList<>(); // not sure if it is safe against ConcurrentModificationException or not
+        for (Object entry : entries) {
+            Object value = getValueM.invoke(entry);
+            Class<?> klazz = (Class) klazzF.get(value);
+            ClassLoader encounteredLoader = klazz.getClassLoader();
+            if (encounteredLoader == loader) {
+                toRemove.add(klazz);
+            } else {
+                LOGGER.log(Level.FINEST, "ignoring {0} with loader {1}", new Object[] {klazz, /* do not hold from LogRecord */String.valueOf(encounteredLoader)});
+            }
+        }
+        LOGGER.log(Level.FINE, "cleaning up {0} associated with {1}", new Object[] {toRemove.toString(), loader.toString()});
+        for (Class<?> klazz : toRemove) {
+            removeM.invoke(map, klazz);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -353,6 +353,7 @@ public final class CpsThreadGroup implements Serializable {
     private void run() throws IOException {
         boolean doneSomeWork = false;
         boolean changed;    // used to see if we need to loop over
+        boolean ending = false;
         do {
             changed = false;
             for (CpsThread t : threads.values().toArray(new CpsThread[threads.size()])) {
@@ -378,6 +379,7 @@ public final class CpsThreadGroup implements Serializable {
                         threads.remove(t.id);
                         if (threads.isEmpty()) {
                             execution.onProgramEnd(o);
+                            ending = true;
                         }
                     }
 
@@ -391,7 +393,7 @@ public final class CpsThreadGroup implements Serializable {
         if (doneSomeWork) {
             saveProgram();
         }
-        if (threads.isEmpty()) {
+        if (ending) {
             execution.cleanUpHeap();
             scripts.clear();
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -391,6 +391,10 @@ public final class CpsThreadGroup implements Serializable {
         if (doneSomeWork) {
             saveProgram();
         }
+        if (threads.isEmpty()) {
+            execution.cleanUpHeap();
+            scripts.clear();
+        }
     }
 
     private transient List<FlowNode> nodesToNotify;

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -90,7 +90,7 @@ public class CpsFlowExecutionTest {
     @Test public void loaderReleased() {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
-                Assume.assumeThat("TODO fails in Jenkins 2 for reasons TBD (no root references detected)", Jenkins.VERSION, Matchers.startsWith("1."));
+                Assume.assumeThat("TODO fails in Jenkins 2 due to leak from ClassInfo.globalClassValue", Jenkins.VERSION, Matchers.startsWith("1."));
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(CpsFlowExecutionTest.class.getName() + ".register(this)"));
                 story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -77,20 +77,23 @@ import org.jvnet.hudson.test.TestExtension;
 import javax.annotation.CheckForNull;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
+import org.jvnet.hudson.test.LoggerRule;
 
 public class CpsFlowExecutionTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    @Rule public LoggerRule logger = new LoggerRule();
     
     private static WeakReference<ClassLoader> LOADER;
     public static void register(Object o) {
         LOADER = new WeakReference<>(o.getClass().getClassLoader());
     }
     @Test public void loaderReleased() {
+        logger.record(CpsFlowExecution.class, Level.FINE);
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
-                Assume.assumeThat("TODO fails in Jenkins 2 due to leak from ClassInfo.globalClassValue", Jenkins.VERSION, Matchers.startsWith("1."));
+                Assume.assumeThat("TODO fails in Jenkins 2 due to undiagnosed leak", Jenkins.VERSION, Matchers.startsWith("1."));
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(CpsFlowExecutionTest.class.getName() + ".register(this)"));
                 story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -50,10 +50,6 @@ import jenkins.model.Jenkins;
 import org.codehaus.groovy.transform.ASTTransformationVisitor;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
-import org.jenkinsci.plugins.workflow.cps.CpsStepContext;
-import org.jenkinsci.plugins.workflow.cps.GroovyShellDecorator;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -65,11 +61,8 @@ import org.jenkinsci.plugins.workflow.support.pickles.SingleTypedPickleFactory;
 import org.jenkinsci.plugins.workflow.support.pickles.TryRepeatedly;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 
-import static java.security.KeyRep.Type.SECRET;
-import static org.eclipse.jgit.lib.ObjectChecker.object;
 import static org.junit.Assert.*;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
@@ -82,6 +75,8 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 
 import javax.annotation.CheckForNull;
+import org.hamcrest.Matchers;
+import org.junit.Assume;
 
 public class CpsFlowExecutionTest {
 
@@ -92,18 +87,17 @@ public class CpsFlowExecutionTest {
     public static void register(Object o) {
         LOADER = new WeakReference<>(o.getClass().getClassLoader());
     }
-    @Ignore("TODO fails in Jenkins 2 for reasons TBD (no root references detected)")
     @Test public void loaderReleased() {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
+                Assume.assumeThat("TODO fails in Jenkins 2 for reasons TBD (no root references detected)", Jenkins.VERSION, Matchers.startsWith("1."));
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(CpsFlowExecutionTest.class.getName() + ".register(this)"));
                 story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
                 assertNotNull(LOADER);
-                System.err.println(LOADER.get());
                 try {
-                    // TODO in Groovy 1.8.9 this keeps static state, but only for the last script (as also noted in JENKINS-23762).
-                    // The fix of GROOVY-5025 (62bfb68) in 1.9 addresses this, which we would get if JENKINS-21249 is implemented.
+                    // In Groovy 1.8.9 this keeps static state, but only for the last script (as also noted in JENKINS-23762).
+                    // The fix of GROOVY-5025 (62bfb68) in 1.9 addresses this, which we get in Jenkins 2.
                     Field f = ASTTransformationVisitor.class.getDeclaredField("compUnit");
                     f.setAccessible(true);
                     f.set(null, null);
@@ -114,42 +108,6 @@ public class CpsFlowExecutionTest {
             }
         });
     }
-
-    /* Failed attempt to make the test print soft references it has trouble clearing. The test ultimately passes, but cannot find the soft references via any root path.
-    private static void assertGC(WeakReference<?> reference) throws Exception {
-        assertTrue(true); reference.get(); // preload any needed classes!
-        Set<Object[]> objects = new HashSet<Object[]>();
-        int size = 1024;
-        while (reference.get() != null) {
-            LiveEngine e = new LiveEngine();
-            // The default filter, ScannerUtils.skipNonStrongReferencesFilter(), omits SoftReference.referent that we care about.
-            // The constructor accepting a filter ANDs it with the default filter, making it useless for this purpose.
-            Field f = LiveEngine.class.getDeclaredField("filter");
-            f.setAccessible(true);
-            f.set(e, new Filter() {
-                final Field referent = Reference.class.getDeclaredField("referent");
-                @Override public boolean accept(Object obj, Object referredFrom, Field reference) {
-                    return !(referent.equals(reference) && referredFrom instanceof WeakReference);
-                }
-            });
-            System.err.println(e.trace(Collections.singleton(reference.get()), null));
-            System.err.println("allocating " + size);
-            try {
-                objects.add(new Object[size]);
-            } catch (OutOfMemoryError ignore) {
-                break;
-            }
-            size *= 1.1;
-            System.gc();
-        }
-        objects = null;
-        System.gc();
-        Object obj = reference.get();
-        if (obj != null) {
-            fail(LiveReferences.fromRoots(Collections.singleton(obj)).toString());
-        }
-    }
-    */
 
     @Test public void getCurrentExecutions() {
         story.addStep(new Statement() {


### PR DESCRIPTION
Had disabled a test due to still-undiagnosed failures on Jenkins 2, which concealed the fact that a recent bug fix (#29) regressed the leak on Jenkins 1:

```
{groovy.lang.GroovyClassLoader$InnerLoader@571df0f9=private static final org.jboss.marshalling.reflect.SerializableClassRegistry org.jboss.marshalling.reflect.SerializableClassRegistry.INSTANCE->
org.jboss.marshalling.reflect.SerializableClassRegistry@67289b2f-registry->
org.jboss.marshalling.reflect.UnlockedHashMap@46269dbf-table->
org.jboss.marshalling.reflect.UnlockedHashMap$Table@4a13d1ef-array->
[Ljava.lang.Object;@2b2b3f3-[121]->
[Lorg.jboss.marshalling.reflect.UnlockedHashMap$Item;@182e8565-[0]->
org.jboss.marshalling.reflect.UnlockedHashMap$Item@13d66b69-key->
groovy.lang.GroovyClassLoader$InnerLoader@571df0f9}
```

@reviewbybees