### PR TITLE
Stop bundling guava.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
             <artifactId>support-core</artifactId>
             <version>2.32</version>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.stephenc.findbugs</groupId>
+                    <artifactId>findbugs-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.30</version>
+        <version>2.31</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -176,6 +176,12 @@
             <groupId>com.cloudbees</groupId>
             <artifactId>groovy-cps</artifactId>
             <version>${groovy-cps.version}</version>
+            <exclusions>
+                <exclusion> <!-- we pick this up from jenkins-core -->
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
@@ -252,6 +258,12 @@
             <version>${groovy-cps.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Consumes more than ⅔ of the size of `workflow-cps.hpi`, and is unused since we pick it up from the Jenkins core classpath anyway.

@reviewbybees