### PR TITLE
When StepExecution.stop throws an exception, forcibly kill the step and record both stack traces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.3</version>
+            <version>2.4-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/8 -->
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -29,7 +29,6 @@ import com.cloudbees.groovy.cps.Outcome;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.SettableFuture;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
-import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 
 import javax.annotation.CheckForNull;
@@ -284,7 +283,8 @@ public final class CpsThread implements Serializable {
         try {
             s.stop(t);
         } catch (Exception e) {
-            LOGGER.log(WARNING, "Failed to stop " + s, e);
+            t.addSuppressed(e);
+            s.getContext().onFailure(t);
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadTest.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.workflow.cps;
 
 import hudson.AbortException;
-import hudson.Extension;
 import hudson.model.Result;
 import hudson.security.ACL;
 import java.util.List;
@@ -43,6 +42,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class CpsThreadTest {
@@ -81,7 +81,7 @@ public class CpsThreadTest {
                 throw new AbortException("never going to stop");
             }
         }
-        @Extension public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+        @TestExtension public static class DescriptorImpl extends AbstractStepDescriptorImpl {
             public DescriptorImpl() {
                 super(Execution.class);
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadTest.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.model.Result;
+import hudson.security.ACL;
+import java.util.List;
+import jenkins.model.CauseOfInterruption;
+import jenkins.model.InterruptedBuildAction;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class CpsThreadTest {
+
+    @ClassRule public static BuildWatcher watcher = new BuildWatcher();
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void stop() throws Exception {
+        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("unkillable()", true));
+        final WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        r.waitForMessage("unkillable", b);
+        ACL.impersonate(Jenkins.ANONYMOUS, new Runnable() {
+            @Override public void run() {
+                b.getExecutor().interrupt();
+            }
+        });
+        r.waitForCompletion(b);
+        r.assertBuildStatus(Result.ABORTED, b);
+        InterruptedBuildAction iba = b.getAction(InterruptedBuildAction.class);
+        assertNotNull(iba);
+        List<CauseOfInterruption> causes = iba.getCauses();
+        assertEquals(1, causes.size());
+        assertEquals(CauseOfInterruption.UserInterruption.class, causes.get(0).getClass());
+        r.assertLogContains("never going to stop", b);
+        r.assertLogNotContains("\tat ", b);
+    }
+
+    public static class UnkillableStep extends AbstractStepImpl {
+        @DataBoundConstructor public UnkillableStep() {}
+        public static class Execution extends AbstractStepExecutionImpl {
+            @Override public boolean start() throws Exception {
+                return false;
+            }
+            @Override public void stop(Throwable cause) throws Exception {
+                throw new AbortException("never going to stop");
+            }
+        }
+        @Extension public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+            public DescriptorImpl() {
+                super(Execution.class);
+            }
+            @Override public String getFunctionName() {
+                return "unkillable";
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
@cyrille-leclerc [encountered a case](https://gist.githubusercontent.com/jglick/b906ae79a0dd857dae0098453fe03612/raw/fe90a36ee9311e35f0ad451c4d4e823642486da2/gistfile1.txt) where `StepExecution.stop` was called but threw an exception; the build kept running. Normally `DurableTaskStep.Execution.stop` first checks whether the remoting channel is alive and well, but in this case for some reason that check passed yet an actual attempt to use the channel to run a termination command failed. Best to abandon the step as a failure at that point.

Downstream of https://github.com/jenkinsci/workflow-step-api-plugin/pull/8 for nicer reporting.

@reviewbybees