### PR TITLE
Delegate preferentially to global bindings before applying custom getProperty behaviors

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
@@ -306,8 +306,18 @@ public class WorkflowTest extends SingleJobTestBase {
                 assertEquals("more", a.getEnvironment().get("STUFF"));
                 assertNotNull(a.getEnvironment().get("PATH"));
                 // Show that EnvActionImpl binding is a fallback only for things which would otherwise have been undefined:
-                p.setDefinition(new CpsFlowDefinition("env.env = 'env.env'; env.echo = 'env.echo'; env.circle = 'env.circle'; env.var = 'env.var'; circle {def var = 'value'; echo \"${var} vs. ${echo} vs. ${circle}\"}", true));
-                story.j.assertLogContains("value vs. env.echo vs. env.circle", story.j.buildAndAssertSuccess(p));
+                p.setDefinition(new CpsFlowDefinition(
+                    "env.env = 'env.env'\n" +
+                    "env.echo = 'env.echo'\n" +
+                    "env.circle = 'env.circle'\n" +
+                    "env.var = 'env.var'\n" +
+                    "env.global = 'env.global'\n" +
+                    "global = 'global'\n" +
+                    "circle {\n" +
+                    "  def var = 'value'\n" +
+                    "  echo \"${var} vs. ${echo} vs. ${circle} vs. ${global}\"\n" +
+                    "}", true));
+                story.j.assertLogContains("value vs. env.echo vs. env.circle vs. global", story.j.buildAndAssertSuccess(p));
             }
         });
     }


### PR DESCRIPTION
Someone on #jenkins claimed to have been using some idiom along the lines of

```groovy
if (SOME_BUILD_PARAM_NAME == '') {
  SOME_BUILD_PARAM_NAME = 'fallback'
}
useSomehow(SOME_BUILD_PARAM_NAME)
```

which I had never intended to support but apparently worked prior to #60 ([release notes](https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Groovy+Plugin#PipelineGroovyPlugin-2.18%28Sep23%2C2016%29)). It seems that the `GlobalVariable` and `env` fallbacks were taking precedence over `Binding`s, which is probably unwanted—generally we want to let scripts override symbols. This should restore the previous behavior in that case.

@reviewbybees