### PR TITLE
Avoid saving program.dat if we are about to run another chunk anyway

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -355,7 +355,7 @@ public final class CpsThreadGroup implements Serializable {
             }
         }
 
-        if (changed) {
+        if (changed && !stillRunnable) {
             try {
                 saveProgram();
             } catch (IOException x) {
@@ -420,6 +420,9 @@ public final class CpsThreadGroup implements Serializable {
 
     @CpsVmThreadOnly
     public void saveProgram(File f) throws IOException {
+        boolean logging = LOGGER.isLoggable(Level.FINER);
+        long start = logging ? System.nanoTime() : 0;
+
         File dir = f.getParentFile();
         File tmpFile = File.createTempFile("atomic",null, dir);
 
@@ -451,6 +454,11 @@ public final class CpsThreadGroup implements Serializable {
         } finally {
             PROGRAM_STATE_SERIALIZATION.set(old);
             Util.deleteFile(tmpFile);
+        }
+
+        if (logging) {
+            long end = System.nanoTime();
+            LOGGER.log(FINER, "saved {0} of size {1}Kb in {2}ms", new Object[] {f, f.length() / 1000, (end - start) / 1000 / 1000});
         }
     }
 


### PR DESCRIPTION
Reverts this aspect of behavior to that prior to #46, which should avoid the incompatibility noted in [2.14](https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Groovy+Plugin#PipelineGroovyPlugin-2.14%28Sep07%2C2016%29). Script authors should still of course avoid using unserializable local variables.

Also avoids some load spent saving `program.dat` unnecessarily, though in my tests so far the benefit is typically negligible: while roughly half of the program saves are avoided, each one only took a few milliseconds anyway. Could affect certain scripts more, if they do a lot of (CPS-transformed) Groovy in between steps.

@reviewbybees