### PR TITLE
Make DSL compilable under -source 8 with some versions of javac

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -275,13 +275,14 @@ public class DSL extends GroovyObjectSupport implements Serializable {
     /**
      * When {@link #invokeMethod(String, Object)} is calling a generic {@link Descriptor}
      */
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected Object invokeDescribable(String symbol, Object _args) {
         List<StepDescriptor> metaSteps = StepDescriptor.metaStepsOf(symbol);
         StepDescriptor metaStep = metaSteps.size()==1 ? metaSteps.get(0) : null;
 
         boolean singleArgumentOnly = false;
         if (metaStep != null) {
-            Descriptor symbolDescriptor = SymbolLookup.get().findDescriptor(metaStep.getMetaStepArgumentType(), symbol);
+            Descriptor symbolDescriptor = SymbolLookup.get().findDescriptor((Class) metaStep.getMetaStepArgumentType(), symbol);
             DescribableModel<?> symbolModel = new DescribableModel(symbolDescriptor.clazz);
 
             singleArgumentOnly = symbolModel.hasSingleRequiredParameter() && symbolModel.getParameters().size() == 1;
@@ -304,7 +305,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
             // might be resolved with a specific type.
             return ud;
         } else {
-            Descriptor d = SymbolLookup.get().findDescriptor(metaStep.getMetaStepArgumentType(), symbol);
+            Descriptor d = SymbolLookup.get().findDescriptor((Class) metaStep.getMetaStepArgumentType(), symbol);
 
             try {
                 // execute this Describable through a meta-step


### PR DESCRIPTION
No semantic change, just makes it easier to experiment with targeting 2.60+ cores.

@reviewbybees