### PR TITLE
Some flaky tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/SerializationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/SerializationTest.java
@@ -49,8 +49,10 @@ public class SerializationTest extends SingleJobTestBase {
                         waitForWorkflowToSuspend();
                     } catch (Exception x) {
                         // ignore persistence failure
-                        if (!x.getMessage().contains("Failed to persist"))
+                        String message = x.getMessage();
+                        if (message == null || !message.contains("Failed to persist")) {
                             throw x;
+                        }
                     }
 
                 story.j.assertBuildStatus(Result.FAILURE, b);

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -250,8 +250,7 @@ public class CpsFlowExecutionTest {
                 SemaphoreStep.waitForStart("wait/1", b);
                 story.j.jenkins.doQuietDown(true, 0);
                 SemaphoreStep.success("wait/1", null);
-                // as above, this is rather weak
-                Thread.sleep(1000);
+                ((CpsFlowExecution) b.getExecution()).waitForSuspension();
                 assertTrue(b.isBuilding());
             }
         });

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpTest.java
@@ -44,6 +44,7 @@ public class CpsThreadDumpTest {
             FlowExecutionOwner owner = b.asFlowExecutionOwner();
             assertNotNull(owner);
             CpsFlowExecution exec = (CpsFlowExecution) owner.getOrNull();
+            assertNotNull(exec);
             assertFalse(exec.isComplete());
             fail("not sure why CpsThreadDumpAction was missing here");
         }


### PR DESCRIPTION
Trying to solve/diagnose some test flakes noticed in recent release tests.

```
java.lang.NullPointerException
	at org.jenkinsci.plugins.workflow.SerializationTest$1.evaluate(SerializationTest.java:52)
java.lang.InterruptedException: sleep interrupted
	at java.lang.Thread.sleep(Native Method)
	at org.jvnet.hudson.test.JenkinsRule.waitForCompletion(JenkinsRule.java:1231)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecutionTest$7.evaluate(CpsFlowExecutionTest.java:262)
java.lang.NullPointerException
	at org.jenkinsci.plugins.workflow.cps.CpsThreadDumpTest.simple(CpsThreadDumpTest.java:47)
```

@reviewbybees