### PR TITLE
Clarify and enforce that params is read-only

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/ParamsVariable.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/ParamsVariable.java
@@ -80,7 +80,7 @@ import org.jenkinsci.plugins.workflow.pickles.PickleFactory;
             }
             values.put(parameterValue.getName(), value);
         }
-        return values;
+        return Collections.unmodifiableMap(values);
     }
 
 }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/ParamsVariable/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/ParamsVariable/help.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <p>
-        Exposes all parameters defined in the build as a map with variously typed values. Example:
+        Exposes all parameters defined in the build as a read-only map with variously typed values. Example:
     </p>
     <pre><code>if (params.BOOLEAN_PARAM_NAME) {doSomething()}</code></pre>
 </j:jelly>


### PR DESCRIPTION
Saw some people on #jenkins trying to mutate it: [JENKINS-38739](https://issues.jenkins-ci.org/browse/JENKINS-38739) for example.

@reviewbybees