### PR TITLE
Consume temporary version of groovy-cps that reduces memory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
         <scm-api-plugin.version>2.0.8</scm-api-plugin.version>
         <!-- Temporary until https://github.com/cloudbees/groovy-cps/pull/74 is released and we can use final-->
-        <groovy-cps.version>1.20-20170921.213551-1</groovy-cps.version>
+        <groovy-cps.version>1.20-20170922.134829-2</groovy-cps.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <git-plugin.version>3.1.0</git-plugin.version>
         <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
         <scm-api-plugin.version>2.0.8</scm-api-plugin.version>
-        <!-- Temporary until https://github.com/cloudbees/groovy-cps/pull/74 is released -->
+        <!-- Temporary until https://github.com/cloudbees/groovy-cps/pull/74 is released and we can use final-->
         <groovy-cps.version>1.20-20170921.213551-1</groovy-cps.version>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
         <git-plugin.version>3.1.0</git-plugin.version>
         <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
         <scm-api-plugin.version>2.0.8</scm-api-plugin.version>
-        <groovy-cps.version>1.19</groovy-cps.version>
+        <!-- Temporary until https://github.com/cloudbees/groovy-cps/pull/74 is released -->
+        <groovy-cps.version>1.20-20170921.213551-1</groovy-cps.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Demonstrates that https://github.com/cloudbees/groovy-cps/pull/74 works and does not introduce errors. 