### PR TITLE
Add some more null-proofing for CpsFlowExecution.heads

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -672,10 +672,11 @@ public class CpsFlowExecution extends FlowExecution {
         FlowHead head;
 
         synchronized(this) {
-            if (heads.isEmpty())
+            if (heads == null || heads.isEmpty()) {
                 head = null;
-            else
+            } else {
                 head = getFirstHead();
+            }
         }
 
         if (head==null) {
@@ -1029,10 +1030,13 @@ public class CpsFlowExecution extends FlowExecution {
 
         // shrink everything into a single new head
         done = true;
-        FlowHead first = getFirstHead();
-        first.setNewHead(head);
-        heads.clear();
-        heads.put(first.getId(),first);
+        if (heads != null) {
+            FlowHead first = getFirstHead();
+            first.setNewHead(head);
+            heads.clear();
+            heads.put(first.getId(),first);
+        }
+
     }
 
     void cleanUpHeap() {


### PR DESCRIPTION
Seems sane, putting up for review

> 2017-10-18 23:35:16.916+0000 [id=731]	WARNING	o.j.p.w.cps.CpsVmExecutorService#reportProblem: Unexpected exception in CPS VM thread: CpsFlowExecution[Owner[BUILDNAME]]
java.lang.NullPointerException
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.getFirstHead(CpsFlowExecution.java:1184)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onProgramEnd(CpsFlowExecution.java:1032)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:351)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$100(CpsThreadGroup.java:82)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:243)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:231)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:64)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)

Which seems similar to https://issues.jenkins-ci.org/browse/JENKINS-43055 in cause -- though don't have a reproducible case for triggering this.