### PR TITLE
Delete program.dat at the end of a build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -367,6 +367,11 @@ public final class CpsThreadGroup implements Serializable {
                 scripts.clear();
             }
             closures.clear();
+            try {
+                Util.deleteFile(execution.getProgramDataFile());
+            } catch (IOException x) {
+                LOGGER.log(Level.WARNING, "Failed to delete program.dat in " + execution, x);
+            }
         }
 
         return stillRunnable;

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -97,7 +97,8 @@ public class CpsFlowExecutionTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 story.j.jenkins.getWorkspaceFor(p).child("lib.groovy").write(CpsFlowExecutionTest.class.getName() + ".register(this)", null);
                 p.setDefinition(new CpsFlowDefinition(CpsFlowExecutionTest.class.getName() + ".register(this); node {load 'lib.groovy'}", false));
-                story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                assertFalse(((CpsFlowExecution) b.getExecution()).getProgramDataFile().exists());
                 assertFalse(LOADERS.isEmpty());
                 try {
                     // In Groovy 1.8.9 this keeps static state, but only for the last script (as also noted in JENKINS-23762).


### PR DESCRIPTION
Just noticed this file was being left behind after the build completes, when it is no longer needed and is just a waste of disk space.

(Not deleting from `croak`, when we leave it behind for possible analysis.)

@reviewbybees