### PR TITLE
Fix StepDescriptorCache handling of null StepDescriptor lookup [JENKINS-44406]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
@@ -35,6 +35,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.CheckForNull;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Shared cacheSingleton for the StepDescriptors, extension-scoped to avoid test issues

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCache.java
@@ -68,11 +68,9 @@ public class StepDescriptorCache implements ExtensionPoint {
         }
 
         StepDescriptor v = store.get(descriptorId);
-        if(v!=null) return v;
-
-        synchronized (this) {
-            v = store.get(descriptorId);
-            if (v != null) return v;
+        if (v != null) {
+            return v;
+        } else {
             Jenkins j = Jenkins.getActiveInstance();
             Descriptor d = j.getDescriptor(descriptorId);
             if (d instanceof StepDescriptor) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCacheTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/nodes/StepDescriptorCacheTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.workflow.cps.nodes;
+
+import org.jenkinsci.plugins.workflow.cps.steps.LoadStep;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class StepDescriptorCacheTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void testStepDescriptorCache() {
+        StepDescriptorCache cache = StepDescriptorCache.getPublicCache();
+        StepDescriptor expected = cache.getDescriptor("org.jenkinsci.plugins.workflow.cps.steps.LoadStep");
+        Assert.assertEquals(LoadStep.DescriptorImpl.class, expected.getClass());
+
+        StepDescriptor nullDescriptor = cache.getDescriptor("nonexistent");
+        Assert.assertNull(nullDescriptor);
+
+        nullDescriptor = cache.getDescriptor(null);
+        Assert.assertNull(nullDescriptor);
+    }
+}


### PR DESCRIPTION
[JENKINS-44406](https://issues.jenkins-ci.org/browse/JENKINS-44406)

Don't rely on Memoizer to handle nulls correctly - it doesn't handle a computed null because ConcurrentHashMap can't (potential fix to Jenkins core). 