### PR TITLE
Rename ReplayCommand into ReplayPipelineCommand

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayPipelineCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayPipelineCommand.java
@@ -40,7 +40,7 @@ import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.OptionDef;
 import org.kohsuke.args4j.spi.Setter;
 
-@Extension public class ReplayCommand extends CLICommand {
+@Extension public class ReplayPipelineCommand extends CLICommand {
 
     @Argument(required=true, index=0, metaVar="JOB", usage="Name of the job to replay.", handler=JobHandler.class)
     public Job<?,?> job;
@@ -50,10 +50,6 @@ import org.kohsuke.args4j.spi.Setter;
 
     @Option(name="-s", aliases="--script", metaVar="SCRIPT", usage="Name of script to edit, such as Script3, if not the main Jenkinsfile.")
     public String script;
-
-    @Override public String getName() {
-        return "replay-pipeline";
-    }
 
     @Override public String getShortDescription() {
         return Messages.ReplayCommand_shortDescription();
@@ -90,7 +86,7 @@ import org.kohsuke.args4j.spi.Setter;
 
     @SuppressWarnings("rawtypes")
     public static class JobHandler extends GenericItemOptionHandler<Job> {
-        
+
         public JobHandler(CmdLineParser parser, OptionDef option, Setter<Job> setter) {
             super(parser, option, setter);
         }


### PR DESCRIPTION
Small consistency improvement: remove then also getName() override to rely on default class name to CLI command name conversion.
(which will stay "replay-pipeline").

I have come across this trying to assess how often people were overriding getName() and apparently this is the only occurrence.
As I think there's no reason anyone would inherit/depend on this, I guess we can safely just rename it for consistency.
(Good thing being when crawling codebase, one will be able to translate the command name into a probable class name, and find it right away using the type-search feature of one's IDE).

@reviewbybees esp. @jglick 