### PR TITLE
Pick up structs improvements and adapt to use preferred APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,9 +105,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <!-- Picks up both https://github.com/jenkinsci/structs-plugin/pull/31 and https://github.com/jenkinsci/structs-plugin/pull/30
-              plus the unreleased https://github.com/jenkinsci/structs-plugin/pull/29 until released -->
-            <version>1.11-fast-20180130.155644-2</version>
+            <version>1.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,9 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.7</version>
+            <!-- Picks up both https://github.com/jenkinsci/structs-plugin/pull/31 and https://github.com/jenkinsci/structs-plugin/pull/30
+              plus the unreleased https://github.com/jenkinsci/structs-plugin/pull/29 until released -->
+            <version>1.11-fast-20180130.143712-1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -147,7 +149,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.9</version>
+            <version>2.18</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
             <artifactId>structs</artifactId>
             <!-- Picks up both https://github.com/jenkinsci/structs-plugin/pull/31 and https://github.com/jenkinsci/structs-plugin/pull/30
               plus the unreleased https://github.com/jenkinsci/structs-plugin/pull/29 until released -->
-            <version>1.11-fast-20180130.143712-1</version>
+            <version>1.11-fast-20180130.155644-2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -288,7 +288,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         boolean singleArgumentOnly = false;
         if (metaStep != null) {
             Descriptor symbolDescriptor = SymbolLookup.get().findDescriptor((Class)(metaStep.getMetaStepArgumentType()), symbol);
-            DescribableModel<?> symbolModel = new DescribableModel(symbolDescriptor.clazz);
+            DescribableModel<?> symbolModel = DescribableModel.of(symbolDescriptor.clazz);
 
             singleArgumentOnly = symbolModel.hasSingleRequiredParameter() && symbolModel.getParameters().size() == 1;
         }
@@ -315,8 +315,8 @@ public class DSL extends GroovyObjectSupport implements Serializable {
                 // execute this Describable through a meta-step
 
                 // split args between MetaStep (represented by mm) and Describable (represented by dm)
-                DescribableModel<?> mm = new DescribableModel(metaStep.clazz);
-                DescribableModel<?> dm = new DescribableModel(d.clazz);
+                DescribableModel<?> mm = DescribableModel.of(metaStep.clazz);
+                DescribableModel<?> dm = DescribableModel.of(d.clazz);
                 DescribableParameter p = mm.getFirstRequiredParameter();
                 if (p==null) {
                     // meta-step not having a required parameter is a bug in this meta step
@@ -457,7 +457,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
     static NamedArgsAndClosure parseArgs(Object arg, StepDescriptor d) {
         boolean singleArgumentOnly = false;
         try {
-            DescribableModel<?> stepModel = new DescribableModel<>(d.clazz);
+            DescribableModel<?> stepModel = DescribableModel.of(d.clazz);
             singleArgumentOnly = stepModel.hasSingleRequiredParameter() && stepModel.getParameters().size() == 1;
         } catch (NoStaplerConstructorException e) {
             // Ignore steps without databound constructors and treat them as normal.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
@@ -129,7 +129,7 @@ import org.kohsuke.stapler.StaplerRequest;
                 if (d.isMetaStep()) {
                     // if we have a symbol name for the wrapped Describable, we can produce
                     // a more concise form that hides it
-                    DescribableModel<?> m = new DescribableModel(d.clazz);
+                    DescribableModel<?> m = DescribableModel.of(d.clazz);
                     DescribableParameter p = m.getFirstRequiredParameter();
                     if (p!=null) {
                         Object wrapped = uninst.getArguments().get(p.getName());
@@ -378,7 +378,7 @@ import org.kohsuke.stapler.StaplerRequest;
             if (d.isAdvanced() == advanced) {
                 t.add(new QuasiDescriptor(d));
                 if (d.isMetaStep()) {
-                    DescribableModel<?> m = new DescribableModel<>(d.clazz);
+                    DescribableModel<?> m = DescribableModel.of(d.clazz);
                     Collection<DescribableParameter> parameters = m.getParameters();
                     if (parameters.size() == 1) {
                         DescribableParameter delegate = parameters.iterator().next();
@@ -485,7 +485,7 @@ import org.kohsuke.stapler.StaplerRequest;
                 // Look for a metastep which could take this as its delegate.
                 for (StepDescriptor d : StepDescriptor.allMeta()) {
                     if (d.getMetaStepArgumentType().isInstance(o)) {
-                        DescribableModel<?> m = new DescribableModel<>(d.clazz);
+                        DescribableModel<?> m = DescribableModel.of(d.clazz);
                         DescribableParameter soleRequiredParameter = m.getSoleRequiredParameter();
                         if (soleRequiredParameter != null) {
                             step = d.newInstance(Collections.singletonMap(soleRequiredParameter.getName(), o));

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -129,7 +129,7 @@ public class StepAtomNode extends AtomNode implements StepNode {
      */
     private static @CheckForNull Class<?> getDelegateType(@Nonnull FlowNode node, @Nonnull StepDescriptor d) {
         if (d.isMetaStep()) {
-            DescribableParameter p = new DescribableModel<>(d.clazz).getFirstRequiredParameter();
+            DescribableParameter p = DescribableModel.of(d.clazz).getFirstRequiredParameter();
             if (p != null) {
                 Object arg = ArgumentsAction.getResolvedArguments(node).get(p.getName());
                 if (arg instanceof UninstantiatedDescribable) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTester.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTester.java
@@ -124,7 +124,7 @@ public class SnippetizerTester {
      */
     @SuppressWarnings("unchecked")
     public static void assertDocGeneration(Class<? extends Describable> describableClass) throws Exception {
-        DescribableModel<?> model = new DescribableModel(describableClass);
+        DescribableModel<?> model = DescribableModel.of(describableClass);
 
         assertNotNull(model);
 


### PR DESCRIPTION
Picks up both https://github.com/jenkinsci/structs-plugin/pull/31 and https://github.com/jenkinsci/structs-plugin/pull/30  plus the unreleased https://github.com/jenkinsci/structs-plugin/pull/29 (until released).

Used to ensure it doesn't violate workflow-cps tests and picks up new APIs correctly.