### PR TITLE
Make StepNode just extend higher-level API in workflow-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.6</version>
+            <!-- Temporary version to pull in upstream PRs, will revert before merge once that is released -->
+            <version>2.9-stepnode-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.9</version>
+            <version>2.10</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <!-- Temporary version to pull in upstream PRs, will revert before merge once that is released -->
-            <version>2.9-stepnode-SNAPSHOT</version>
+            <version>2.9</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNode.java
@@ -11,5 +11,6 @@ import javax.annotation.CheckForNull;
  * Retained for binary & API compatibility but the interface has been pushed up a level into the
  *  workflow-api plugin to allow broader access.
  */
+@Deprecated
 public interface StepNode extends org.jenkinsci.plugins.workflow.graph.StepNode {
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNode.java
@@ -7,16 +7,9 @@ import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import javax.annotation.CheckForNull;
 
 /**
- * Optional interface for {@link FlowNode} that has associated {@link StepDescriptor}
- *
- * @author Kohsuke Kawaguchi
+ * Optional interface for {@link FlowNode} that has associated {@link StepDescriptor}.
+ * Retained for binary & API compatibility but the interface has been pushed up a level into the
+ *  workflow-api plugin to allow broader access.
  */
-public interface StepNode {
-    /**
-     * Returns the descriptor for {@link Step} that produced this flow node.
-     *
-     * @return
-     *      null for example if the descriptor that created the node has since been uninstalled.
-     */
-    @CheckForNull StepDescriptor getDescriptor();
+public interface StepNode extends org.jenkinsci.plugins.workflow.graph.StepNode {
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNode.java
@@ -8,7 +8,7 @@ import javax.annotation.CheckForNull;
 
 /**
  * Optional interface for {@link FlowNode} that has associated {@link StepDescriptor}.
- * Retained for binary & API compatibility but the interface has been pushed up a level into the
+ * Retained for binary and API compatibility but the interface has been pushed up a level into the
  *  workflow-api plugin to allow broader access.
  */
 @Deprecated

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNode.java
@@ -10,7 +10,7 @@ import javax.annotation.CheckForNull;
 /**
  * Optional interface for {@link FlowNode} that has associated {@link StepDescriptor}.
  * Retained for binary and API compatibility but the interface has been pushed up a level into the
- *  workflow-api plugin to allow broader access.
+ *  {@link org.jenkinsci.plugins.workflow.graph.StepNode} interface in workflow-api plugin to allow broader access.
  */
 @Deprecated
 @SuppressFBWarnings(value="NM_SAME_SIMPLE_NAME_AS_INTERFACE", justification="We want to keep the SimpleName the same, to make it easy to replace usages")

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNode.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow.cps.nodes;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -12,5 +13,6 @@ import javax.annotation.CheckForNull;
  *  workflow-api plugin to allow broader access.
  */
 @Deprecated
+@SuppressFBWarnings(value="NM_SAME_SIMPLE_NAME_AS_INTERFACE", justification="We want to keep the SimpleName the same, to make it easy to replace usages")
 public interface StepNode extends org.jenkinsci.plugins.workflow.graph.StepNode {
 }


### PR DESCRIPTION
Allows compatibility while permitting workflow-api to expose step info. 

Downstream of https://github.com/jenkinsci/workflow-api-plugin/pull/28


@reviewbybees 