### PR TITLE
Cache the StepDescriptors to elliminate a moderate bottleneck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.9</version>
+            <version>2.11</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.workflow.cps.nodes;
 
 import hudson.model.Action;
-import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -59,10 +58,7 @@ public class StepAtomNode extends AtomNode implements StepNode {
 
     @Override public StepDescriptor getDescriptor() {
         if (descriptor == null && descriptorId != null) {
-            Jenkins j = Jenkins.getInstance();
-            if (j != null) {
-                descriptor = (StepDescriptor) j.getDescriptor(descriptorId);
-            }
+            descriptor = StepDescriptorCache.getPublicCache().getDescriptor(descriptorId);
         }
         return descriptor;
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.workflow.cps.nodes;
 
 import hudson.Extension;
-import hudson.ExtensionListListener;
 import hudson.ExtensionPoint;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
@@ -44,19 +44,8 @@ import javax.annotation.CheckForNull;
 @Restricted(NoExternalUse.class)
 public class StepDescriptorCache implements ExtensionPoint {
 
-    /** Used ONLY for unit tests where there isn't actually a running Jenkins */
-    private static StepDescriptorCache fallbackSingleton = null;
-
     public static StepDescriptorCache getPublicCache() {
-        Jenkins myJenkins = Jenkins.getInstance();
-        if ( myJenkins == null) {
-            if (fallbackSingleton == null) {
-                 fallbackSingleton = new StepDescriptorCache();
-            }
-            return fallbackSingleton;
-        } else {
-            return myJenkins.getExtensionList(StepDescriptorCache.class).get(0);
-        }
+        return Jenkins.getActiveInstance().getExtensionList(StepDescriptorCache.class).get(0);
     }
 
     public StepDescriptorCache() {}

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
@@ -83,9 +83,6 @@ public class StepDescriptorCache implements ExtensionPoint {
 
     @CheckForNull
     public StepDescriptor getDescriptor(String descriptorId) {
-        if (descriptorId != null && Jenkins.getInstance() != null) {
-            return (StepDescriptor) (Jenkins.getInstance().getDescriptor(descriptorId));
-        }
         if (descriptorId != null) {
             return descriptorCache.get(descriptorId);
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
@@ -1,0 +1,80 @@
+package org.jenkinsci.plugins.workflow.cps.nodes;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import hudson.Extension;
+import hudson.ExtensionListListener;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.CheckForNull;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Shared cacheSingleton for the StepDescriptors, extension-scoped to avoid test issues
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class StepDescriptorCache {
+
+    // This ensures we use extension loading unless running a pure unit test with no Jenkins
+    private static StepDescriptorCache getCacheInstance() {
+        Jenkins myJenkins = Jenkins.getInstance();
+        if ( myJenkins == null) {
+            return new StepDescriptorCache();
+        } else {
+            return myJenkins.getExtensionList(StepDescriptorCache.class).get(0);
+        }
+    }
+
+    private static final StepDescriptorCache cacheSingleton = StepDescriptorCache.getCacheInstance();
+
+    public static StepDescriptorCache getPublicCache() {
+        return cacheSingleton;
+    }
+
+
+    ExtensionListListener myListener = new ExtensionListListener() {
+        @Override
+        public void onChange() {
+            invalidateAll();
+        }
+    };
+
+    public StepDescriptorCache() {
+        // Ensures we purge the cache if steps change
+        Jenkins.getInstance().getExtensionList(StepDescriptor.class).addListener(myListener);
+    }
+
+    public void invalidateAll() {
+        descriptorCache.invalidateAll();
+    }
+
+    private static transient final LoadingCache<String,StepDescriptor> descriptorCache = CacheBuilder.newBuilder().maximumSize(1000).build(new CacheLoader<String,StepDescriptor>() {
+        @Override public StepDescriptor load(String descriptorId) {
+            if (descriptorId != null) {
+                Jenkins j = Jenkins.getInstance();
+                if (j != null) {
+                    return (StepDescriptor) j.getDescriptor(descriptorId);
+                }
+            }
+            return null;
+        }
+    });
+
+    @CheckForNull
+    public StepDescriptor getDescriptor(String descriptorId) {
+        if (descriptorId != null) {
+            try {
+                return descriptorCache.get(descriptorId);
+            } catch (ExecutionException exec) {
+                throw new RuntimeException(exec);  // If we can't get the descriptor good grief
+            }
+
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.workflow.cps.nodes;
 
 import hudson.model.Action;
-import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.actions.BodyInvocationAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
@@ -34,11 +33,8 @@ public class StepStartNode extends BlockStartNode implements StepNode {
     }
 
     public StepDescriptor getDescriptor() {
-        if (descriptor == null) {
-            Jenkins j = Jenkins.getInstance();
-            if (j != null) {
-                descriptor = (StepDescriptor) j.getDescriptor(descriptorId);
-            }
+        if (descriptor == null && descriptorId != null) {
+            descriptor = StepDescriptorCache.getPublicCache().getDescriptor(descriptorId);
         }
         return descriptor;
     }


### PR DESCRIPTION
Profiling showed this is rather expensive, due to repeated iteration needs to find the descriptor. 

This converts this to a simple, fast hashmap lookup, rather than checking against a whole list of items. 

Side point: it probably reduces the garbage objects Jenkins generates. 