### PR TITLE
Record timing information for internal processes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -404,7 +404,7 @@ public class CpsFlowExecution extends FlowExecution {
     }
 
     synchronized void logTimings() {
-        if (LOGGER.isLoggable(Level.FINE)) {
+        if (timings != null && LOGGER.isLoggable(Level.FINE)) {
             Map<String, String> formatted = new TreeMap<>();
             for (Map.Entry<String, Long> entry : timings.entrySet()) {
                 formatted.put(entry.getKey(), entry.getValue() / 1000 / 1000 + "ms");
@@ -1288,7 +1288,9 @@ public class CpsFlowExecution extends FlowExecution {
             writeChild(w, context, "result", e.result, Result.class);
             writeChild(w, context, "script", e.script, String.class);
             writeChild(w, context, "loadedScripts", e.loadedScripts, Map.class);
-            writeChild(w, context, "timings", e.timings, Map.class);
+            synchronized (e) {
+                writeChild(w, context, "timings", e.timings, Map.class);
+            }
             writeChild(w, context, "sandbox", e.sandbox, Boolean.class);
             if (e.user != null) {
                 writeChild(w, context, "user", e.user, String.class);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1489,11 +1489,14 @@ public class CpsFlowExecution extends FlowExecution {
                                 if (owner != null) {
                                     FlowExecution exec = owner.getOrNull();
                                     if (exec instanceof CpsFlowExecution) {
-                                        pw.println("Timings for " + run + ":");
-                                        for (Map.Entry<String, Long> entry : new TreeMap<>(((CpsFlowExecution) exec).timings).entrySet()) {
-                                            pw.println("  " + entry.getKey() + "\t" + entry.getValue() / 1000 / 1000 + "ms");
+                                        Map<String, Long> timings = ((CpsFlowExecution) exec).timings;
+                                        if (timings != null) {
+                                            pw.println("Timings for " + run + ":");
+                                            for (Map.Entry<String, Long> entry : new TreeMap<>(timings).entrySet()) {
+                                                pw.println("  " + entry.getKey() + "\t" + entry.getValue() / 1000 / 1000 + "ms");
+                                            }
+                                            pw.println();
                                         }
-                                        pw.println();
                                     }
                                 }
                             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
@@ -24,6 +24,7 @@ import org.codehaus.groovy.control.SourceUnit;
  * @see "doc/classloader.md"
  * @see CpsGroovyShellFactory
  */
+@SuppressFBWarnings(value="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED", justification="irrelevant")
 class CpsGroovyShell extends GroovyShell {
 
     private static final Logger LOGGER = Logger.getLogger(CpsGroovyShell.class.getName());
@@ -42,7 +43,6 @@ class CpsGroovyShell extends GroovyShell {
         this(execution, cc, execution != null ? new TimingLoader(parent, execution) : parent);
     }
 
-    @SuppressFBWarnings(value="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED", justification="irrelevant")
     private CpsGroovyShell(@CheckForNull CpsFlowExecution execution, CompilerConfiguration cc, ClassLoader usuallyTimingLoader) {
         super(usuallyTimingLoader, new Binding(), cc);
         this.execution = execution;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
@@ -38,15 +38,19 @@ class CpsGroovyShell extends GroovyShell {
     /**
      * Use {@link CpsGroovyShellFactory} to instantiate it.
      */
-    @SuppressFBWarnings(value="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED", justification="irrelevant")
     CpsGroovyShell(ClassLoader parent, @CheckForNull CpsFlowExecution execution, CompilerConfiguration cc) {
-        super(execution != null ? new TimingLoader(parent, execution) : parent, new Binding(), cc);
+        this(execution, cc, execution != null ? new TimingLoader(parent, execution) : parent);
+    }
+
+    @SuppressFBWarnings(value="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED", justification="irrelevant")
+    private CpsGroovyShell(@CheckForNull CpsFlowExecution execution, CompilerConfiguration cc, ClassLoader usuallyTimingLoader) {
+        super(usuallyTimingLoader, new Binding(), cc);
         this.execution = execution;
         try {
             // Apparently there is no supported way to initialize a GroovyShell with a specified GroovyClassLoader.
             Field loaderF = GroovyShell.class.getDeclaredField("loader");
             loaderF.setAccessible(true);
-            loaderF.set(this, new CleanGroovyClassLoader(parent, cc));
+            loaderF.set(this, new CleanGroovyClassLoader(usuallyTimingLoader, cc));
         } catch (Exception x) {
             LOGGER.log(Level.WARNING, "failed to install CleanGroovyClassLoader", x);
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -420,9 +420,6 @@ public final class CpsThreadGroup implements Serializable {
 
     @CpsVmThreadOnly
     public void saveProgram(File f) throws IOException {
-        boolean logging = LOGGER.isLoggable(Level.FINER);
-        long start = logging ? System.nanoTime() : 0;
-
         File dir = f.getParentFile();
         File tmpFile = File.createTempFile("atomic",null, dir);
 
@@ -456,11 +453,6 @@ public final class CpsThreadGroup implements Serializable {
             PROGRAM_STATE_SERIALIZATION.set(old);
             execution.time(TimingKind.save, true);
             Util.deleteFile(tmpFile);
-        }
-
-        if (logging) {
-            long end = System.nanoTime();
-            LOGGER.log(FINER, "saved {0} of size {1}Kb in {2}ms", new Object[] {f, f.length() / 1000, (end - start) / 1000 / 1000});
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -442,9 +442,8 @@ public final class CpsThreadGroup implements Serializable {
             return;
         }
 
-        execution.time(TimingKind.save, false);
         boolean serializedOK = false;
-        try {
+        try (CpsFlowExecution.Timing t = execution.time(TimingKind.saveProgram)) {
             RiverWriter w = new RiverWriter(tmpFile, execution.getOwner());
             try {
                 w.writeObject(this);
@@ -464,7 +463,6 @@ public final class CpsThreadGroup implements Serializable {
             throw new IOException("Failed to persist "+f,e);
         } finally {
             PROGRAM_STATE_SERIALIZATION.set(old);
-            execution.time(TimingKind.save, true);
             Util.deleteFile(tmpFile);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -433,6 +433,7 @@ public final class CpsThreadGroup implements Serializable {
             return;
         }
 
+        execution.time(TimingKind.save, false);
         try {
             RiverWriter w = new RiverWriter(tmpFile, execution.getOwner());
             try {
@@ -450,6 +451,7 @@ public final class CpsThreadGroup implements Serializable {
             throw new IOException("Failed to persist "+f,e);
         } finally {
             PROGRAM_STATE_SERIALIZATION.set(old);
+            execution.time(TimingKind.save, true);
             Util.deleteFile(tmpFile);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
@@ -90,6 +90,7 @@ class CpsVmExecutorService extends InterceptingExecutorService {
 
     private ThreadContext setUp() {
         CpsFlowExecution execution = cpsThreadGroup.getExecution();
+        execution.time(CpsFlowExecution.TimingKind.run, false);
         ACL.impersonate(execution.getAuthentication());
         CURRENT.set(cpsThreadGroup);
         cpsThreadGroup.busy = true;
@@ -108,6 +109,11 @@ class CpsVmExecutorService extends InterceptingExecutorService {
         CURRENT.set(null);
         cpsThreadGroup.busy = false;
         context.restore();
+        CpsFlowExecution execution = cpsThreadGroup.getExecution();
+        execution.time(CpsFlowExecution.TimingKind.run, true);
+        if (isShutdown()) {
+            execution.logTimings();
+        }
     }
 
     static ThreadLocal<CpsThreadGroup> CURRENT = new ThreadLocal<>();

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinitionValidatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinitionValidatorTest.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import static org.hamcrest.Matchers.containsString;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class CpsFlowDefinitionValidatorTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void doCheckScriptCompile() throws Exception {
+        CpsFlowDefinition.DescriptorImpl d = r.jenkins.getDescriptorByType(CpsFlowDefinition.DescriptorImpl.class);
+        assertThat(d.doCheckScriptCompile("echo 'hello'").toString(), containsString("\"success\""));
+        assertThat(d.doCheckScriptCompile("echo 'hello").toString(), containsString("\"fail\""));
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -52,6 +52,7 @@ import javax.annotation.CheckForNull;
 import jenkins.model.Jenkins;
 import org.codehaus.groovy.reflection.ClassInfo;
 import org.codehaus.groovy.transform.ASTTransformationVisitor;
+import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
@@ -271,6 +272,28 @@ public class CpsFlowExecutionTest {
                 WorkflowJob p = story.j.jenkins.getItemByFullName("p", WorkflowJob.class);
                 WorkflowRun b = p.getLastBuild();
                 story.j.assertLogContains("I am done", story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
+            }
+        });
+    }
+
+    @Test public void timing() {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                logger.record(CpsFlowExecution.TIMING_LOGGER, Level.FINE).capture(100);
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition("semaphore 'wait'", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                SemaphoreStep.waitForStart("wait/1", b);
+            }
+        });
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.getItemByFullName("p", WorkflowJob.class);
+                WorkflowRun b = p.getLastBuild();
+                SemaphoreStep.success("wait/1", null);
+                story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b));
+                assertThat(logger.getRecords(), Matchers.hasSize(Matchers.equalTo(1)));
+                assertEquals(CpsFlowExecution.TimingKind.values().length, ((CpsFlowExecution) b.getExecution()).timings.keySet().size());
             }
         });
     }


### PR DESCRIPTION
Useful for determining, both during experimentation and in the field, where the most load is consumed by the Jenkins master when running Pipeline builds: class loading for Groovy compilation, saving `program.dat`, etc.

Supersedes the simple logging in #92.

@reviewbybees