### PR TITLE
Defer writing FlowNode actions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.31</version>
+        <version>2.29</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-cps</artifactId>
-    <version>2.40-SNAPSHOT</version>
+    <version>2.40-deferactionwrite-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Groovy</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Groovy+Plugin</url>
@@ -62,10 +62,11 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
+        <jenkins.version>2.60.2</jenkins.version>
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.1.0</git-plugin.version>
-        <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
+        <java.level>8</java.level>
+        <workflow-support-plugin.version>2.15-deferactionwrite-SNAPSHOT</workflow-support-plugin.version>
         <scm-api-plugin.version>2.0.8</scm-api-plugin.version>
         <groovy-cps.version>1.18</groovy-cps.version>
     </properties>
@@ -73,12 +74,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.10</version>
+            <version>2.13-deferactionwrite-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.18</version>
+            <version>2.21-deferactionwrite-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,20 +66,23 @@
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.1.0</git-plugin.version>
         <java.level>8</java.level>
-        <workflow-support-plugin.version>2.15-deferactionwrite-SNAPSHOT</workflow-support-plugin.version>
+        <!-- Temp version until https://github.com/jenkinsci/workflow-support-plugin/pull/43 is released -->
+        <workflow-support-plugin.version>2.15-deferactionwrite-20170901.213922-1</workflow-support-plugin.version>
         <scm-api-plugin.version>2.0.8</scm-api-plugin.version>
         <groovy-cps.version>1.18</groovy-cps.version>
     </properties>
     <dependencies>
         <dependency>
+            <!-- Temp version until https://github.com/jenkinsci/workflow-step-api-plugin/pull/29 gets released  -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.13-deferactionwrite-SNAPSHOT</version>
+            <version>2.13-deferactionwrite2-20170901.210414-1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.21-deferactionwrite-SNAPSHOT</version>
+            <!-- Temp version for https://github.com/jenkinsci/workflow-api-plugin/pull/49 -->
+            <version>2.21-deferactionwrite-20170901.212705-1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <git-plugin.version>3.1.0</git-plugin.version>
         <java.level>8</java.level>
         <!-- Temp version until https://github.com/jenkinsci/workflow-support-plugin/pull/43 is released -->
-        <workflow-support-plugin.version>2.15-deferactionwrite-20170901.213922-1</workflow-support-plugin.version>
+        <workflow-support-plugin.version>2.15-deferactionwrite-20170915.012921-2</workflow-support-plugin.version>
         <scm-api-plugin.version>2.0.8</scm-api-plugin.version>
         <groovy-cps.version>1.19</groovy-cps.version>
     </properties>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -122,10 +122,9 @@ class CpsBodyExecution extends BodyExecution {
                 sn.addActionWithoutPersist((PersistentAction)a);
             }
         }
