### PR TITLE
CpsThreadGroup.scripts could be empty in readResolve

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -152,12 +152,13 @@ public final class CpsThreadGroup implements Serializable {
         if (scripts != null) { // compatibility: the field will be null in old programs
             GroovyShell shell = execution.getShell();
             assert shell.getContext().getVariables().isEmpty();
-            assert !scripts.isEmpty();
-            // Take the canonical bindings from the main script and relink that object with that of the shell and all other loaded scripts which kept the same bindings.
-            shell.getContext().getVariables().putAll(scripts.get(0).getBinding().getVariables());
-            for (Script script : scripts) {
-                if (script.getBinding().getVariables().equals(shell.getContext().getVariables())) {
-                    script.setBinding(shell.getContext());
+            if (!scripts.isEmpty()) {
+                // Take the canonical bindings from the main script and relink that object with that of the shell and all other loaded scripts which kept the same bindings.
+                shell.getContext().getVariables().putAll(scripts.get(0).getBinding().getVariables());
+                for (Script script : scripts) {
+                    if (script.getBinding().getVariables().equals(shell.getContext().getVariables())) {
+                        script.setBinding(shell.getContext());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Observed in a build on a server where agents are ephemeral, after restarting Jenkins and then killing a resumed build:

```
Resuming build at … after Jenkins restart
Waiting to resume part of … #…: ???
Waiting to resume part of … #…: Waiting for next available executor
Waiting to resume part of … #…: Waiting for next available executor
Waiting to resume part of … #…: Waiting for next available executor
Waiting to resume part of … #…: Waiting for next available executor
Waiting to resume part of … #…: Waiting for next available executor
Waiting to resume part of … #…: Waiting for next available executor
Waiting to resume part of … #…: Waiting for next available executor
Waiting to resume part of … #…: Waiting for next available executor
Waiting to resume part of … #…: Waiting for next available executor
Waiting to resume part of … #…: There are no nodes with the label ‘…’
Waiting to resume part of … #…: There are no nodes with the label ‘…’
Waiting to resume part of … #…: There are no nodes with the label ‘…’
Waiting to resume part of … #…: There are no nodes with the label ‘…’
Waiting to resume part of … #…: There are no nodes with the label ‘…’
Waiting to resume part of … #…: Waiting for next available executor
Waiting to resume part of … #…: Waiting for next available executor
Waiting to resume part of … #…: Waiting for next available executor
Aborted by …
Click here to forcibly terminate running steps
Resuming build at … after Jenkins restart
[Pipeline] End of Pipeline

GitHub has been notified of this commit’s build result

an exception which occurred:
	in object of type org.jenkinsci.plugins.workflow.cps.CpsThreadGroup
Caused: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:653)
	at java.util.ArrayList.get(ArrayList.java:429)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.readResolve(CpsThreadGroup.java:157)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.marshalling.reflect.SerializableClass.callReadResolve(SerializableClass.java:413)
	at org.jboss.marshalling.river.RiverUnmarshaller.doReadNewObject(RiverUnmarshaller.java:1287)
	at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:276)
	at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:209)
	at org.jboss.marshalling.AbstractObjectInput.readObject(AbstractObjectInput.java:41)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$2.onSuccess(CpsFlowExecution.java:625)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$2.onSuccess(CpsFlowExecution.java:618)
	at org.jenkinsci.plugins.workflow.support.concurrent.Futures$1.run(Futures.java:150)
	at com.google.common.util.concurrent.MoreExecutors$SameThreadExecutorService.execute(MoreExecutors.java:253)
	at com.google.common.util.concurrent.ExecutionList$RunnableExecutorPair.execute(ExecutionList.java:149)
	at com.google.common.util.concurrent.ExecutionList.add(ExecutionList.java:105)
	at com.google.common.util.concurrent.AbstractFuture.addListener(AbstractFuture.java:155)
	at org.jenkinsci.plugins.workflow.support.concurrent.Futures.addCallback(Futures.java:160)
	at org.jenkinsci.plugins.workflow.support.concurrent.Futures.addCallback(Futures.java:90)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.loadProgramAsync(CpsFlowExecution.java:615)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:587)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:582)
	at hudson.model.RunMap.retrieve(RunMap.java:224)
	at hudson.model.RunMap.retrieve(RunMap.java:56)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:500)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:482)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.getByNumber(AbstractLazyLoadRunMap.java:380)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.search(AbstractLazyLoadRunMap.java:345)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.newestBuild(AbstractLazyLoadRunMap.java:275)
	at jenkins.model.lazy.LazyBuildMixIn.getLastBuild(LazyBuildMixIn.java:245)
	at org.jenkinsci.plugins.workflow.job.WorkflowJob.getLastBuild(WorkflowJob.java:255)
	at org.jenkinsci.plugins.workflow.job.WorkflowJob.getLastBuild(WorkflowJob.java:113)
	at hudson.model.Job.getLastCompletedBuild(Job.java:960)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$PipelineTimings$1.writeTo(CpsFlowExecution.java:1500)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:359)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:273)
	at com.cloudbees.jenkins.support.SupportPlugin$PeriodicWorkImpl$1.run(SupportPlugin.java:761)
Caused: java.io.IOException: Failed to load build state
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$3.onSuccess(CpsFlowExecution.java:696)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$3.onSuccess(CpsFlowExecution.java:694)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4$1.run(CpsFlowExecution.java:743)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.run(CpsVmExecutorService.java:35)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
Finished: FAILURE
```

No idea how it could happen but apparently `scripts` is empty, so, moving along.

@reviewbybees