### PR TITLE
Adds option to treat missing script file as an empty file

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
@@ -61,6 +61,7 @@ public class CpsScmFlowDefinition extends FlowDefinition {
 
     private final SCM scm;
     private final String scriptPath;
+    private boolean ignoreMissingScript;
     private boolean lightweight;
 
     @DataBoundConstructor public CpsScmFlowDefinition(SCM scm, String scriptPath) {
@@ -74,6 +75,14 @@ public class CpsScmFlowDefinition extends FlowDefinition {
 
     public String getScriptPath() {
         return scriptPath;
+    }
+
+    public boolean isIgnoreMissingScript() {
+        return ignoreMissingScript;
+    }
+
+    @DataBoundSetter public void setIgnoreMissingScript(boolean ignoreMissingScript) {
+        this.ignoreMissingScript = ignoreMissingScript;
     }
 
     public boolean isLightweight() {
@@ -98,8 +107,19 @@ public class CpsScmFlowDefinition extends FlowDefinition {
         if (isLightweight()) {
             try (SCMFileSystem fs = SCMFileSystem.of(build.getParent(), scm)) {
                 if (fs != null) {
-                    String script = fs.child(scriptPath).contentAsString();
-                    listener.getLogger().println("Obtained " + scriptPath + " from " + scm.getKey());
+                    String script;
+                    try {
+                        script = fs.child(scriptPath).contentAsString();
+                        listener.getLogger().println("Obtained " + scriptPath + " from " + scm.getKey());
+                    } catch (java.io.FileNotFoundException e) {
+                        if (isIgnoreMissingScript()) {
+                            // Set script to am empty string to mimic an empty scriptFile
+                            script = "";
+                            listener.getLogger().println("The file " + scriptPath + " from " + scm.getKey() + " was not found, ignoring");
+                        } else {
+                            throw e;
+                        }
+                    }
                     return new CpsFlowExecution(script, true, owner);
                 } else {
                     listener.getLogger().println("Lightweight checkout support not available, falling back to full checkout.");
@@ -133,9 +153,17 @@ public class CpsScmFlowDefinition extends FlowDefinition {
                 throw new IOException(scriptFile + " is not inside " + dir);
             }
             if (!scriptFile.exists()) {
-                throw new AbortException(scriptFile + " not found");
+                if (isIgnoreMissingScript()) {
+                    // Set script to am empty string to mimic an empty scriptFile
+                    script = "";
+                    listener.getLogger().println("The file " + scriptPath + " from " + scm.getKey() + " was not found, ignoring");
+                } else {
+                    throw new AbortException(scriptFile + " not found");
+                }
+            } else {
+                script = scriptFile.readToString();
             }
-            script = scriptFile.readToString();
+
         }
         CpsFlowExecution exec = new CpsFlowExecution(script, true, owner);
         exec.flowStartNodeActions.add(new WorkspaceActionImpl(dir, null));

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
@@ -110,16 +110,16 @@ public class CpsScmFlowDefinition extends FlowDefinition {
                     String script;
                     try {
                         script = fs.child(scriptPath).contentAsString();
-                        listener.getLogger().println("Obtained " + scriptPath + " from " + scm.getKey());
                     } catch (java.io.FileNotFoundException e) {
                         if (isIgnoreMissingScript()) {
-                            // Set script to am empty string to mimic an empty scriptFile
+                            // Set script to an empty string to mimic an empty scriptFile
                             script = "";
                             listener.getLogger().println("The file " + scriptPath + " from " + scm.getKey() + " was not found, ignoring");
                         } else {
                             throw e;
                         }
                     }
+                    listener.getLogger().println("Obtained " + scriptPath + " from " + scm.getKey());
                     return new CpsFlowExecution(script, true, owner);
                 } else {
                     listener.getLogger().println("Lightweight checkout support not available, falling back to full checkout.");
@@ -154,7 +154,7 @@ public class CpsScmFlowDefinition extends FlowDefinition {
             }
             if (!scriptFile.exists()) {
                 if (isIgnoreMissingScript()) {
-                    // Set script to am empty string to mimic an empty scriptFile
+                    // Set script to an empty string to mimic an empty scriptFile
                     script = "";
                     listener.getLogger().println("The file " + scriptPath + " from " + scm.getKey() + " was not found, ignoring");
                 } else {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition/config.jelly
@@ -29,6 +29,9 @@ THE SOFTWARE.
     <f:entry field="scriptPath" title="${%Script Path}">
         <f:textbox default="Jenkinsfile"/>
     </f:entry>
+    <f:entry field="ignoreMissingScript" title="${%Ignore missing script}">
+        <f:checkbox default="false"/>
+    </f:entry>
     <f:entry field="lightweight" title="${%Lightweight checkout}">
         <f:checkbox default="true"/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition/help-ignoreMissingScript.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition/help-ignoreMissingScript.html
@@ -1,0 +1,4 @@
+<div>
+    If selected, a missing file as referenced in "Script Path" will be treated as an empty file. This
+    allows the job to succeed before the specified Pipeline script has been created.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinitionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinitionTest.java
@@ -64,11 +64,13 @@ public class CpsScmFlowDefinitionTest {
         sampleRepo.init();
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         CpsScmFlowDefinition def = new CpsScmFlowDefinition(new GitStep(sampleRepo.toString()).createSCM(), "Jenkinsfile");
+        def.setIgnoreMissingScript(false);
         def.setLightweight(true);
         p.setDefinition(def);
         r.configRoundtrip(p);
         def = (CpsScmFlowDefinition) p.getDefinition();
         assertEquals("Jenkinsfile", def.getScriptPath());
+        assertFalse(def.isIgnoreMissingScript());
         assertTrue(def.isLightweight());
         assertEquals(GitSCM.class, def.getScm().getClass());
     }
@@ -181,4 +183,32 @@ public class CpsScmFlowDefinitionTest {
         r.assertLogContains("version one", r.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("VERSION", "one")))));
     }
 
+    @Test public void ignoreMissingScriptOnLightweightCheckout() throws Exception {
+        sampleRepo.init();
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        GitStep step = new GitStep(sampleRepo.toString());
+        CpsScmFlowDefinition def = new CpsScmFlowDefinition(step.createSCM(), "flow.groovy");
+        def.setIgnoreMissingScript(true);
+        def.setLightweight(true);
+        p.setDefinition(def);
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogNotContains("Cloning the remote Git repository", b);
+        r.assertLogContains("The file flow.groovy from git " + sampleRepo + " was not found, ignoring", b);
+    }
+
+    @Test public void ignoreMissingScriptOnFullCheckout() throws Exception
+    {
+        sampleRepo.init();
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        GitStep step = new GitStep(sampleRepo.toString());
+        CpsScmFlowDefinition def =
+                new CpsScmFlowDefinition(step.createSCM(), "flow.groovy");
+        def.setIgnoreMissingScript(true);
+        def.setLightweight(false);
+        p.setDefinition(def);
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("Cloning the remote Git repository", b);
+        r.assertLogContains("The file flow.groovy from git " + sampleRepo +
+                " was not found, ignoring", b);
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinitionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinitionTest.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.workflow.cps;
 
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.plugins.git.BranchSpec;
@@ -183,6 +184,17 @@ public class CpsScmFlowDefinitionTest {
         r.assertLogContains("version one", r.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("VERSION", "one")))));
     }
 
+    @Test public void missingScriptOnLightweightCheckout() throws Exception {
+        sampleRepo.init();
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        GitStep step = new GitStep(sampleRepo.toString());
+        CpsScmFlowDefinition def = new CpsScmFlowDefinition(step.createSCM(), "flow.groovy");
+        def.setIgnoreMissingScript(false);
+        def.setLightweight(true);
+        p.setDefinition(def);
+        r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+    }
+
     @Test public void ignoreMissingScriptOnLightweightCheckout() throws Exception {
         sampleRepo.init();
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
@@ -194,6 +206,19 @@ public class CpsScmFlowDefinitionTest {
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogNotContains("Cloning the remote Git repository", b);
         r.assertLogContains("The file flow.groovy from git " + sampleRepo + " was not found, ignoring", b);
+    }
+
+    @Test public void missingScriptOnFullCheckout() throws Exception
+    {
+        sampleRepo.init();
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        GitStep step = new GitStep(sampleRepo.toString());
+        CpsScmFlowDefinition def =
+                new CpsScmFlowDefinition(step.createSCM(), "flow.groovy");
+        def.setIgnoreMissingScript(false);
+        def.setLightweight(false);
+        p.setDefinition(def);
+        r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
     }
 
     @Test public void ignoreMissingScriptOnFullCheckout() throws Exception


### PR DESCRIPTION
When automating project creation along with base Jenkins jobs
for various projects, the current behavior of the Groovy plugin requires
a development team to create an empty script file before they may be
ready to develop a proper pipeline in order to pass CI. This becomes
a barrier to a development team when the failure of the initial CI job
provides a negative code review on a change.

This commit adds an option to treat a missing script file as an empty
file thus allowing the CI job to pass. The default for this option is
"false" thus preserving the original behavior of the plugin.