### PR TITLE
The argumentsToString parameter was not, in fact, checked for null

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/MonomorphicStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/MonomorphicStep.java
@@ -57,7 +57,7 @@ public class MonomorphicStep extends AbstractStepImpl {
 
 
         @Override
-        public String argumentsToString(@CheckForNull Map<String, Object> map) {
+        public String argumentsToString(Map<String, Object> map) {
             if (map.get("data") instanceof Map) {
                 Map<String,String> data = (Map<String,String>)(map.get("data"));
                 return data.get("firstArg")+","+data.get("secondArg");


### PR DESCRIPTION
Cf. https://github.com/jenkinsci/workflow-step-api-plugin/pull/27.

@reviewbybees