### PR TITLE
[JENKINS-40909] NPE encountered during tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -64,7 +64,9 @@ public class StepAtomNode extends AtomNode implements StepNode {
     }
 
     protected Object readResolve() throws ObjectStreamException {
-        this.descriptorId = this.descriptorId.intern();
+        if (descriptorId != null) {
+            this.descriptorId = this.descriptorId.intern();
+        }
         return super.readResolve();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -40,7 +40,9 @@ public class StepStartNode extends BlockStartNode implements StepNode {
     }
 
     protected Object readResolve() throws ObjectStreamException {
-        this.descriptorId = this.descriptorId.intern();
+        if (descriptorId != null) {
+            this.descriptorId = this.descriptorId.intern();
+        }
         return super.readResolve();
     }
 


### PR DESCRIPTION
If the test in https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/24 is run against `workflow-cps` 2.22, as it is currently, there is a `NullPointerException` which is harmless—corrected in #89. But if it is run against 2.23 to fix that, we get an exception deserializing flow nodes, introduced by code in #82. I am not exactly sure what the problem is, since with this patch the flow nodes do wind up correctly deserialized, and the `*.xml` is correct; somehow at the time `readResolve` is called, all fields are null.

@reviewbybees esp. @svanoort