### PR TITLE
[FIXED JENKINS-47339] Add build-implied REBUILD permission.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
@@ -116,7 +116,7 @@ public class ReplayAction implements Action {
     }
 
     /* accessible to Jelly */ public boolean isRebuildEnabled() {
-        if (!run.hasPermission(REBUILD)) {
+        if (!run.hasPermission(Item.BUILD)) {
             return false;
         }
         if (!run.getParent().isBuildable()) {
@@ -329,13 +329,10 @@ public class ReplayAction implements Action {
 
     public static final Permission REPLAY = new Permission(Run.PERMISSIONS, "Replay", Messages._Replay_permission_description(), Item.CONFIGURE, PermissionScope.RUN);
 
-    public static final Permission REBUILD = new Permission(Run.PERMISSIONS, "Rebuild", Messages._Rebuild_permission_description(), Item.BUILD, PermissionScope.RUN);
-
     @SuppressFBWarnings(value="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", justification="getEnabled return value discarded")
     @Initializer(after=InitMilestone.PLUGINS_STARTED, before=InitMilestone.EXTENSIONS_AUGMENTED)
     public static void ensurePermissionRegistered() {
         REPLAY.getEnabled();
-        REBUILD.getEnabled();
     }
 
     @Extension public static class Factory extends TransientActionFactory<Run> {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/Messages.properties
@@ -1,2 +1,3 @@
+Rebuild.permission.description=Ability to rebuild an existing Pipeline build with the same script.
 Replay.permission.description=Ability to perform a new Pipeline build with an edited script.
 ReplayCommand.shortDescription=Replay a Pipeline build with edited script taken from standard input

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/Messages.properties
@@ -1,3 +1,2 @@
-Rebuild.permission.description=Ability to rebuild an existing Pipeline build with the same script.
 Replay.permission.description=Ability to perform a new Pipeline build with an edited script.
 ReplayCommand.shortDescription=Replay a Pipeline build with edited script taken from standard input

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction/index.jelly
@@ -4,27 +4,38 @@
     <l:layout title="Replay ${it.owner.displayName}" norefresh="true">
         <st:include page="sidepanel.jelly" it="${it.owner}"/>
         <l:main-panel>
-            <j:if test="${it.enabled}">
+            <j:if test="${it.enabled or it.rebuildEnabled}">
                 <h1>Replay ${it.owner.displayName}</h1>
                 <p>
                     <j:out value="${%blurb}"/>
                 </p>
-                <f:form action="run" method="POST" name="config">
-                    <f:entry field="mainScript" title="Main Script">
-                      <wfe:workflow-editor script="${it.originalScript}" checkUrl="${rootURL}/${it.owner.url}${it.urlName}/checkScript" checkDependsOn=""/>
-                    </f:entry>
-                    <j:forEach var="loadedScript" items="${it.originalLoadedScripts.entrySet()}">
-                        <f:entry field="${loadedScript.key.replace('.', '_')}" title="${loadedScript.key}">
-                            <wfe:workflow-editor script="${loadedScript.value}" checkUrl="${rootURL}/${it.owner.url}${it.urlName}/checkScript" checkDependsOn=""/>
-                        </f:entry>
-                    </j:forEach>
-                    <f:block>
-                        <a href="${rootURL}/${it.owner.parent.url}/pipeline-syntax" target="_blank">${%Pipeline Syntax}</a>
-                    </f:block>
-                    <f:bottomButtonBar>
-                        <f:submit value="Run"/>
-                    </f:bottomButtonBar>
-                </f:form>
+                <j:choose>
+                    <j:when test="${it.enabled}">
+                        <f:form action="run" method="POST" name="config">
+                            <f:entry field="mainScript" title="Main Script">
+                                <wfe:workflow-editor script="${it.originalScript}" checkUrl="${rootURL}/${it.owner.url}${it.urlName}/checkScript" checkDependsOn=""/>
+                            </f:entry>
+                            <j:forEach var="loadedScript" items="${it.originalLoadedScripts.entrySet()}">
+                                <f:entry field="${loadedScript.key.replace('.', '_')}" title="${loadedScript.key}">
+                                    <wfe:workflow-editor script="${loadedScript.value}" checkUrl="${rootURL}/${it.owner.url}${it.urlName}/checkScript" checkDependsOn=""/>
+                                </f:entry>
+                            </j:forEach>
+                            <f:block>
+                                <a href="${rootURL}/${it.owner.parent.url}/pipeline-syntax" target="_blank">${%Pipeline Syntax}</a>
+                            </f:block>
+                            <f:bottomButtonBar>
+                                <f:submit value="Run"/>
+                            </f:bottomButtonBar>
+                        </f:form>
+                    </j:when>
+                    <j:otherwise>
+                        <f:form action="rebuild" method="POST" name="rebuild">
+                            <f:bottomButtonBar>
+                                <f:submit value="Run"/>
+                            </f:bottomButtonBar>
+                        </f:form>
+                    </j:otherwise>
+                </j:choose>
             </j:if>
         </l:main-panel>
     </l:layout>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
@@ -295,8 +295,8 @@ public class ReplayActionTest {
                 GlobalMatrixAuthorizationStrategy gmas = new GlobalMatrixAuthorizationStrategy();
                 gmas.add(Jenkins.READ, "dev3");
                 List<Permission> permissions = Run.PERMISSIONS.getPermissions();
-                assertThat(permissions, Matchers.hasItem(ReplayAction.REBUILD));
-                gmas.add(ReplayAction.REBUILD, "dev3");
+                assertThat(permissions, Matchers.hasItem(Item.BUILD));
+                gmas.add(Item.BUILD, "dev3");
                 gmas.add(Item.READ, "dev3");
 
                 story.j.jenkins.setAuthorizationStrategy(gmas);

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.cps.replay;
 
+import com.gargoylesoftware.htmlunit.WebAssert;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTextArea;
@@ -61,6 +62,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 public class ReplayActionTest {
@@ -154,7 +157,7 @@ public class ReplayActionTest {
                 assertThat(permissions, Matchers.hasItem(ReplayAction.REPLAY));
                 gmas.add(ReplayAction.REPLAY, "dev2");
                 gmas.add(Jenkins.READ, "dev3");
-                gmas.add(Item.BUILD, "dev3"); // does not imply REPLAY
+                gmas.add(Item.BUILD, "dev3"); // does not imply REPLAY, does allow rebuilding
                 story.j.jenkins.setAuthorizationStrategy(gmas);
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("", /* whole-script approval */ false));
@@ -164,6 +167,7 @@ public class ReplayActionTest {
                 assertFalse("not sandboxed, so only safe for admins", canReplay(b1, "dev1"));
                 assertFalse(canReplay(b1, "dev2"));
                 assertFalse(canReplay(b1, "dev3"));
+                assertTrue(canRebuild(b1, "dev3"));
                 p.setDefinition(new CpsFlowDefinition("", /* sandbox */ true));
                 WorkflowRun b2 = p.scheduleBuild2(0).get();
                 assertTrue(canReplay(b2, "admin"));
@@ -171,12 +175,14 @@ public class ReplayActionTest {
                 assertTrue(canReplay(b2, "dev1"));
                 assertTrue(canReplay(b2, "dev2"));
                 assertFalse(canReplay(b2, "dev3"));
+                assertTrue(canRebuild(b2, "dev3"));
                 // Disable the job and verify that no one can replay it.
                 p.makeDisabled(true);
                 assertFalse(canReplay(b2, "admin"));
                 assertFalse(canReplay(b2, "dev1"));
                 assertFalse(canReplay(b2, "dev2"));
                 assertFalse(canReplay(b2, "dev3"));
+                assertFalse(canRebuild(b2, "dev3"));
             }
         });
     }
@@ -185,6 +191,15 @@ public class ReplayActionTest {
         return ACL.impersonate(User.get(user).impersonate(), new NotReallyRoleSensitiveCallable<Boolean,RuntimeException>() {
             @Override public Boolean call() throws RuntimeException {
                 return a.isEnabled();
+            }
+        });
+    }
+
+    private static boolean canRebuild(WorkflowRun b, String user) {
+        final ReplayAction a = b.getAction(ReplayAction.class);
+        return ACL.impersonate(User.get(user).impersonate(), new NotReallyRoleSensitiveCallable<Boolean,RuntimeException>() {
+            @Override public Boolean call() throws RuntimeException {
+                return a.isRebuildEnabled();
             }
         });
     }
@@ -267,6 +282,53 @@ public class ReplayActionTest {
                 assertEquals(3, b3.getNumber());
                 // Main script picked up from #1, not #2.
                 story.j.assertLogContains("got new text", b3);
+            }
+        });
+    }
+
+    @Issue("JENKINS-47339")
+    @Test
+    public void rebuild() throws Exception {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                story.j.jenkins.setSecurityRealm(story.j.createDummySecurityRealm());
+                GlobalMatrixAuthorizationStrategy gmas = new GlobalMatrixAuthorizationStrategy();
+                gmas.add(Jenkins.READ, "dev3");
+                List<Permission> permissions = Run.PERMISSIONS.getPermissions();
+                assertThat(permissions, Matchers.hasItem(ReplayAction.REBUILD));
+                gmas.add(ReplayAction.REBUILD, "dev3");
+                gmas.add(Item.READ, "dev3");
+
+                story.j.jenkins.setAuthorizationStrategy(gmas);
+
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition("echo 'script to rebuild'", true));
+                WorkflowRun b1 = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                story.j.assertLogContains("script to rebuild", b1);
+
+                WorkflowRun b2;
+                { // First time around, verify that UI elements are present and functional.
+                    ReplayAction a = b1.getAction(ReplayAction.class);
+                    assertNotNull(a);
+                    assertFalse(canReplay(b1, "dev3"));
+                    assertTrue(canRebuild(b1, "dev3"));
+                    JenkinsRule.WebClient wc = story.j.createWebClient();
+                    wc.login("dev3");
+                    HtmlPage page = wc.getPage(b1, a.getUrlName());
+                    WebAssert.assertFormNotPresent(page, "config");
+                    HtmlForm form = page.getFormByName("rebuild");
+                    HtmlPage redirect = story.j.submit(form);
+                    assertEquals(p.getAbsoluteUrl(), redirect.getUrl().toString());
+                    story.j.waitUntilNoActivity();
+                    b2 = p.getBuildByNumber(2);
+                    assertNotNull(b2);
+                }
+                story.j.assertLogContains("script to rebuild", story.j.assertBuildStatusSuccess(b2));
+                ReplayCause cause = b2.getCause(ReplayCause.class);
+                assertNotNull(cause);
+                assertEquals(1, cause.getOriginalNumber());
+                assertEquals(b1, cause.getOriginal());
+                assertEquals(b2, cause.getRun());
             }
         });
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
@@ -294,8 +294,6 @@ public class ReplayActionTest {
                 story.j.jenkins.setSecurityRealm(story.j.createDummySecurityRealm());
                 GlobalMatrixAuthorizationStrategy gmas = new GlobalMatrixAuthorizationStrategy();
                 gmas.add(Jenkins.READ, "dev3");
-                List<Permission> permissions = Run.PERMISSIONS.getPermissions();
-                assertThat(permissions, Matchers.hasItem(Item.BUILD));
                 gmas.add(Item.BUILD, "dev3");
                 gmas.add(Item.READ, "dev3");
 


### PR DESCRIPTION
[JENKINS-47339](https://issues.jenkins-ci.org/browse/JENKINS-47339)

Allows rebuilding a Pipeline run with the exact same script.

This will be used directly by Blue Ocean for its rebuild functionality, which doesn't need to be able to make changes to the script, so shouldn't require `Item.CONFIGURE` or `ReplayAction.REPLAY`. Instead, it'll require either `Item.BUILD` or `ReplayAction.REBUILD`.

cc @reviewbybees @i386