### PR TITLE
[JENKINS-45109] Also adjust StepNode.getTypeDisplayName to handle metasteps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -66,7 +66,7 @@ public class StepStartNode extends BlockStartNode implements StepNode {
     }
 
     public String getStepName() {
-        StepDescriptor d = getDescriptor();
-        return d!=null ? d.getDisplayName() : descriptorId;
+        String n = StepAtomNode.effectiveDisplayName(this);
+        return n != null ? n : descriptorId;
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNodeTest.java
@@ -27,8 +27,10 @@ package org.jenkinsci.plugins.workflow.cps.nodes;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import hudson.model.Result;
+import hudson.tasks.junit.JUnitResultArchiver;
 import java.util.List;
 import static org.hamcrest.Matchers.*;
+import org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
@@ -62,6 +64,7 @@ public class StepNodeTest {
         List<FlowNode> coreStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("step"));
         assertThat(coreStepNodes, hasSize(1));
         assertEquals("junit", coreStepNodes.get(0).getDisplayFunctionName());
+        assertEquals(r.jenkins.getDescriptor(JUnitResultArchiver.class).getDisplayName(), coreStepNodes.get(0).getDisplayName());
         List<FlowNode> coreWrapperStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), Predicates.and(new NodeStepTypePredicate("wrap"), new Predicate<FlowNode>() {
             @Override public boolean apply(FlowNode n) {
                 return n instanceof StepStartNode && !((StepStartNode) n).isBody();
@@ -69,6 +72,7 @@ public class StepNodeTest {
         }));
         assertThat(coreWrapperStepNodes, hasSize(1));
         assertEquals("configFileProvider", coreWrapperStepNodes.get(0).getDisplayFunctionName());
+        assertEquals(r.jenkins.getDescriptor(ConfigFileBuildWrapper.class).getDisplayName() + " : Start", coreWrapperStepNodes.get(0).getDisplayName());
         r.assertLogContains("[Pipeline] junit", b);
         r.assertLogContains("[Pipeline] configFileProvider", b);
         r.assertLogContains("[Pipeline] // configFileProvider", b);


### PR DESCRIPTION
Amends #148 to address the first bullet point of [JENKINS-45101](https://issues.jenkins-ci.org/browse/JENKINS-45101), which it turns out is not the fault of Blue Ocean, and can in fact be seen in the original **Pipeline Steps** view as well.

@reviewbybees