### PR TITLE
[FIXED JENKINS-37538] Set the context class loader to a neutral value inside step executions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
@@ -60,10 +60,12 @@ class CpsVmExecutorService extends InterceptingExecutorService {
             this.thread = thread;
             this.name = thread.getName();
             this.classLoader = thread.getContextClassLoader();
+            ORIGINAL_CONTEXT_CLASS_LOADER.set(classLoader);
         }
         void restore() {
             thread.setName(name);
             thread.setContextClassLoader(classLoader);
+            ORIGINAL_CONTEXT_CLASS_LOADER.set(null);
         }
     }
 
@@ -90,4 +92,7 @@ class CpsVmExecutorService extends InterceptingExecutorService {
     }
 
     static ThreadLocal<CpsThreadGroup> CURRENT = new ThreadLocal<CpsThreadGroup>();
+    /** {@link Thread#getContextClassLoader} to be used for plugin code, as opposed to Groovy. */
+    static ThreadLocal<ClassLoader> ORIGINAL_CONTEXT_CLASS_LOADER = new ThreadLocal<>();
+
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -170,8 +170,10 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         final CpsStepContext context = new CpsStepContext(d,thread,handle,an,ps.body);
         Step s;
         boolean sync;
+        ClassLoader originalLoader = Thread.currentThread().getContextClassLoader();
         try {
             d.checkContextAvailability(context);
+            Thread.currentThread().setContextClassLoader(CpsVmExecutorService.ORIGINAL_CONTEXT_CLASS_LOADER.get());
             s = d.newInstance(ps.namedArgs);
             StepExecution e = s.start(context);
             thread.setStep(e);
@@ -182,6 +184,8 @@ public class DSL extends GroovyObjectSupport implements Serializable {
             context.onFailure(e);
             s = null;
             sync = true;
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalLoader);
         }
 
         if (sync) {


### PR DESCRIPTION
[JENKINS-37538](https://issues.jenkins-ci.org/browse/JENKINS-37538)

Amends #42. Probably fixes a bug which I have not yet been able to reproduce. My working hypothesis is that with certain class loaders as `Thread.contextClassLoader`, `SAXParserFactory.newInstance()` fails for reasons TBD but probably related to a mismatch between the `ClassLoader` defining some copy of `SAXParserFactory` and one defining a copy of `org.apache.xerces.jaxp.SAXParserFactoryImpl`, due to a design flaw in `ServiceLoader`.

My first thought was to use `d.clazz.getClassLoader()` so that the `Step`’s own plugin code would be available, but in the case of `artifactory` (cf. https://github.com/JFrogDev/jenkins-artifactory-plugin/pull/30) this will delegate to the loader of `parameterized-trigger` which currently (reasons TBD) bundles `WEB-INF/lib/xercesImpl-2.9.1.jar`, so that is still possibly a problem. Instead I am taking the more conservative choice of the context loader in effect for most other plugin code in Jenkins, leaving the use of `GroovyClassLoader.InnerLoader` to code run directly from Pipeline script.

@reviewbybees