### PR TITLE
[JENKINS-32986] Apply a timeout to some hang-prone operations in the CPS VM thread

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.21</version>
+        <version>2.22</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.13-20170205.153141-1</version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/29 -->
+            <version>2.13</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.13-20170205.153141-1</version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/29 -->
+            <version>2.13</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.19</version>
+        <version>2.21</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.11</version>
+            <version>2.13-20170205.153141-1</version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/29 -->
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.9</version>
+            <version>2.13-20170205.153141-1</version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/29 -->
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -29,6 +29,7 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -37,6 +38,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.*;
@@ -264,7 +266,7 @@ class CpsBodyExecution extends BodyExecution {
 
                 @Override
                 public void onFailure(Throwable t) {
-                    // couldn't cancel
+                    LOGGER.log(Level.WARNING, "could not cancel " + context + " with " + Arrays.toString(causes), t);
                 }
             });
         } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -38,11 +38,13 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.*;
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.*;
 import org.jenkinsci.plugins.workflow.support.concurrent.Futures;
+import org.jenkinsci.plugins.workflow.support.concurrent.Timeout;
 
 /**
  * Represents a {@link Continuable} that is either runnable or suspended (that waits for an
@@ -156,7 +158,7 @@ public final class CpsThread implements Serializable {
         final CpsThread old = CURRENT.get();
         CURRENT.set(this);
 
-        try {
+        try (Timeout timeout = Timeout.limit(5, TimeUnit.MINUTES)) {
             LOGGER.log(FINE, "runNextChunk on {0}", resumeValue);
             Outcome o = resumeValue;
             resumeValue = null;
@@ -281,7 +283,7 @@ public final class CpsThread implements Serializable {
             return;
         }
 
-        try {
+        try (Timeout timeout = Timeout.limit(30, TimeUnit.SECONDS)) {
             s.stop(t);
         } catch (Exception e) {
             t.addSuppressed(e);


### PR DESCRIPTION
Begins to address [JENKINS-32986](https://issues.jenkins-ci.org/browse/JENKINS-32986). Does not go so far as to impose a hard limit. #93 probably required for any sort of quota.

Downstream of https://github.com/jenkinsci/workflow-support-plugin/pull/29.

@reviewbybees