### PR TITLE
Incorrect handling of synchronous abnormal termination of the body block

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -139,6 +139,9 @@ class CpsBodyExecution extends BodyExecution {
             }
         } catch (Throwable t) {
             // body has completed synchronously and abnormally
+            synchronized (this) {
+                this.thread = currentThread;
+            }
             onFailure.receive(t);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -167,23 +167,22 @@ public final class CpsThread implements Serializable {
             } else {
                 LOGGER.log(FINE, "ran and produced {0}", outcome);
             }
+
+            if (outcome.getNormal() instanceof ThreadTask) {
+                // if an execution in the thread safepoint is requested, deliver that
+                ThreadTask sc = (ThreadTask) outcome.getNormal();
+                ThreadTaskResult r = sc.eval(this);
+                if (r.resume!=null) {
+                    // yield, then keep evaluating the CPS code
+                    resumeValue = r.resume;
+                } else {
+                    // break but with a different value
+                    outcome = r.suspend;
+                }
+            }
         } finally {
             CURRENT.set(old);
         }
-
-        if (outcome.getNormal() instanceof ThreadTask) {
-            // if an execution in the thread safepoint is requested, deliver that
-            ThreadTask sc = (ThreadTask) outcome.getNormal();
-            ThreadTaskResult r = sc.eval(this);
-            if (r.resume!=null) {
-                // yield, then keep evaluating the CPS code
-                resumeValue = r.resume;
-            } else {
-                // break but with a different value
-                outcome = r.suspend;
-            }
-        }
-
 
         if (promise!=null) {
             if (outcome.isSuccess())        promise.set(outcome.getNormal());

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
@@ -1,0 +1,86 @@
+package org.jenkinsci.plugins.workflow.cps;
+
+import groovy.lang.Closure;
+import hudson.model.Result;
+import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;
+import org.jenkinsci.plugins.workflow.cps.CpsBodyExecutionTest.SynchronousExceptionInBodyStep.EmperorHasNoClothes;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.junit.Test;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+public class CpsBodyExecutionTest extends AbstractCpsFlowTest {
+    /**
+     * When the body of a step is synchronous and explodes, the failure should be recorded and the pipeline job
+     * should move on.
+     *
+     * But instead, this hangs because CpsBodyExecution has a bug in how it handles this case.
+     * It tries to launch the body (in this case the 'bodyBlock' method) in a separate CPS thread,
+     * and puts the parent CPS thread on hold. Yet when the child CPS thread ends with an exception,
+     * it fails to record this result correctly, and it gets into the eternal sleep in which
+     * the parent CPS thread expects to be notified of the outcome of the child CPS thread, which
+     * never arrives.
+     */
+    @Test
+    public void synchronousExceptionInBody() throws Exception {
+        WorkflowJob p = jenkins.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("synchronousExceptionInBody()",true));
+
+        WorkflowRun b = jenkins.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        jenkins.assertLogContains(EmperorHasNoClothes.class.getName(),b);
+    }
+
+    public static class SynchronousExceptionInBodyStep extends AbstractStepImpl {
+        @DataBoundConstructor
+        public SynchronousExceptionInBodyStep() {}
+
+        @TestExtension
+        public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+            public DescriptorImpl() {
+                super(Execution.class);
+            }
+
+            @Override
+            public String getFunctionName() {
+                return "synchronousExceptionInBody";
+            }
+        }
+
+        public static class Execution extends AbstractStepExecutionImpl {
+            /**
+             * Invoked as a body that induces a synchronous exception
+             */
+            public void bodyBlock() {
+                throw new EmperorHasNoClothes();
+            }
+
+            @Override
+            public boolean start() throws Exception {
+                Closure body = ScriptBytecodeAdapter.getMethodPointer(this, "bodyBlock");
+                CpsStepContext cps = (CpsStepContext) getContext();
+                CpsThread t = CpsThread.current();
+                cps.newBodyInvoker(t.getGroup().export(body))
+                        .withCallback(BodyExecutionCallback.wrap(cps))
+                        .start();
+                return false;
+            }
+
+            @Override
+            public void stop(@Nonnull Throwable cause) throws Exception {
+                throw new UnsupportedOperationException();
+            }
+        }
+
+        public static class EmperorHasNoClothes extends RuntimeException {}
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/EmperorHasNoClothes.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/EmperorHasNoClothes.java
@@ -1,0 +1,8 @@
+package org.jenkinsci.plugins.workflow.cps;
+
+/**
+ * @author Kohsuke Kawaguchi
+ * @see CpsBodyExecutionTest#synchronousExceptionInBody()
+ */
+public class EmperorHasNoClothes extends RuntimeException {
+}


### PR DESCRIPTION
Fixing a bug in CPS VM about how it handles an exception in sync body.

When the body of a step is synchronous and explodes, the failure should be recorded and the pipeline job should move on.

But instead, this hangs because `CpsBodyExecution` has a bug in how it handles this case. It tries to launch the body  in a separate CPS thread, and puts the parent CPS thread on hold. Yet when the child CPS thread ends with an exception, it fails to record this result correctly, and it gets into the eternal sleep in which the parent CPS thread expects to be notified of the outcome of the child CPS thread, which never arrives.


Any exception aside from `CpsCallableInvocation` is a sign that the execution has completed abnormally and synchronously. So this code pass should have close parallel to the normal case that immediately follows the `params.body.getBody(currentThread).call()` invocation, yet the thread association is missing from the failure case.

`CpsBodyExecution.onSuccess/onFailure` also assumes that they run in CPS VM thread to be able to grow the flow node graph, as can be seen in their use of `CpsThread.current()`. In the typical case where the body being invoked is also CPS code, this assumption correctly holds as these callbacks as invoked as Continuation while running CPS thread code, but if it executes synchronously, this assumption does not hold, as the call stack originates in `ThreadTask.eval(this)` that's outside the code that sets the `CpsThread.current()` return value.

`ThreadTask.eval()` always operate in the context of single `CpsThread`, it seems reasonable to run this code whiel `CpsThread.current()` is still set.

@reviewbybees 