-        if (!sn.isPersistent()) {
+        if (sn.isPersistent()) {
             sn.persistSafe();
         }
-        sn.persistSafe();
 
         StepContext sc = new CpsBodySubContext(context, sn);
         for (BodyExecutionCallback c : callbacks) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -377,7 +377,7 @@ class CpsBodyExecution extends BodyExecution {
         StepStartNode start = new StepStartNode(head.getExecution(),
                 context.getStepDescriptor(), head.get());
         this.startNodeId = start.getId();
-        start.addAction(new BodyInvocationAction());
+        start.addActionWithoutPersist(new BodyInvocationAction());
         head.setNewHead(start);
         return start;
     }
@@ -393,7 +393,7 @@ class CpsBodyExecution extends BodyExecution {
 
             StepEndNode end = new StepEndNode(head.getExecution(),
                     getBodyStartNode(), head.get());
-            end.addAction(new BodyInvocationAction());
+            end.addActionWithoutPersist(new BodyInvocationAction());
             head.setNewHead(end);
 
             return end;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -11,15 +11,18 @@ import com.cloudbees.groovy.cps.sandbox.SandboxInvoker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.SettableFuture;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Action;
 import hudson.model.Result;
 import hudson.util.Iterators;
 import jenkins.model.CauseOfInterruption;
 import org.jenkinsci.plugins.workflow.actions.BodyInvocationAction;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
+import org.jenkinsci.plugins.workflow.actions.PersistentAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.steps.BodyExecution;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
@@ -115,9 +118,14 @@ class CpsBodyExecution extends BodyExecution {
 
         StepStartNode sn = addBodyStartFlowNode(head);
         for (Action a : params.startNodeActions) {
-            if (a!=null)
-                sn.addAction(a);
+            if (a!=null) {
+                sn.addActionWithoutPersist((PersistentAction)a);
+            }
         }
+        if (!sn.isPersistent()) {
+            sn.persistSafe();
+        }
+        sn.persistSafe();
 
         StepContext sc = new CpsBodySubContext(context, sn);
         for (BodyExecutionCallback c : callbacks) {
@@ -373,8 +381,10 @@ class CpsBodyExecution extends BodyExecution {
      *
      * @see #addBodyEndFlowNode()
      */
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "temporary")
     private @Nonnull StepStartNode addBodyStartFlowNode(FlowHead head) {
-        StepStartNode start = new StepStartNode(head.getExecution(),
+        CpsFlowExecution exec = head.getExecution();
+        StepStartNode start = new StepStartNode(exec,
                 context.getStepDescriptor(), head.get());
         this.startNodeId = start.getId();
         start.addActionWithoutPersist(new BodyInvocationAction());

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1027,6 +1027,12 @@ public class CpsFlowExecution extends FlowExecution {
         if (outcome.isFailure())
             head.addAction(new ErrorAction(outcome.getAbnormal()));
 
+        try {
+            this.getStorage().persistAll();
+        } catch (IOException ioe) {
+            LOGGER.log(Level.WARNING, "Failed to persist the final FlowNodes upon program completion");
+        }
+
         // shrink everything into a single new head
         done = true;
         FlowHead first = getFirstHead();
@@ -1480,6 +1486,11 @@ public class CpsFlowExecution extends FlowExecution {
         @Override public void saveActions(FlowNode node, List<Action> actions) throws IOException {
             try (Timing t = time(TimingKind.flowNode)) {
                 delegate.saveActions(node, actions);
+            }
+        }
+        @Override public void persistAll() throws IOException {
+            try (Timing t = time(TimingKind.flowNode)) {
+                delegate.persistAll();
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -212,7 +212,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
                     if (comp != null && allEnv != null) {
                         allEnv.entrySet().removeAll(comp.getEnvironment().entrySet());
                     }
-                    an.addAction(new ArgumentsActionImpl(ps.namedArgs, allEnv));
+                    an.addActionWithoutPersist(new ArgumentsActionImpl(ps.namedArgs, allEnv));
                 }
             } catch (Exception e) {
                 // Avoid breaking execution because we can't store some sort of crazy Step argument

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -281,7 +281,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
 
         boolean singleArgumentOnly = false;
         if (metaStep != null) {
-            Descriptor symbolDescriptor = SymbolLookup.get().findDescriptor(metaStep.getMetaStepArgumentType(), symbol);
+            Descriptor symbolDescriptor = SymbolLookup.get().findDescriptor((Class)(metaStep.getMetaStepArgumentType()), symbol);
             DescribableModel<?> symbolModel = new DescribableModel(symbolDescriptor.clazz);
 
             singleArgumentOnly = symbolModel.hasSingleRequiredParameter() && symbolModel.getParameters().size() == 1;
@@ -304,7 +304,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
             // might be resolved with a specific type.
             return ud;
         } else {
-            Descriptor d = SymbolLookup.get().findDescriptor(metaStep.getMetaStepArgumentType(), symbol);
+            Descriptor d = SymbolLookup.get().findDescriptor((Class)(metaStep.getMetaStepArgumentType()), symbol);
 
             try {
                 // execute this Describable through a meta-step

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
@@ -111,6 +111,7 @@ final class FlowHead implements Serializable {
 
     void setNewHead(FlowNode v) {
         try {
+            this.getExecution().getStorage().persistAll(); // Ensures we're actually persisting old nodes before starting a new one
             this.head = v;
 
             CpsThreadGroup c = CpsThreadGroup.current();

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
@@ -112,7 +112,6 @@ final class FlowHead implements Serializable {
     void setNewHead(FlowNode v) {
         try {
             this.head = v;
-            execution.storage.storeNode(head);
 
             CpsThreadGroup c = CpsThreadGroup.current();
             if (c !=null) {
@@ -125,6 +124,11 @@ final class FlowHead implements Serializable {
                 // TODO can CpsThreadGroup.notifyNewHead be used instead to notify both kinds of listeners?
                 execution.notifyListeners(Collections.singletonList(v), true);
                 execution.notifyListeners(Collections.singletonList(v), false);
+
+                // Persist at the very end now, once we have all actions not attached in the Execution itself
+                if (v.isPersistent()) {
+                    v.save();
+                }
             }
         } catch (IOException e) {
             LOGGER.log(Level.FINE, "Failed to record new head: " + v, e);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -58,12 +58,12 @@ public class StepAtomNode extends AtomNode implements StepNode {
     // once we successfully convert descriptorId to a real instance, cache that
     private transient StepDescriptor descriptor;
 
-    public StepAtomNode(CpsFlowExecution exec, StepDescriptor d, FlowNode parent) {
+    public StepAtomNode(CpsFlowExecution exec, @Nonnull StepDescriptor d, FlowNode parent) {
         super(exec, exec.iotaStr(), parent);
         if (d.deferWritingState()) {
             this.persistent = false;
         }
-        this.descriptorId = d!=null ? d.getId().intern() : null;
+        this.descriptorId = d.getId().intern();
 
         // we use SimpleXStreamFlowNodeStorage, which uses XStream, so
         // constructor call is always for brand-new FlowNode that has not existed anywhere.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -60,7 +60,7 @@ public class StepAtomNode extends AtomNode implements StepNode {
 
     public StepAtomNode(CpsFlowExecution exec, @Nonnull StepDescriptor d, FlowNode parent) {
         super(exec, exec.iotaStr(), parent);
-        if (d.deferWritingState()) {
+        if (d.delayWritingFlownodeActions()) {
             this.persistent = false;
         }
         this.descriptorId = d.getId().intern();

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -60,6 +60,9 @@ public class StepAtomNode extends AtomNode implements StepNode {
 
     public StepAtomNode(CpsFlowExecution exec, StepDescriptor d, FlowNode parent) {
         super(exec, exec.iotaStr(), parent);
+        if (d.deferWritingState()) {
+            this.persistent = false;
+        }
         this.descriptorId = d!=null ? d.getId().intern() : null;
 
         // we use SimpleXStreamFlowNodeStorage, which uses XStream, so

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -27,7 +27,7 @@ public class StepStartNode extends BlockStartNode implements StepNode {
         if (d.deferWritingState()) {
             this.persistent = false;
         }
-        this.descriptorId = d!=null ? d.getId().intern() : null;
+        this.descriptorId = d.getId().intern();
 
         // we use SimpleXStreamFlowNodeStorage, which uses XStream, so
         // constructor call is always for brand-new FlowNode that has not existed anywhere.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -24,6 +24,9 @@ public class StepStartNode extends BlockStartNode implements StepNode {
     public StepStartNode(CpsFlowExecution exec, StepDescriptor d, FlowNode parent) {
         super(exec, exec.iotaStr(), parent);
         this.descriptor = d;
+        if (d.deferWritingState()) {
+            this.perssistent = false;
+        }
         this.descriptorId = d!=null ? d.getId().intern() : null;
 
         // we use SimpleXStreamFlowNodeStorage, which uses XStream, so

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -25,7 +25,7 @@ public class StepStartNode extends BlockStartNode implements StepNode {
         super(exec, exec.iotaStr(), parent);
         this.descriptor = d;
         if (d.deferWritingState()) {
-            this.perssistent = false;
+            this.persistent = false;
         }
         this.descriptorId = d!=null ? d.getId().intern() : null;
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepStartNode.java
@@ -24,7 +24,7 @@ public class StepStartNode extends BlockStartNode implements StepNode {
     public StepStartNode(CpsFlowExecution exec, StepDescriptor d, FlowNode parent) {
         super(exec, exec.iotaStr(), parent);
         this.descriptor = d;
-        if (d.deferWritingState()) {
+        if (d.delayWritingFlownodeActions()) {
             this.persistent = false;
         }
         this.descriptorId = d.getId().intern();


### PR DESCRIPTION
Finally we have the payoff!  This reduces the amount of disk serialization calls significantly. 

Next up:
- [x] Deploy SNAPSHOT for downstream use, as 2.41-deferactionwrite-20170908.150443-1
- [x] Downstream of this, in workflow-job plugin, defer write of timing action
- [x] Ensure that persist is invoked eventually in most cases (finally, etc)

Downstream of:

- https://github.com/jenkinsci/workflow-step-api-plugin/pull/29
- https://github.com/jenkinsci/workflow-api-plugin/pull/49
- https://github.com/jenkinsci/workflow-support-plugin/pull/43

# Result: 
**In IO-~50% more FlowNode throughput, or put another way, ~33% reduction in build time in IO-bound situations.**

Benchmark: running the follow pipeline, ramping up from 1 to 6 concurrent runs evenly over a minute, and starting a new build when one completes.   Plateau on the left is with a modern core and latest pipeline plugin versions and on the right is with downstream plugin versions + this one.  


<img width="1612" alt="screen shot 2017-09-01 at 5 59 25 pm" src="https://user-images.githubusercontent.com/5400948/29989183-6e1b08a2-8f3f-11e7-8fed-9b2c66b20a7e.png">

<img width="1606" alt="screen shot 2017-09-01 at 6 00 02 pm" src="https://user-images.githubusercontent.com/5400948/29989241-b1cba8f4-8f3f-11e7-93a5-5ddb84c723e6.png">

Pipeline: 

```groovy
/*
Simple echo steps
*/
properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')), pipelineTriggers([])])

for (int i=0; i<10; i++) {
	stage ("Stage $i") {
		// Some echos.
		for (int j=0; j < 20; j++) {
			// Put in some logging.
            echo "Here goes echo number $j"
		}
	}
}
```

Combined with finishing off the log handling rewrite work, we will probably end up cutting the IO burden of pipeline in half AKA double performance in IO-bound situations. 

**TODO:**
- [ ] Create a test utility that can report on which FlowNodes are persisted to disk and which are not, and compare persisted version to actual version. (maybe look to see if actions are trivially equal)
    - Consider that we may have different persistence models for FlowNodes in the future, i.e. nonpersistent, fully persistent, etc
- [ ] Instrument testcases for error in pipeline syntax, error in pipeline, normal run of steps, and running steps which defer writing their actions and do it inside the StepExecution. 