### PR TITLE
Noting that CpsScmFlowDefinition.scriptPath must use `/` as the separator

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition/help-scriptPath.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition/help-scriptPath.html
@@ -1,5 +1,5 @@
 <div>
-    Relative location within the checkout of your Pipeline script.
+    Relative location (<code>/</code>-separated regardless of platform) within the checkout of your Pipeline script.
     Note that it will always be run inside a Groovy sandbox.
     <code>Jenkinsfile</code> is conventional and allows you to switch easily to a multibranch project
     (just use <code>checkout scm</code> to retrieve sources from the same location as is configured here).


### PR DESCRIPTION
A user was seen trying to use `\` with `GitSCM` and it did not work.

@reviewbybees