### PR TITLE
Pipeline Syntax, not Pipeline Groovy

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/help-script.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/help-script.html
@@ -1,4 +1,4 @@
 <p>
     Groovy script defining this Pipeline.
-    Use the <b>Pipeline Groovy</b> link for details.
+    Use the <b>Pipeline Syntax</b> link for details.
 </p>


### PR DESCRIPTION
You want people to go to `/job/…/pipeline-syntax/` (in a separate tab), not the plugin wiki as the original text might have been read to imply:

> Groovy script defining this Pipeline. Use the **Pipeline Groovy** link for details.
> (from [Pipeline: Groovy](https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Groovy+Plugin))

@reviewbybees