### PR TITLE
[JENKINS-34488] Save an alternate exception when failed to save ErrorAction

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -897,8 +897,20 @@ public class CpsFlowExecution extends FlowExecution {
         // TODO: if program terminates with exception, we need to record it
         // TODO: in the error case, we have to close all the open nodes
         FlowNode head = new FlowEndNode(this, iotaStr(), (FlowStartNode)startNodes.pop(), result, getCurrentHeads().toArray(new FlowNode[0]));
-        if (outcome.isFailure())
-            head.addAction(new ErrorAction(outcome.getAbnormal()));
+        if (outcome.isFailure()) {
+            try {
+                head.addAction(new ErrorAction(outcome.getAbnormal()));
+            } catch (Exception e) {
+                // considered caused for failed to serialize the error.
+                // retry without the original error.
+                LOGGER.log(Level.SEVERE, "Failed to save ErrorAction", e);
+                try {
+                    head.replaceAction(new ErrorAction(new ErrorActionException("Failed to add error action", e)));
+                } catch (Exception e2) {
+                    LOGGER.log(Level.SEVERE, "Failed to save ErrorAction again: Give up!", e2);
+                }
+            }
+        }
 
         // shrink everything into a single new head
         done = true;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -332,7 +332,19 @@ public final class CpsThreadGroup implements Serializable {
                         result = ((FlowInterruptedException) error).getResult();
                     }
                     execution.setResult(result);
-                    t.head.get().addAction(new ErrorAction(error));
+
+                    try {
+                        t.head.get().addAction(new ErrorAction(error));
+                    } catch (Exception e) {
+                        // considered caused for failed to serialize the error.
+                        // retry without the original error.
+                        LOGGER.log(Level.SEVERE, "Failed to save ErrorAction", e);
+                        try {
+                            t.head.get().replaceAction(new ErrorAction(new ErrorActionException("Failed to add error action", e)));
+                        } catch (Exception e2) {
+                            LOGGER.log(Level.SEVERE, "Failed to save ErrorAction again: Give up!", e2);
+                        }
+                    }
                 }
 
                 if (!t.isAlive()) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/ErrorActionException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/ErrorActionException.java
@@ -1,0 +1,27 @@
+package org.jenkinsci.plugins.workflow.cps;
+
+import org.jenkinsci.plugins.workflow.actions.ErrorAction;
+
+/**
+ * Exception used when failed to save {@link ErrorAction}.
+ *
+ * Will be stored in {@link ErrorAction}
+ * instead of the original exception.
+ *
+ * @since 2.18
+ */
+public class ErrorActionException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * ctor
+     *
+     * @param msg message
+     * @param t root cause
+     *
+     * @see Exception#Exception(String, Throwable)
+     */
+    public ErrorActionException(String msg, Throwable t) {
+        super(msg, t);
+    }
+}


### PR DESCRIPTION
[JENKINS-34488](https://issues.jenkins-ci.org/browse/JENKINS-34488) Failing 'assert' hangs the pipeline

`hudson.util.XStream2` rejects to serialize some classes:
* https://github.com/jenkinsci/jenkins/blob/jenkins-2.22/core/src/main/java/hudson/util/XStream2.java#L442
* https://github.com/jenkinsci/remoting/blob/remoting-2.62/src/main/java/hudson/remoting/ClassFilter.java#L56

This results failure in saving `ErrorAction` when pipeline codes failed with some specific exceptions.
`assert` without a message parameter in groovy throws `org.codehaus.groovy.runtime.powerassert.PowerAssertionError`, and it will be rejected by `XStream2`.

This results skip later codes and causes to fail to finish codes.

This change is a workaround for this issue.
It saves `ErrorAction` with alternate exception when failed to save `ErrorAction`.

There're two points causing this problem:
* `CpsFlowExecution#onProgramEnd`
* `CpsThreadGroup#run`
