### PR TITLE
Add anchors for variables

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/globals.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/globals.groovy
@@ -26,8 +26,10 @@ l.layout(title:_("Pipeline Syntax: Global Variable Reference"), norefresh: true)
           h2(_("Variables"))
           dl(class:'steps variables root'){
             for (GlobalVariable v : snippetizer.getGlobalVariables()) {
-              dt {
-                code(v.getName())
+              dt(id: v.getName()) {
+                a(href: '#' + v.getName()) {
+                  code(v.getName())
+                }
               }
               dd{
                 RequestDispatcher rd = request.getView(v, "help");


### PR DESCRIPTION
This allows links to specific variables like this: `/pipeline-syntax/globals#env`