### PR TITLE
compatibleSinceVersion=2.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <configuration>
+                    <compatibleSinceVersion>2.18</compatibleSinceVersion>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
IIUC this will ensure that anyone upgrading from [2.17 or earlier](https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Groovy+Plugin) is asked to read release notes according to [this system](https://wiki.jenkins-ci.org/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions).

@reviewbybees esp. @daniel-beck who suggested it