### PR TITLE
Set the Thread.contextClassLoader to the GroovyClassLoader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
-        <jenkins-test-harness.version>2.15-SNAPSHOT</jenkins-test-harness.version>
+        <jenkins-test-harness.version>2.15</jenkins-test-harness.version>
         <npm.loglevel>--silent</npm.loglevel>
     </properties>
     <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
@@ -27,11 +27,11 @@ class CpsVmExecutorService extends InterceptingExecutorService {
         return new Runnable() {
             @Override
             public void run() {
-                String oldThreadName = setUp();
+                ThreadContext context = setUp();
                 try {
                     r.run();
                 } finally {
-                    tearDown(oldThreadName);
+                    tearDown(context);
                 }
             }
         };
@@ -42,31 +42,52 @@ class CpsVmExecutorService extends InterceptingExecutorService {
         return new Callable<V>() {
             @Override
             public V call() throws Exception {
-                String oldThreadName = setUp();
+                ThreadContext context = setUp();
                 try {
                     return r.call();
                 } finally {
-                    tearDown(oldThreadName);
+                    tearDown(context);
                 }
             }
         };
     }
 
-    private String setUp() {
+    private static class ThreadContext {
+        final Thread thread;
+        final String name;
+        final ClassLoader classLoader;
+        ThreadContext(Thread thread) {
+            this.thread = thread;
+            this.name = thread.getName();
+            this.classLoader = thread.getContextClassLoader();
+        }
+        void restore() {
+            thread.setName(name);
+            thread.setContextClassLoader(classLoader);
+        }
+    }
+
+    private ThreadContext setUp() {
         CpsFlowExecution execution = cpsThreadGroup.getExecution();
         ACL.impersonate(execution.getAuthentication());
         CURRENT.set(cpsThreadGroup);
         cpsThreadGroup.busy = true;
         Thread t = Thread.currentThread();
-        String oldThreadName = t.getName();
+        ThreadContext context = new ThreadContext(t);
         t.setName("Running " + execution);
-        return oldThreadName;
+        assert cpsThreadGroup != null;
+        assert cpsThreadGroup.getExecution() != null;
+        if (cpsThreadGroup.getExecution().getShell() != null) {
+            assert cpsThreadGroup.getExecution().getShell().getClassLoader() != null;
+            t.setContextClassLoader(cpsThreadGroup.getExecution().getShell().getClassLoader());
+        }
+        return context;
     }
 
-    private void tearDown(String oldThreadName) {
+    private void tearDown(ThreadContext context) {
         CURRENT.set(null);
         cpsThreadGroup.busy = false;
-        Thread.currentThread().setName(oldThreadName);
+        context.restore();
     }
 
     static ThreadLocal<CpsThreadGroup> CURRENT = new ThreadLocal<CpsThreadGroup>();

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
@@ -75,7 +75,6 @@ class CpsVmExecutorService extends InterceptingExecutorService {
         Thread t = Thread.currentThread();
         ThreadContext context = new ThreadContext(t);
         t.setName("Running " + execution);
-        assert cpsThreadGroup != null;
         assert cpsThreadGroup.getExecution() != null;
         if (cpsThreadGroup.getExecution().getShell() != null) {
             assert cpsThreadGroup.getExecution().getShell().getClassLoader() != null;

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorServiceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorServiceTest.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.Rule;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class CpsVmExecutorServiceTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void contextClassLoader() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("echo(/yes I can load ${Thread.currentThread().contextClassLoader.loadClass(getClass().name)}/)", false));
+        r.buildAndAssertSuccess(p);
+    }
+
+}


### PR DESCRIPTION
Intended to augment https://github.com/jenkinsci/script-security-plugin/pull/80 a bit: some class loading calls from deep in the bowels of Groovy use the CCL, and so we can get a performance benefit by making sure that is set to the `GroovyClassLoader`, since that will delegate to the `SandboxResolvingClassLoader` which will then cache the expensive core results.

Only partially effective, since plenty of other calls either using `Class.forName(String)`—meaning, look it up in the Jenkins core class loader, typically provided by the application server—or use the `ClassLoader` associated with some reference class, which might be in the JRE, Jenkins core (incl. Groovy itself), a plugin, or the Groovy script. Any such calls which use an initiating loader below `GroovyClassLoader`¹ will still go through the full stack and will introduce lock contention and I/O overhead.

At any rate, it seems generally appropriate for the CCL used during program execution to be that of the program.

@reviewbybees

¹`SandboxResolvingClassLoader` is never an initiating loader, since it defines no classes.