### PR TITLE
[JENKINS-46391] Test verifying CPS-specific ~/foo/ behavior

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <git-plugin.version>3.1.0</git-plugin.version>
         <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
         <scm-api-plugin.version>2.0.8</scm-api-plugin.version>
-        <groovy-cps.version>1.18</groovy-cps.version>
+        <groovy-cps.version>1.19</groovy-cps.version>
     </properties>
     <dependencies>
         <dependency>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.34-20170823.172346-3</version> <!-- Switch to release once https://github.com/jenkinsci/script-security-plugin/pull/146 is merged/released -->
+            <version>1.34</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.31</version>
+            <version>1.34-20170823.172346-3</version> <!-- Switch to release once https://github.com/jenkinsci/script-security-plugin/pull/146 is merged/released -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -224,4 +224,11 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
         jenkins.assertLogContains("org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance", b);
     }
 
+    @Issue("JENKINS-46391")
+    @Test
+    public void tildePattern() throws Exception {
+        WorkflowJob job = jenkins.jenkins.createProject(WorkflowJob.class, "p");
+        job.setDefinition(new CpsFlowDefinition("def f = ~/f.*/; f.matcher('foo').matches()", true));
+        jenkins.buildAndAssertSuccess(job);
+    }
 }


### PR DESCRIPTION
[JENKINS-46391](https://issues.jenkins-ci.org/browse/JENKINS-46391)

Downstream of https://github.com/jenkinsci/script-security-plugin/pull/146

cc @reviewbybees 