### PR TITLE
[JENKINS-39154] Restore ACE editor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.17</version>
-        <relativePath />
+        <version>2.16</version>
+        <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-cps</artifactId>


### PR DESCRIPTION
[JENKINS-39154](https://issues.jenkins-ci.org/browse/JENKINS-39154)

Rejects https://github.com/jenkinsci/plugin-pom/pull/36 until I can get an explanation from @tfennelly on how this plugin should be updated.

@reviewbybees ASAP