### PR TITLE
[FIXED JENKINS-38037] Single-arg check for executable symbols fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.4</version>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -241,8 +241,10 @@ public class DSL extends GroovyObjectSupport implements Serializable {
 
         boolean singleArgumentOnly = false;
         if (metaStep != null) {
-            DescribableModel<?> metaModel = new DescribableModel(metaStep.clazz);
-            singleArgumentOnly = metaModel.hasSingleRequiredParameter() && metaModel.getParameters().size() == 1;
+            Descriptor symbolDescriptor = SymbolLookup.get().findDescriptor(metaStep.getMetaStepArgumentType(), symbol);
+            DescribableModel<?> symbolModel = new DescribableModel(symbolDescriptor.clazz);
+
+            singleArgumentOnly = symbolModel.hasSingleRequiredParameter() && symbolModel.getParameters().size() == 1;
         }
 
         // The only time a closure is valid is when the resulting Describable is immediately executed via a meta-step

--- a/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
@@ -203,25 +203,10 @@ public class DSLTest {
     @Test
     public void metaStepSyntax() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "metaStepSyntax");
-        String metaStep;
-        if (ArtifactArchiver.DescriptorImpl.class.isAnnotationPresent(Symbol.class)) {
-            metaStep = "archiveArtifacts(allowEmptyArchive: true, artifacts: 'msg.out')";
-        } else {
-            metaStep = "step([$class: 'ArtifactArchiver', allowEmptyArchive: true, artifacts: 'msg.out'])";
-        }
-
-        p.setDefinition(new CpsFlowDefinition("node {\n" +
-                "writeFile text: 'hello world', file: 'msg.out'\n" +
-                metaStep + "\n" +
-                "}\n",
-                false));
-
+        p.setDefinition(new CpsFlowDefinition("multiShape(count: 2, name: 'pentagon') { echo 'Multiple shapes' }", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-
-        VirtualFile archivedFile = b.getArtifactManager().root().child("msg.out");
-        assertTrue(archivedFile.exists());
-        assertEquals("hello world", IOUtils.toString(archivedFile.open()));
-
+        r.assertLogContains("wrapping in a group of 2 instances of pentagon", b);
+        r.assertLogContains("Multiple shapes", b);
     }
 
     @Test public void contextClassLoader() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
@@ -27,10 +27,6 @@ package org.jenkinsci.plugins.workflow;
 import hudson.model.Result;
 import javax.inject.Inject;
 
-import hudson.tasks.ArtifactArchiver;
-import jenkins.util.VirtualFile;
-import org.apache.commons.io.IOUtils;
-import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -38,7 +34,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
-import org.jenkinsci.plugins.workflow.steps.CoreStep;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,9 +42,6 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Verifies general DSL functionality.

--- a/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
@@ -200,9 +200,10 @@ public class DSLTest {
         r.assertLogContains("First arg: three, second arg: four", b);
     }
 
+    @Issue("JENKINS-38037")
     @Test
-    public void metaStepSyntax() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "metaStepSyntax");
+    public void metaStepSyntaxForDataBoundSetters() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "metaStepSyntaxForDataBoundSetters");
         p.setDefinition(new CpsFlowDefinition("multiShape(count: 2, name: 'pentagon') { echo 'Multiple shapes' }", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("wrapping in a group of 2 instances of pentagon", b);

--- a/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/MultiShape.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/MultiShape.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.testMetaStep;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class MultiShape extends Curve {
+
+    public final String name;
+    public int count;
+
+    @DataBoundConstructor public MultiShape(String name) {
+        this.name = name;
+    }
+
+    @DataBoundSetter
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    @Override public String getDescription() {
+        return "group of " + count + " instances of " + name;
+    }
+
+    @Symbol("multiShape")
+    @Extension public static class DescriptorImpl extends Descriptor<Curve> {}
+
+}


### PR DESCRIPTION
[JENKINS-38037](https://issues.jenkins-ci.org/browse/JENKINS-38037)

Back in [this change](https://github.com/jenkinsci/workflow-cps-plugin/commit/7857e23bfc9e404063a1e512287a0a735445d318), I screwed up and used the metastep descriptor for determining whether a symbol-driven `Describable` had a single required argument. That was...wrong. It was only relevant for executable symbols, and we should be checking the `DescribableModel` for the symbol, not the meta-step. So, fixing that.

cc @reviewbybees esp @jglick @kohsuke 