### PR TITLE
JENKINS-44406 Return Null Object instead of null for compute

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/NullStepDescriptorHolder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/NullStepDescriptorHolder.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.plugins.workflow.cps.nodes;
+
+
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+
+import java.util.Set;
+
+public class NullStepDescriptorHolder extends Step {
+    public static final NullStepDescriptor nulllDescriptor = new NullStepDescriptor();
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return null;
+    }
+
+    //do not use annoation @extension since we don't want to expose it
+    public static class NullStepDescriptor extends StepDescriptor {
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return null;
+        }
+
+        @Override
+        public String getFunctionName() {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
@@ -36,6 +36,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.CheckForNull;
 
+import static org.jenkinsci.plugins.workflow.cps.nodes.NullStepDescriptorHolder.nulllDescriptor;
+
 /**
  * Shared cacheSingleton for the StepDescriptors, extension-scoped to avoid test issues
  */
@@ -62,19 +64,28 @@ public class StepDescriptorCache implements ExtensionPoint {
 
         public StepDescriptor compute(String descriptorId) {
             Jenkins j = Jenkins.getInstance();
+            StepDescriptor descriptor=null;
             if (descriptorId != null && j != null) {
-                return (StepDescriptor) j.getDescriptor(descriptorId);
+                descriptor= (StepDescriptor) j.getDescriptor(descriptorId);
             }
-            return null;
+            if(descriptor==null){
+                descriptor=nulllDescriptor;
+            }
+            return descriptor;
         }
     };
 
     @CheckForNull
     public StepDescriptor getDescriptor(String descriptorId) {
+        StepDescriptor descriptor = null;
         if (descriptorId != null) {
-            return descriptorCache.get(descriptorId);
+            descriptor = descriptorCache.get(descriptorId);
         }
-        return null;
-
+        if (descriptor == nulllDescriptor ) {
+            return null;
+        } else {
+            return descriptor;
+        }
     }
+
 }


### PR DESCRIPTION
[JENKINS-44406](https://issues.jenkins-ci.org/browse/JENKINS-44406)

when pipeline step get removed or renamed, the REST API  wfapi/runs?fullStages=true will throw NPE. Simply use Null object to fix the issue