### PR TITLE
[JENKINS-34464] Bump structs version, add test for result roundtrip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.6</version>
+            <version>1.7-20170522.160448-1</version> <!-- TODO: Switch to release after https://github.com/jenkinsci/structs-plugin/pull/19 is merged and released -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.7-20170525.172515-3</version> <!-- TODO: Switch to release after https://github.com/jenkinsci/structs-plugin/pull/19 is merged and released -->
+            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.7-20170522.160448-1</version> <!-- TODO: Switch to release after https://github.com/jenkinsci/structs-plugin/pull/19 is merged and released -->
+            <version>1.7-20170525.172515-3</version> <!-- TODO: Switch to release after https://github.com/jenkinsci/structs-plugin/pull/19 is merged and released -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
@@ -29,6 +29,7 @@ import hudson.model.BooleanParameterDefinition;
 import hudson.model.BooleanParameterValue;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.tasks.ArtifactArchiver;
@@ -45,6 +46,7 @@ import org.jenkinsci.plugins.workflow.support.steps.WorkspaceStep;
 import org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStep;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStep;
 import org.jenkinsci.plugins.workflow.testMetaStep.Colorado;
+import org.jenkinsci.plugins.workflow.testMetaStep.EchoResultStep;
 import org.jenkinsci.plugins.workflow.testMetaStep.Hawaii;
 import org.jenkinsci.plugins.workflow.testMetaStep.Island;
 import org.jenkinsci.plugins.workflow.testMetaStep.MonomorphicData;
@@ -305,6 +307,12 @@ public class SnippetizerTest {
         dataList.add(new MonomorphicDataWithSymbol("three", "four"));
         MonomorphicListWithSymbolStep monomorphicStep = new MonomorphicListWithSymbolStep(dataList);
         st.assertRoundTrip(monomorphicStep, "monomorphListSymbolStep([monomorphSymbol(firstArg: 'one', secondArg: 'two'), monomorphSymbol(firstArg: 'three', secondArg: 'four')])");
+    }
+
+    @Issue("JENKINS-34464")
+    @Test
+    public void resultRoundTrips() throws Exception {
+        st.assertRoundTrip(new EchoResultStep(Result.UNSTABLE), "echoResult 'UNSTABLE'");
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/EchoResultStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/EchoResultStep.java
@@ -1,0 +1,72 @@
+package org.jenkinsci.plugins.workflow.testMetaStep;
+
+import hudson.Extension;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
+
+public class EchoResultStep extends Step implements Serializable {
+
+    private Result result;
+
+    @DataBoundConstructor
+    public EchoResultStep(Result result) {
+        this.result = result;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new EchoResultStepExecution(this, context);
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends StepDescriptor {
+        @Override
+        public String getFunctionName() {
+            return "echoResult";
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.singleton(TaskListener.class);
+        }
+    }
+
+    public static class EchoResultStepExecution extends StepExecution {
+        private final EchoResultStep step;
+
+        public EchoResultStepExecution(EchoResultStep s, StepContext context) {
+            super(context);
+            this.step = s;
+        }
+
+        @Override
+        public boolean start() throws Exception {
+            TaskListener listener = getContext().get(TaskListener.class);
+
+            if (listener != null)
+                listener.getLogger().println("Result is " + step.getResult());
+
+            return true;
+        }
+
+        @Override
+        public void stop(Throwable cause) throws Exception {
+        }
+    }
+
+    private static final long serialVersionUID = 1L;
+
+}


### PR DESCRIPTION
[JENKINS-34464](https://issues.jenkins-ci.org/browse/JENKINS-34464)

Downstream of https://github.com/jenkinsci/structs-plugin/pull/19, upstream of https://github.com/jenkinsci/workflow-multibranch-plugin/pull/63

The `workflow-multibranch` test was failing, seemingly due to `workflow-cps` having the older `structs` version (plus some other problems, but those are fixed over in that PR anyway). So let's bump the `structs` release.

cc @reviewbybees 