### PR TITLE
[JENKINS-27295] [JENKINS-29952] Overhaul of access to build parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.3</version>
+            <version>2.7-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
@@ -77,7 +77,7 @@ public class EnvActionImpl extends GroovyObjectSupport implements EnvironmentAct
         return Collections.unmodifiableMap(env);
     }
 
-    @Override public Object getProperty(String propertyName) {
+    @Override public String getProperty(String propertyName) {
         try {
             CpsThread t = CpsThread.current();
             return EnvironmentExpander.getEffectiveEnvironment(getEnvironment(), t.getContextVariable(EnvVars.class), t.getContextVariable(EnvironmentExpander.class)).get(propertyName);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/ParamsVariable.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/ParamsVariable.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import hudson.Extension;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jenkinsci.plugins.workflow.pickles.PickleFactory;
+
+/**
+ * Allows access to {@link ParametersAction}.
+ */
+@Extension public class ParamsVariable extends GlobalVariable {
+
+    @Override public String getName() {
+        return "params";
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override public Object getValue(CpsScript script) throws Exception {
+        Run<?,?> b = script.$build();
+        if (b == null) {
+            throw new IllegalStateException("cannot find owning build");
+        }
+        ParametersAction action = b.getAction(ParametersAction.class);
+        if (action == null) {
+            return Collections.emptyMap();
+        }
+        List<ParameterValue> parameterValues;
+        try { // TODO 1.651.2+ remove reflection
+            parameterValues = (List<ParameterValue>) ParametersAction.class.getMethod("getAllParameters").invoke(action);
+        } catch (NoSuchMethodException x) {
+            parameterValues = action.getParameters();
+        }
+        // Could extend AbstractMap and make a Serializable lazy wrapper, but getValue impls seem cheap anyway.
+        Map<String,Object> values = new HashMap<>();
+        for (ParameterValue parameterValue : parameterValues) {
+            Object value = parameterValue.getValue();
+            if (!(value instanceof Serializable)) {
+                boolean canPickle = false;
+                for (PickleFactory pf : PickleFactory.all()) {
+                    if (pf.writeReplace(value) != null) {
+                        // For example SecretPickle can handle Secret from PasswordParameterValue.
+                        canPickle = true;
+                        break;
+                    }
+                }
+                if (!canPickle) {
+                    // Just skip anything not serializable, such as a Run from a RunParameterValue.
+                    continue;
+                }
+            }
+            values.put(parameterValue.getName(), value);
+        }
+        return values;
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/ParamsVariable/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/ParamsVariable/help.jelly
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2016 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    <p>
+        Exposes all parameters defined in the build as a map with variously typed values. Example:
+    </p>
+    <pre><code>if (params.BOOLEAN_PARAM_NAME) {doSomething()}</code></pre>
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
@@ -305,6 +305,9 @@ public class WorkflowTest extends SingleJobTestBase {
                 assertEquals("custom2", a.getEnvironment().get("BUILD_TAG"));
                 assertEquals("more", a.getEnvironment().get("STUFF"));
                 assertNotNull(a.getEnvironment().get("PATH"));
+                // Show that EnvActionImpl binding is a fallback only for things which would otherwise have been undefined:
+                p.setDefinition(new CpsFlowDefinition("env.env = 'env.env'; env.echo = 'env.echo'; env.circle = 'env.circle'; env.var = 'env.var'; circle {def var = 'value'; echo \"${var} vs. ${echo} vs. ${circle}\"}", true));
+                story.j.assertLogContains("value vs. env.echo vs. env.circle", story.j.buildAndAssertSuccess(p));
             }
         });
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
@@ -261,6 +261,7 @@ public class WorkflowTest extends SingleJobTestBase {
         }
     }
 
+    @Issue("JENKINS-29952")
     @Test public void env() {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
@@ -279,7 +280,8 @@ public class WorkflowTest extends SingleJobTestBase {
                         + "  sh 'echo tag3=$BUILD_TAG stuff=$STUFF'\n"
                         + "  env.PATH=\"/opt/stuff/bin:${env.PATH}\"\n"
                         + "  sh 'echo shell PATH=$PATH'\n"
-                        + "  echo \"groovy PATH=${env.PATH}\""
+                        + "  echo \"groovy PATH=${env.PATH}\"\n"
+                        + "  echo \"simplified groovy PATH=${PATH}\"\n"
                         + "}", true));
                 startBuilding();
                 SemaphoreStep.waitForStart("env/1", b);
@@ -297,6 +299,7 @@ public class WorkflowTest extends SingleJobTestBase {
                 story.j.assertLogContains("tag3=custom2 stuff=more", b);
                 story.j.assertLogContains("shell PATH=/opt/stuff/bin:", b);
                 story.j.assertLogContains("groovy PATH=/opt/stuff/bin:", b);
+                story.j.assertLogContains("simplified groovy PATH=/opt/stuff/bin:", b);
                 EnvironmentAction a = b.getAction(EnvironmentAction.class);
                 assertNotNull(a);
                 assertEquals("custom2", a.getEnvironment().get("BUILD_TAG"));

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinitionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinitionTest.java
@@ -22,41 +22,28 @@
  * THE SOFTWARE.
  */
 
-package org.jenkinsci.plugins.workflow;
+package org.jenkinsci.plugins.workflow.cps;
 
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.model.Run;
-import hudson.model.TaskListener;
 import hudson.scm.ChangeLogSet;
-import hudson.scm.NullSCM;
-import hudson.scm.SCMRevisionState;
 import hudson.triggers.SCMTrigger;
-import org.apache.commons.io.IOUtils;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
-import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.scm.GitSampleRepoRule;
 import org.jenkinsci.plugins.workflow.steps.scm.GitStep;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.jvnet.hudson.test.SingleFileSCM;
 
 public class CpsScmFlowDefinitionTest {
 
@@ -126,25 +113,6 @@ public class CpsScmFlowDefinitionTest {
         assertEquals(2, b.number);
         List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b.getChangeSets();
         assertEquals(Collections.emptyList(), changeSets);
-    }
-
-    // TODO 1.599+ use standard version
-    private static class SingleFileSCM extends NullSCM {
-        private final String path;
-        private final byte[] contents;
-        SingleFileSCM(String path, String contents) throws UnsupportedEncodingException {
-            this.path = path;
-            this.contents = contents.getBytes("UTF-8");
-        }
-        @Override public void checkout(Run<?, ?> build, Launcher launcher, FilePath workspace, TaskListener listener, File changelogFile, SCMRevisionState baseline) throws IOException, InterruptedException {
-            listener.getLogger().println("Staging " + path);
-            OutputStream os = workspace.child(path).write();
-            IOUtils.write(contents, os);
-            os.close();
-        }
-        private Object writeReplace() {
-            return new Object();
-        }
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/ParamsVariableTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/ParamsVariableTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import hudson.model.BooleanParameterDefinition;
+import hudson.model.BooleanParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.PasswordParameterDefinition;
+import hudson.model.PasswordParameterValue;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Test;
+import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ParamsVariableTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Issue("JENKINS-27295")
+    @Test public void smokes() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("echo(/TEXT=${params.TEXT} FLAG=${params.FLAG ? 'yes' : 'no'} PASS=${params.PASS}/)",true));
+        p.addProperty(new ParametersDefinitionProperty(
+            new StringParameterDefinition("TEXT", ""),
+            new BooleanParameterDefinition("FLAG", false, null),
+            new PasswordParameterDefinition("PASS", "", null)));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(
+            new StringParameterValue("TEXT", "hello"),
+            new BooleanParameterValue("FLAG", true),
+            new PasswordParameterValue("PASS", "s3cr3t"))));
+        r.assertLogContains("TEXT=hello", b);
+        r.assertLogContains("FLAG=yes", b);
+        r.assertLogContains("PASS=s3cr3t", b);
+    }
+
+}


### PR DESCRIPTION
Implements [JENKINS-27295](https://issues.jenkins-ci.org/browse/JENKINS-27295) and [JENKINS-29952](https://issues.jenkins-ci.org/browse/JENKINS-29952) and also demonstrates that [JENKINS-28447](https://issues.jenkins-ci.org/browse/JENKINS-28447) is fixed by the upstream https://github.com/jenkinsci/workflow-job-plugin/pull/24.

@reviewbybees