### PR TITLE
[FIXED JENKINS-38169] Treat single required+named param differently.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -424,9 +424,13 @@ public class DSL extends GroovyObjectSupport implements Serializable {
                 a = a.subList(0,a.size()-1);
             }
 
-            if (a.size()==1 && a.get(0) instanceof Map && !((Map) a.get(0)).containsKey("$class") && !singleRequiredArg) {
-                // this is how Groovy passes in Map
-                return new NamedArgsAndClosure((Map) a.get(0), c);
+            if (a.size()==1 && a.get(0) instanceof Map && !((Map) a.get(0)).containsKey("$class")) {
+                Map mapArg = (Map) a.get(0);
+                if (!singleRequiredArg ||
+                        (soleArgumentKey != null && mapArg.size() == 1 && mapArg.containsKey(soleArgumentKey))) {
+                    // this is how Groovy passes in Map
+                    return new NamedArgsAndClosure(mapArg, c);
+                }
             }
 
             switch (a.size()) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/DSLTest.java
@@ -202,6 +202,15 @@ public class DSLTest {
         r.assertLogContains("Multiple shapes", b);
     }
 
+    @Issue("JENKINS-38169")
+    @Test
+    public void namedSoleParamForStep() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "namedSoleParamForStep");
+        p.setDefinition(new CpsFlowDefinition("echo message:'Hello world'", true));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("Hello world", b);
+    }
+
     @Test public void contextClassLoader() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("try {def c = classLoad(getClass().name); error(/did not expect to be able to load ${c} from ${c.classLoader}/)} catch (ClassNotFoundException x) {echo(/good, got ${x}/)}", false));


### PR DESCRIPTION
[JENKINS-38169](https://issues.jenkins-ci.org/browse/JENKINS-38169)

If you call `echo message:'foo'` previous to this change, the Map that
gets passed as the first element of args ends up being used as the
sole parameter itself, so you end up with `name:[name:'foo']` being
passed as the args. That's obviously wrong. So let's add a check to
see if there is a `soleArgumentKey`, the arg map only has one
key/value, and that key is equal to `soleArgumentKey` - if that's
true, just pass the arg map directly.

cc @reviewbybees esp @jglick 