### PR TITLE
TimingLoader leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1048,6 +1048,10 @@ public class CpsFlowExecution extends FlowExecution {
     }
 
     private static void cleanUpLoader(ClassLoader loader, Set<ClassLoader> encounteredLoaders, Set<Class<?>> encounteredClasses) throws Exception {
+        if (loader instanceof CpsGroovyShell.TimingLoader) {
+            cleanUpLoader(loader.getParent(), encounteredLoaders, encounteredClasses);
+            return;
+        }
         if (!(loader instanceof GroovyClassLoader)) {
             return;
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1331,7 +1331,9 @@ public class CpsFlowExecution extends FlowExecution {
             writeChild(w, context, "script", e.script, String.class);
             writeChild(w, context, "loadedScripts", e.loadedScripts, Map.class);
             synchronized (e) {
-                writeChild(w, context, "timings", e.timings, Map.class);
+                if (e.timings != null) {
+                    writeChild(w, context, "timings", e.timings, Map.class);
+                }
             }
             writeChild(w, context, "sandbox", e.sandbox, Boolean.class);
             if (e.user != null) {
@@ -1348,7 +1350,7 @@ public class CpsFlowExecution extends FlowExecution {
             }
         }
 
-        private <T> void writeChild(HierarchicalStreamWriter w, MarshallingContext context, String name, T v, Class<T> staticType) {
+        private <T> void writeChild(HierarchicalStreamWriter w, MarshallingContext context, String name, @Nonnull T v, Class<T> staticType) {
             if (!mapper.shouldSerializeMember(CpsFlowExecution.class,name))
                 return;
             startNode(w, name, staticType);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
@@ -145,7 +145,7 @@ class CpsGroovyShell extends GroovyShell {
             return super.generateScriptName();
     }
 
-    private static class TimingLoader extends ClassLoader {
+    static class TimingLoader extends ClassLoader {
         private final @Nonnull CpsFlowExecution execution;
         TimingLoader(ClassLoader parent, @Nonnull CpsFlowExecution execution) {
             super(parent);


### PR DESCRIPTION
Corrects a regression in #93, caught only by a test in `workflow-cps-global-lib`—I suppose something about the existence of a trusted loader in the hierarchy triggers the problem.

Subsumes #135.

@reviewbybees