### PR TITLE
Optimize fetching the sole parameter to avoid needless reflection and possible classloading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.12</version>
+            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -458,7 +458,13 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         boolean singleArgumentOnly = false;
         try {
             DescribableModel<?> stepModel = DescribableModel.of(d.clazz);
-            singleArgumentOnly = stepModel.hasSingleRequiredParameter() && stepModel.getParameters().size() == 1;
+            if (stepModel != null) {
+                singleArgumentOnly = stepModel.hasSingleRequiredParameter() && stepModel.getParameters().size() == 1;
+                if (singleArgumentOnly) {  // Can fetch the one argument we need
+                    String paramName = stepModel.getSoleRequiredParameter().getName();
+                    return parseArgs(arg, d.takesImplicitBlockArgument(), paramName, singleArgumentOnly);
+                }
+            }
         } catch (NoStaplerConstructorException e) {
             // Ignore steps without databound constructors and treat them as normal.
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -458,13 +458,11 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         boolean singleArgumentOnly = false;
         try {
             DescribableModel<?> stepModel = DescribableModel.of(d.clazz);
-            if (stepModel != null) {
-                singleArgumentOnly = stepModel.hasSingleRequiredParameter() && stepModel.getParameters().size() == 1;
-                if (singleArgumentOnly) {  // Can fetch the one argument we need
-                    DescribableParameter dp = stepModel.getSoleRequiredParameter();
-                    String paramName = (dp != null) ? dp.getName() : null;
-                    return parseArgs(arg, d.takesImplicitBlockArgument(), paramName, singleArgumentOnly);
-                }
+            singleArgumentOnly = stepModel.hasSingleRequiredParameter() && stepModel.getParameters().size() == 1;
+            if (singleArgumentOnly) {  // Can fetch the one argument we need
+                DescribableParameter dp = stepModel.getSoleRequiredParameter();
+                String paramName = (dp != null) ? dp.getName() : null;
+                return parseArgs(arg, d.takesImplicitBlockArgument(), paramName, singleArgumentOnly);
             }
         } catch (NoStaplerConstructorException e) {
             // Ignore steps without databound constructors and treat them as normal.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -461,7 +461,8 @@ public class DSL extends GroovyObjectSupport implements Serializable {
             if (stepModel != null) {
                 singleArgumentOnly = stepModel.hasSingleRequiredParameter() && stepModel.getParameters().size() == 1;
                 if (singleArgumentOnly) {  // Can fetch the one argument we need
-                    String paramName = stepModel.getSoleRequiredParameter().getName();
+                    DescribableParameter dp = stepModel.getSoleRequiredParameter();
+                    String paramName = (dp != null) ? dp.getName() : null;
                     return parseArgs(arg, d.takesImplicitBlockArgument(), paramName, singleArgumentOnly);
                 }
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepTest.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import static java.util.Arrays.*;
 import java.util.List;
+
+import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.SingleJobTestBase;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
@@ -328,7 +330,7 @@ public class ParallelStepTest extends SingleJobTestBase {
                         }
                     }
                 }
-                assertEquals(128*3,shell);
+                assertEquals(42*3,shell);
             }
         });
     }

--- a/src/test/resources/org/jenkinsci/plugins/workflow/cps/steps/localMethodCallWithinLotsOfBranches.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/workflow/cps/steps/localMethodCallWithinLotsOfBranches.groovy
@@ -14,7 +14,7 @@ def doNotify(msg) {
 node {
     ws {}
     def x = [:]
-    for (def i=0; i<128; i++) {
+    for (def i=0; i<42; i++) {
         def j = i;
         // TODO JENKINS-25979 x["branch${i}"] = {…} does not work
         x.put("branch${i}", { notify("Hello ${j}") })


### PR DESCRIPTION
Removes yet another cause of needless runtime Reflection/classloading when running pipeline.  Should result in running steps much faster generally and with less disk hits from classloading + less lock contention.

Similar to https://github.com/jenkinsci/structs-plugin/pull/31 but on the DSL side (using the DescribableModel more efficiently with what is provided) -- also related to https://github.com/jenkinsci/structs-plugin/pull/30. 

Incidentally includes https://github.com/jenkinsci/workflow-cps-plugin/pull/201 for the fixed Structs.

Justification: see attached image showing Object monitor thread contention when running 40x concurrent trivial pipelines -- this is one of the top 10 leading bottlenecks.

<img width="1605" alt="screen shot 2018-02-02 at 11 15 04 am" src="https://user-images.githubusercontent.com/5400948/35743198-d638f2b6-080a-11e8-8127-e0da67921e84.png">

**Remaining locking bottlenecks for future PRs:**

* Script Security - ProxyWhiteList.delegates ArrayList during permitsXXXX calls -- addressed by https://github.com/jenkinsci/script-security-plugin/pull/179 which uses caching so locks are only held very briefly (rather than while doing O(n) a full scan of all possible Whitelists). 
* Reusing an XStream instance (mandatory internal locking) - [JENKINS-19561](https://issues.jenkins-ci.org/browse/JENKINS-19561) - a larger bottleneck when your storage is fast, but less trivial to solve (I have plans to do a limited solution in the near future). 

@reviewbybees 