### PR TITLE
[JENKINS-47105] Another attempt at fixing CpsFlowExecutionTest.loaderReleased

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.33</version>
+        <version>2.35</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -63,6 +63,7 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>2.7.3</jenkins.version>
+        <jenkins-test-harness.version>2.28-20170925.205852-2</jenkins-test-harness.version> <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/75 -->
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.1.0</git-plugin.version>
         <workflow-support-plugin.version>2.14</workflow-support-plugin.version>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -72,6 +72,7 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
@@ -85,7 +86,14 @@ import org.jvnet.hudson.test.TestExtension;
 public class CpsFlowExecutionTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
-    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule() {
+        @Override protected JenkinsRule createJenkinsRule(Description description) {
+            JenkinsRule r = super.createJenkinsRule(description);
+            // TODO seems that Timeout induces a leak in loaderReleased (which assertGC cannot find)
+            r.timeout = 0;
+            return r;
+        }
+    };
     @Rule public LoggerRule logger = new LoggerRule();
 
     @After public void clearLoaders() {


### PR DESCRIPTION
Replaces #178. Downstream of https://github.com/jenkinsci/jenkins-test-harness/pull/75.

@reviewbybees