### PR TITLE
Intern or deduplicate many duplicated strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
             <!-- Only until PR this depends on is released, then will set to that version -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.6-SNAPSHOT</version>
+            <version>2.6-dedup-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,10 @@
             <version>2.5</version>
         </dependency>
         <dependency>
+            <!-- Only until PR this depends on is released, then will set to that version -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.4</version>
+            <version>2.6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,9 @@
             <version>2.5</version>
         </dependency>
         <dependency>
-            <!-- Only until PR this depends on is released, then will set to that version -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.6-dedup-SNAPSHOT</version>
+            <version>2.6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.6-SNAPSHOT</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -263,7 +263,7 @@ public class CpsFlowExecution extends FlowExecution {
 
     static {
         for(int i = 0; i< ID_LOOKUP_TABLE.length; i++) {
-            ID_LOOKUP_TABLE[i] = String.valueOf(i);
+            ID_LOOKUP_TABLE[i] = String.valueOf(i).intern();  // Interning here allows allows us to just intern on deserialize
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -255,6 +255,18 @@ public class CpsFlowExecution extends FlowExecution {
 
     private final AtomicInteger iota = new AtomicInteger();
 
+    /** Number of node IDs to use in lookup table, 500 covers most common flow graphs  */
+    private static final int ID_LOOKUP_TABLE_SIZE = 500;
+
+    /** Preallocated lookup table for small ID values, used instead of interning for speed & simplicity */
+    private static transient String[] ID_LOOKUP_TABLE = new String[ID_LOOKUP_TABLE_SIZE];
+
+    static {
+        for(int i = 0; i< ID_LOOKUP_TABLE.length; i++) {
+            ID_LOOKUP_TABLE[i] = String.valueOf(i);
+        }
+    }
+
     private transient List<GraphListener> listeners;
 
     /**
@@ -429,7 +441,13 @@ public class CpsFlowExecution extends FlowExecution {
      */
     @Restricted(NoExternalUse.class)
     public String iotaStr() {
-        return String.valueOf(iota());
+        int iotaVal = iota();
+        // We intern this because many, many FlowNodes will have the same ID values
+        if ( iotaVal > 0 && iotaVal < ID_LOOKUP_TABLE_SIZE) {
+            return ID_LOOKUP_TABLE[iotaVal];
+        } else {
+            return String.valueOf(iota()).intern();
+        }
     }
 
     @Restricted(NoExternalUse.class)

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -259,7 +259,7 @@ public class CpsFlowExecution extends FlowExecution {
     private static final int ID_LOOKUP_TABLE_SIZE = 500;
 
     /** Preallocated lookup table for small ID values, used instead of interning for speed & simplicity */
-    private static transient String[] ID_LOOKUP_TABLE = new String[ID_LOOKUP_TABLE_SIZE];
+    private static final String[] ID_LOOKUP_TABLE = new String[ID_LOOKUP_TABLE_SIZE];
 
     static {
         for(int i = 0; i< ID_LOOKUP_TABLE.length; i++) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -32,6 +32,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 
+import java.io.ObjectStreamException;
 import java.util.Collections;
 
 /**
@@ -64,6 +65,11 @@ public class StepAtomNode extends AtomNode implements StepNode {
             }
         }
         return descriptor;
+    }
+
+    private Object readResolve() throws ObjectStreamException {
+        StepAtomNode returnVal = new StepAtomNode((CpsFlowExecution)getExecution(), this.descriptor, this.getParents().get(0));
+        return returnVal;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -48,7 +48,7 @@ public class StepAtomNode extends AtomNode implements StepNode {
 
     public StepAtomNode(CpsFlowExecution exec, StepDescriptor d, FlowNode parent) {
         super(exec, exec.iotaStr(), parent);
-        this.descriptorId = d!=null ? d.getId() : null;
+        this.descriptorId = d!=null ? d.getId().intern() : null;
 
         // we use SimpleXStreamFlowNodeStorage, which uses XStream, so
         // constructor call is always for brand-new FlowNode that has not existed anywhere.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -42,7 +42,7 @@ import java.util.Collections;
  */
 public class StepAtomNode extends AtomNode implements StepNode {
 
-    private final String descriptorId;
+    private String descriptorId;
 
     // once we successfully convert descriptorId to a real instance, cache that
     private transient StepDescriptor descriptor;
@@ -67,9 +67,9 @@ public class StepAtomNode extends AtomNode implements StepNode {
         return descriptor;
     }
 
-    private Object readResolve() throws ObjectStreamException {
-        StepAtomNode returnVal = new StepAtomNode((CpsFlowExecution)getExecution(), this.descriptor, this.getParents().get(0));
-        return returnVal;
+    protected Object readResolve() throws ObjectStreamException {
+        this.descriptorId = this.descriptorId.intern();
+        return super.readResolve();
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -24,7 +24,7 @@ public class StepStartNode extends BlockStartNode implements StepNode {
     public StepStartNode(CpsFlowExecution exec, StepDescriptor d, FlowNode parent) {
         super(exec, exec.iotaStr(), parent);
         this.descriptor = d;
-        this.descriptorId = d!=null ? d.getId() : null;
+        this.descriptorId = d!=null ? d.getId().intern() : null;
 
         // we use SimpleXStreamFlowNodeStorage, which uses XStream, so
         // constructor call is always for brand-new FlowNode that has not existed anywhere.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -9,6 +9,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 
+import java.io.ObjectStreamException;
 import java.util.Collections;
 
 /**
@@ -17,7 +18,7 @@ import java.util.Collections;
  * @author Kohsuke Kawaguchi
  */
 public class StepStartNode extends BlockStartNode implements StepNode {
-    private final String descriptorId;
+    private String descriptorId;
 
     private transient StepDescriptor descriptor;
 
@@ -40,6 +41,11 @@ public class StepStartNode extends BlockStartNode implements StepNode {
             }
         }
         return descriptor;
+    }
+
+    protected Object readResolve() throws ObjectStreamException {
+        this.descriptorId = this.descriptorId.intern();
+        return super.readResolve();
     }
 
     @Override


### PR DESCRIPTION
Should reduce memory footprint for Jenkins pipeline a bit and simplify garbage collection some. 

See [JENKINS-39456](https://issues.jenkins-ci.org/browse/JENKINS-39456)