### PR TITLE
[JENKINS-44548] NPE from loadProgramFailed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
@@ -94,13 +94,15 @@ final class FlowHead implements Serializable {
     }
 
     void newStartNode(FlowStartNode n) throws IOException {
-        for (Action a : execution.flowStartNodeActions) {
-            if (a instanceof FlowNodeAction) {
-                ((FlowNodeAction) a).onLoad(n);
+        if (execution.flowStartNodeActions != null) {
+            for (Action a : execution.flowStartNodeActions) {
+                if (a instanceof FlowNodeAction) {
+                    ((FlowNodeAction) a).onLoad(n);
+                }
+                n.addAction(a);
             }
-            n.addAction(a);
-        }
-        execution.flowStartNodeActions.clear();
+            execution.flowStartNodeActions.clear();
+        } // may be unset from loadProgramFailed
         synchronized (execution) {
             this.head = execution.startNodes.push(n);
         }


### PR DESCRIPTION
[JENKINS-44548](https://issues.jenkins-ci.org/browse/JENKINS-44548)

`CpsFlowExecution.storage` and `startNodes` are initialized after `onLoad` by `initializeStorage`. But `flowStartNodeActions`, normally initialized from the constructor, will not be reinitialized after a load from disk, so this could be null in case we are in `loadProgramFailed`.

@reviewbybees