### PR TITLE
[JENKINS-29656] Retry I/O operations due to Windows file locks.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -443,6 +443,7 @@ public final class CpsThreadGroup implements Serializable {
                 }
                 Files.move(tmpFile.toPath(), f.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
                 LOGGER.log(FINE, "program state saved");
+                break;
             } catch (RuntimeException e) {
                 if (i < MAX_RETRIES - 1) {
                     LOGGER.log(FINE, "Retry [" + (i + 1) + "/" + MAX_RETRIES + "]", e);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -444,19 +444,6 @@ public final class CpsThreadGroup implements Serializable {
                 Files.move(tmpFile.toPath(), f.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
                 LOGGER.log(FINE, "program state saved");
                 break;
-            } catch (RuntimeException e) {
-                if (i < MAX_RETRIES - 1) {
-                    LOGGER.log(FINE, "Retry [" + (i + 1) + "/" + MAX_RETRIES + "]", e);
-                    long timeout = Math.min(1000, (long) (10 * Math.pow(2, i)));
-                    try {
-                        TimeUnit.MILLISECONDS.sleep(timeout);
-                        continue;
-                    } catch (InterruptedException ignore) {
-                        // give up
-                    }
-                }
-                propagateErrorToWorkflow(e);
-                throw new IOException("Failed to persist "+f,e);
             } catch (IOException e) {
                 if (i < MAX_RETRIES - 1) {
                     LOGGER.log(FINE, "Retry [" + (i + 1) + "/" + MAX_RETRIES + "]", e);


### PR DESCRIPTION
Attempted fix for [JENKINS-29656](https://issues.jenkins-ci.org/browse/JENKINS-29656).

(I couldn't test this locally because unit tests were failing even before this change, but I've used similar code in one of my other projects and it works fine.)