### PR TITLE
Catch any kind of exception from parseScript

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -137,6 +137,7 @@ import javax.annotation.concurrent.GuardedBy;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.apache.commons.io.Charsets;
+import org.codehaus.groovy.GroovyBugError;
 import org.jboss.marshalling.reflect.SerializableClassRegistry;
 
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.*;
@@ -656,7 +657,7 @@ public class CpsFlowExecution extends FlowExecution {
                         }
                     });
 
-        } catch (IOException e) {
+        } catch (Exception | GroovyBugError e) {
             loadProgramFailed(e, result);
         }
     }


### PR DESCRIPTION
The error in [JENKINS-46191](https://issues.jenkins-ci.org/browse/JENKINS-46191), for example, can apparently be fatal during startup:

```
BUG! exception in phase 'class generation' in source unit 'WorkflowScript' Error while popping argument from operand stack tracker in class WorkflowScript method …. 
	at org.codehaus.groovy.classgen.asm.OperandStack.popWithMessage(OperandStack.java:72) 
	at …
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:558) 
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298) 
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268) 
	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688) 
	at groovy.lang.GroovyShell.parse(GroovyShell.java:700) 
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:129) 
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:123) 
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:516) 
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.loadProgramAsync(CpsFlowExecution.java:613) 
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:588) 
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:612) 
	at hudson.model.RunMap.retrieve(RunMap.java:225) 
	at hudson.model.RunMap.retrieve(RunMap.java:57) 
	at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:500) 
	at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:482) 
	at jenkins.model.lazy.AbstractLazyLoadRunMap.getByNumber(AbstractLazyLoadRunMap.java:380) 
	at hudson.model.RunMap.getById(RunMap.java:205) 
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.run(WorkflowRun.java:878) 
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.get(WorkflowRun.java:888) 
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$1.computeNext(FlowExecutionList.java:65) 
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$1.computeNext(FlowExecutionList.java:57) 
	at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:143) 
	at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:138) 
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$ItemListenerImpl.onLoaded(FlowExecutionList.java:178) 
	at jenkins.model.Jenkins.<init>(Jenkins.java:999) 
	at hudson.model.Hudson.<init>(Hudson.java:86) 
	at hudson.model.Hudson.<init>(Hudson.java:82) 
	at hudson.WebAppMain$3.run(WebAppMain.java:235) 
Caused: hudson.util.HudsonFailedToLoad 
	at hudson.WebAppMain$3.run(WebAppMain.java:249)
```

Complements https://github.com/jenkinsci/workflow-job-plugin/pull/59.

@reviewbybees