### PR TITLE
Adjusting Jenkins versions being tested

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.32.2', /* JENKINS-42189 */ '2.47'])
+buildPlugin(jenkinsVersions: [null, '2.60.1'])


### PR DESCRIPTION
The [JENKINS-33358](https://issues.jenkins-ci.org/browse/JENKINS-33358) Groovy update went into 2.47. So at first I planned to have CI test

* the current plugin baseline (2.7.3)
* 2.46.3, the last LTS prior to that update, and after the change in 2.12 (IIRC) which enforced plugin dependencies at startup
* 2.60.1, the current LTS, after that update

But then I decided to skip 2.46.x since it uses the same Groovy 2.4.7 as the baseline (unlike the case in, say, `workflow-cps-global-lib` which still needs to test against three lines—using Groovy 1.x, 2.4.7, and 2.4.8), and has the same plugin dependency enforcements as the current LTS. And saving some machine time for a heavily-edited plugin is probably not a bad idea anyway.

@reviewbybees