### PR TITLE
scripts might be null if loading old builds

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -62,6 +62,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.*;
+import javax.annotation.CheckForNull;
 import static org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.*;
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.*;
 
@@ -122,7 +123,7 @@ public final class CpsThreadGroup implements Serializable {
      */
     public final Map<Integer,Closure> closures = new HashMap<Integer,Closure>();
 
-    private final List<Script> scripts = new ArrayList<>();
+    private final @CheckForNull List<Script> scripts = new ArrayList<>();
 
     CpsThreadGroup(CpsFlowExecution execution) {
         this.execution = execution;
@@ -361,7 +362,9 @@ public final class CpsThreadGroup implements Serializable {
         }
         if (ending) {
             execution.cleanUpHeap();
-            scripts.clear();
+            if (scripts != null) {
+                scripts.clear();
+            }
             closures.clear();
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -136,7 +136,9 @@ public final class CpsThreadGroup implements Serializable {
 
     /** Track a script so that we can fix up its {@link Script#getBinding}s after deserialization. */
     void register(Script script) {
-        scripts.add(script);
+        if (scripts != null) {
+            scripts.add(script);
+        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Regression in #41. Corrects a `NullPointerException` thrown at the end of a very old build noticed in tests after https://github.com/jenkinsci/pipeline-input-step-plugin/pull/9.

@reviewbybees