### PR TITLE
A call to get(FlowNode) need not wait for the CpsThread

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
@@ -291,6 +291,10 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
 
     @Override
     protected <T> T doGet(Class<T> key) throws IOException, InterruptedException {
+        if (FlowNode.class.isAssignableFrom(key)) {
+            return key.cast(getNode());
+        }
+
         CpsThread t = getThreadSynchronously();
         if (t == null) {
             throw new IOException("cannot find current thread");
@@ -299,9 +303,6 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
         T v = t.getContextVariable(key);
         if (v!=null)        return v;
 
-        if (FlowNode.class.isAssignableFrom(key)) {
-            return key.cast(getNode());
-        }
         if (key == CpsThread.class) {
             return key.cast(t);
         }


### PR DESCRIPTION
Since you cannot override the contextual `FlowNode` with `BodyInvoker` as a contextual variable, there is no need to look up the `CpsThread`, which is a blocking operation. Would have helped avoid a problem in https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/2 and might have even helped https://github.com/jenkinsci/throttle-concurrent-builds-plugin/pull/50 which was a showstopper. (`CpsStepContext.getNode` is also potentially blocking, but at a lower level—does not need the program to have resumed AFAIK.)

@reviewbybees