### PR TITLE
 [JENKINS-37400] Allow to use constant variable names for parameters.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.3</version>
+            <version>1.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.workflow.cps;
 
 import com.cloudbees.groovy.cps.SerializableScript;
 import groovy.lang.GroovyShell;
+import groovy.lang.MissingPropertyException;
 import groovy.lang.Script;
 import hudson.EnvVars;
 import hudson.model.ParameterValue;
@@ -128,7 +129,16 @@ public abstract class CpsScript extends SerializableScript {
                 }
             }
         }
-        return super.getProperty(property);
+
+        try {
+            return super.getProperty(property);
+        } catch (MissingPropertyException e) {
+            // pass
+        }
+
+        // this might be a const value (e.g. enum value)
+        DSL dsl = (DSL) getBinding().getVariable(STEPS_VAR);
+        return dsl.getProperty(property);
     }
 
     public @CheckForNull Run<?,?> $build() throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsWhitelist.java
@@ -38,14 +38,13 @@ class CpsWhitelist extends AbstractWhitelist {
                 return true;
             }
             if (name.equals("getProperty") && args.length == 1 && args[0] instanceof String) {
-                for (GlobalVariable v : GlobalVariable.ALL) {
-                    if (v.getName().equals(args[0])) {
-                        return true;
-                    }
-                }
+                return true;
             }
         }
         if (receiver instanceof DSL && method.getName().equals("invokeMethod")) {
+            return true;
+        }
+        if (receiver instanceof DSL && method.getName().equals("getProperty") && args.length == 1 && args[0] instanceof String) {
             return true;
         }
         // TODO JENKINS-24982: it would be nice if AnnotatedWhitelist accepted @Whitelisted on an override

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -35,6 +35,7 @@ import hudson.model.Descriptor;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.structs.describable.DescribableParameter;
+import org.jenkinsci.plugins.structs.describable.UninstantiatedConstant;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
@@ -94,6 +95,22 @@ public class DSL extends GroovyObjectSupport implements Serializable {
 
     protected Object readResolve() throws IOException {
         return this;
+    }
+
+    /**
+     * Resolve a constant name in the current context.
+     *
+     * The context will be determined later,
+     * And only returns an object to perform delayed evaluation.
+     *
+     * @param property property name
+     * @return  an object to perform delayed evaluation
+     * @since TODO
+     */
+    @Override
+    @CpsVmThreadOnly
+    public Object getProperty(String property) {
+        return new UninstantiatedConstant(property);
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
@@ -34,6 +34,8 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import groovy.lang.MissingPropertyException;
+
 /**
  * Verifies general DSL functionality.
  */
@@ -145,5 +147,12 @@ public class DSLTest {
         p.setDefinition(new CpsFlowDefinition("with_const enumValue: GOOD, enumLikeValue: SUCCESS", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("(GOOD, SUCCESS)", b);
+    }
+
+    @Test
+    public void const_parameters_unknown() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("with_const enumValue: NOT_GOOD, enumLikeValue: SUCCESS", true));
+        r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
@@ -139,4 +139,11 @@ public class DSLTest {
         r.assertLogContains("constructible with compass and straightedge", b);
     }
 
+    @Test
+    public void const_parameters() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("with_const enumValue: GOOD, enumLikeValue: SUCCESS", true));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("(GOOD, SUCCESS)", b);
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/WithConst.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/WithConst.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.testMetaStep;
+
+import org.jenkinsci.ConstSymbol;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.TaskListener;
+
+/**
+ * A step instantiated with constant values.
+ */
+public class WithConst extends State {
+    public static enum EnumValue {
+        GOOD,
+        BAD,
+    }
+    public static class EnumLikeValue {
+        private final String name;
+        public EnumLikeValue(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @ConstSymbol("SUCCESS")
+        public static final EnumLikeValue SUCCESS = new EnumLikeValue("SUCCESS");
+        @ConstSymbol("FAILURE")
+        public static final EnumLikeValue FAILURE = new EnumLikeValue("FAILURE");
+    }
+
+    private final EnumValue enumValue;
+    private final EnumLikeValue enumLikeValue;
+
+    @DataBoundConstructor
+    public WithConst(EnumValue enumValue, EnumLikeValue enumLikeValue) {
+        this.enumValue = enumValue;
+        this.enumLikeValue = enumLikeValue;
+    }
+
+    @Override
+    public void sayHello(TaskListener hello) {
+        hello.getLogger().println(String.format(
+            "I'm instantiated with (%s, %s)",
+            enumValue.name(),
+            enumLikeValue.getName()
+        ));
+    }
+
+    @Symbol("with_const")
+    @Extension
+    public static class DescriptorImpl extends Descriptor<State> {
+    }
+}


### PR DESCRIPTION
[JENKINS-37400](https://issues.jenkins-ci.org/browse/JENKINS-37400)

I want to use constant values in workflow-cps like
```
def runWrapper = selectRun job: 'upstream-project-name', 
  selector: status(SUCCESSFUL)
```

This change requires jenkinsci/structs-plugin#11. Build will fail.
