### PR TITLE
Edge Case: CpsScript invokeMethod does not execute closures defined in the script binding

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -91,30 +91,30 @@ public abstract class CpsScript extends SerializableScript {
     @Override
     public final Object invokeMethod(String name, Object args){
 
-    		// check for user defined closures in the script binding
-    		if (getBinding().hasVariable(name)){
-    		    Object local_var = getBinding().getVariable(name);
-    		    if (local_var instanceof CpsClosure2){
-                    CpsClosure2 local_closure = (CpsClosure2) local_var;
-    		        return local_closure.call(args);
-    		    }
-    		}
+        // check for user defined closures in the script binding
+        if (getBinding().hasVariable(name)){
+            Object local_var = getBinding().getVariable(name);
+            if (local_var instanceof CpsClosure2){
+                CpsClosure2 local_closure = (CpsClosure2) local_var;
+                return local_closure.call(args);
+            }
+        }
     		
-			// if global variables are defined by that name, try to call it.
-		    // the 'call' convention comes from Closure
-	        GlobalVariable v = GlobalVariable.byName(name, $buildNoException());
-	        if (v != null) {
-	            try {
-	                Object o = v.getValue(this);
-	                return InvokerHelper.getMetaClass(o).invokeMethod(o, "call", args);
-	            } catch (Exception x) {
-	                throw new InvokerInvocationException(x);
-	            }
-	        }
+        // if global variables are defined by that name, try to call it.
+        // the 'call' convention comes from Closure
+        GlobalVariable v = GlobalVariable.byName(name, $buildNoException());
+        if (v != null) {
+            try {
+                Object o = v.getValue(this);
+                return InvokerHelper.getMetaClass(o).invokeMethod(o, "call", args);
+            } catch (Exception x) {
+                throw new InvokerInvocationException(x);
+            }
+        }
 		
-	        // otherwise try Step impls.
-	        DSL dsl = (DSL) getBinding().getVariable(STEPS_VAR);
-	        return dsl.invokeMethod(name,args);
+        // otherwise try Step impls.
+        DSL dsl = (DSL) getBinding().getVariable(STEPS_VAR);
+        return dsl.invokeMethod(name,args);
 	             
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.workflow.cps;
 import com.cloudbees.groovy.cps.SerializableScript;
 import groovy.lang.GroovyShell;
 import groovy.lang.MissingPropertyException;
+import groovy.lang.MissingMethodException;
 import groovy.lang.Script;
 import hudson.model.Queue;
 import hudson.model.Run;
@@ -89,33 +90,33 @@ public abstract class CpsScript extends SerializableScript {
      * That means we cannot let user-written script override this method, hence the final.
      */
     @Override
-    public final Object invokeMethod(String name, Object args) {
-        // TODO probably better to call super method and only proceed here incase of MissingMethodException:
-        
-        // check for user defined closures in the script binding
-        if (getBinding().hasVariable(name)){
-	    Object local_var = getBinding().getVariable(name);
-            if (local_var instanceof CpsClosure2){
-		CpsClosure2 local_closure = (CpsClosure2) local_var;
-                return local_closure.call(args);
-            }
-        }
-        
-        // if global variables are defined by that name, try to call it.
-        // the 'call' convention comes from Closure
-        GlobalVariable v = GlobalVariable.byName(name, $buildNoException());
-        if (v != null) {
-            try {
-                Object o = v.getValue(this);
-                return InvokerHelper.getMetaClass(o).invokeMethod(o, "call", args);
-            } catch (Exception x) {
-                throw new InvokerInvocationException(x);
-            }
-        }
+    public final Object invokeMethod(String name, Object args){
 
-        // otherwise try Step impls.
-        DSL dsl = (DSL) getBinding().getVariable(STEPS_VAR);
-        return dsl.invokeMethod(name,args);
+    		// check for user defined closures in the script binding
+    		if (getBinding().hasVariable(name)){
+    		    Object local_var = getBinding().getVariable(name);
+    		    if (local_var instanceof CpsClosure2){
+                    CpsClosure2 local_closure = (CpsClosure2) local_var;
+    		        return local_closure.call(args);
+    		    }
+    		}
+    		
+			// if global variables are defined by that name, try to call it.
+		    // the 'call' convention comes from Closure
+	        GlobalVariable v = GlobalVariable.byName(name, $buildNoException());
+	        if (v != null) {
+	            try {
+	                Object o = v.getValue(this);
+	                return InvokerHelper.getMetaClass(o).invokeMethod(o, "call", args);
+	            } catch (Exception x) {
+	                throw new InvokerInvocationException(x);
+	            }
+	        }
+		
+	        // otherwise try Step impls.
+	        DSL dsl = (DSL) getBinding().getVariable(STEPS_VAR);
+	        return dsl.invokeMethod(name,args);
+	             
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -27,7 +27,6 @@ package org.jenkinsci.plugins.workflow.cps;
 import com.cloudbees.groovy.cps.SerializableScript;
 import groovy.lang.GroovyShell;
 import groovy.lang.MissingPropertyException;
-import groovy.lang.MissingMethodException;
 import groovy.lang.Script;
 import hudson.model.Queue;
 import hudson.model.Run;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -92,12 +92,12 @@ public abstract class CpsScript extends SerializableScript {
     public final Object invokeMethod(String name, Object args) {
         // TODO probably better to call super method and only proceed here incase of MissingMethodException:
 
-        // check for user defined closures in the script binding
+        // check for user instantiated objects in the script binding
+        // that respond to call.
         if (getBinding().hasVariable(name)){
-            Object local_var = getBinding().getVariable(name);
-            if (local_var instanceof CpsClosure2){
-                CpsClosure2 local_closure = (CpsClosure2) local_var;
-                return local_closure.call(args);
+            Object o = getBinding().getVariable(name);
+            if (!InvokerHelper.getMetaClass(o).respondsTo(o, "call", (Object[]) args).isEmpty()){
+                return InvokerHelper.getMetaClass(o).invokeMethod(o, "call", args);
             }
         }
         

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -91,6 +91,15 @@ public abstract class CpsScript extends SerializableScript {
     @Override
     public final Object invokeMethod(String name, Object args) {
         // TODO probably better to call super method and only proceed here incase of MissingMethodException:
+        
+        // check for user defined closures in the script binding
+        if (getBinding().hasVariable(name)){
+            if (getBinding().getVariable(name) instanceof CpsClosure2){
+				CpsClosure2 local_closure = (CpsClosure2) getBinding().getVariable(name);
+                return local_closure.call(args);
+            }
+        }
+        
         // if global variables are defined by that name, try to call it.
         // the 'call' convention comes from Closure
         GlobalVariable v = GlobalVariable.byName(name, $buildNoException());

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -97,7 +97,11 @@ public abstract class CpsScript extends SerializableScript {
         if (getBinding().hasVariable(name)){
             Object o = getBinding().getVariable(name);
             if (!InvokerHelper.getMetaClass(o).respondsTo(o, "call", (Object[]) args).isEmpty()){
-                return InvokerHelper.getMetaClass(o).invokeMethod(o, "call", args);
+                try{
+                    return InvokerHelper.getMetaClass(o).invokeMethod(o, "call", args);
+                } catch (Exception x) {
+                    throw new InvokerInvocationException(x);
+                }
             }
         }
         

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -94,8 +94,9 @@ public abstract class CpsScript extends SerializableScript {
         
         // check for user defined closures in the script binding
         if (getBinding().hasVariable(name)){
-            if (getBinding().getVariable(name) instanceof CpsClosure2){
-		CpsClosure2 local_closure = (CpsClosure2) getBinding().getVariable(name);
+	    Object local_var = getBinding().getVariable(name);
+            if (local_var instanceof CpsClosure2){
+		CpsClosure2 local_closure = (CpsClosure2) local_var;
                 return local_closure.call(args);
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -95,7 +95,7 @@ public abstract class CpsScript extends SerializableScript {
         // check for user defined closures in the script binding
         if (getBinding().hasVariable(name)){
             if (getBinding().getVariable(name) instanceof CpsClosure2){
-				CpsClosure2 local_closure = (CpsClosure2) getBinding().getVariable(name);
+		CpsClosure2 local_closure = (CpsClosure2) getBinding().getVariable(name);
                 return local_closure.call(args);
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -90,7 +90,8 @@ public abstract class CpsScript extends SerializableScript {
      */
     @Override
     public final Object invokeMethod(String name, Object args){
-
+        // TODO probably better to call super method and only proceed here incase of MissingMethodException:
+        
         // check for user defined closures in the script binding
         if (getBinding().hasVariable(name)){
             Object local_var = getBinding().getVariable(name);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -89,7 +89,7 @@ public abstract class CpsScript extends SerializableScript {
      * That means we cannot let user-written script override this method, hence the final.
      */
     @Override
-    public final Object invokeMethod(String name, Object args){
+    public final Object invokeMethod(String name, Object args) {
         // TODO probably better to call super method and only proceed here incase of MissingMethodException:
 
         // check for user defined closures in the script binding
@@ -100,7 +100,7 @@ public abstract class CpsScript extends SerializableScript {
                 return local_closure.call(args);
             }
         }
-    		
+        
         // if global variables are defined by that name, try to call it.
         // the 'call' convention comes from Closure
         GlobalVariable v = GlobalVariable.byName(name, $buildNoException());
@@ -112,10 +112,10 @@ public abstract class CpsScript extends SerializableScript {
                 throw new InvokerInvocationException(x);
             }
         }
-		
+
         // otherwise try Step impls.
         DSL dsl = (DSL) getBinding().getVariable(STEPS_VAR);
-        return dsl.invokeMethod(name,args);         
+        return dsl.invokeMethod(name,args);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScript.java
@@ -91,7 +91,7 @@ public abstract class CpsScript extends SerializableScript {
     @Override
     public final Object invokeMethod(String name, Object args){
         // TODO probably better to call super method and only proceed here incase of MissingMethodException:
-        
+
         // check for user defined closures in the script binding
         if (getBinding().hasVariable(name)){
             Object local_var = getBinding().getVariable(name);
@@ -115,8 +115,7 @@ public abstract class CpsScript extends SerializableScript {
 		
         // otherwise try Step impls.
         DSL dsl = (DSL) getBinding().getVariable(STEPS_VAR);
-        return dsl.invokeMethod(name,args);
-	             
+        return dsl.invokeMethod(name,args);         
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
@@ -15,6 +15,7 @@ import org.jvnet.hudson.test.Issue;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.junit.Rule;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 
 public class CpsScriptTest extends AbstractCpsFlowTest {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
@@ -112,4 +112,5 @@ public class CpsScriptTest extends AbstractCpsFlowTest {
         }
         assertEquals(dumpError(), Result.SUCCESS, exec.getResult());
     }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
@@ -12,16 +12,8 @@ import static org.junit.Assert.*;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.junit.Rule;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 
 public class CpsScriptTest extends AbstractCpsFlowTest {
-    
-    @Rule public JenkinsRule r = new JenkinsRule();
-    
     /**
      * Test the 'evaluate' method call.
      * The first test case.
@@ -120,15 +112,5 @@ public class CpsScriptTest extends AbstractCpsFlowTest {
         }
         assertEquals(dumpError(), Result.SUCCESS, exec.getResult());
     }
-    
-    /**
-     *  Test user defined closure execution
-     */
-    @Test public void userDefinedClosureExecution() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("binding.setVariable(\"my_closure\", { echo \"my closure!\" })\n my_closure() ", true));
-        r.assertLogContains("my closure!", r.assertBuildStatusSuccess(p.scheduleBuild2(0))); 
-    }
-    
-    
+
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
@@ -112,5 +112,4 @@ public class CpsScriptTest extends AbstractCpsFlowTest {
         }
         assertEquals(dumpError(), Result.SUCCESS, exec.getResult());
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
@@ -12,8 +12,15 @@ import static org.junit.Assert.*;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 
 public class CpsScriptTest extends AbstractCpsFlowTest {
+    
+    @Rule public JenkinsRule r = new JenkinsRule();
+    
     /**
      * Test the 'evaluate' method call.
      * The first test case.
@@ -112,5 +119,15 @@ public class CpsScriptTest extends AbstractCpsFlowTest {
         }
         assertEquals(dumpError(), Result.SUCCESS, exec.getResult());
     }
-
+    
+    /**
+     *  Test user defined closure execution
+     */
+    @Test public void userDefinedClosureExecution() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("binding.setVariable(\"my_closure\", { echo \"my closure!\" })\n my_closure() ", true));
+        r.assertLogContains("my closure!", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+    }
+    
+    
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsScriptTest.java
@@ -126,7 +126,7 @@ public class CpsScriptTest extends AbstractCpsFlowTest {
     @Test public void userDefinedClosureExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("binding.setVariable(\"my_closure\", { echo \"my closure!\" })\n my_closure() ", true));
-        r.assertLogContains("my closure!", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+        r.assertLogContains("my closure!", r.assertBuildStatusSuccess(p.scheduleBuild2(0))); 
     }
     
     

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -367,6 +367,19 @@ public class DSLTest {
     }
 
     /**
+    * Tests untyped arguments 
+    */
+    @Test public void userDefinedClosureUntypedArgInvocationExecution() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("my_closure = { a , b -> \n" +
+                                                      "  echo \"my message is ${a} and ${b}\" \n" +
+                                                      "}\n" +
+                                                      "my_closure(\"string1\" ,2)",false));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("my message is string1 and 2", b);
+    }
+    
+    /**
     * Tests the ability to execute a user defined closure with variable arguments
     * note: currently fails because CpsClosure's don't currently work with varargs
     *
@@ -376,9 +389,8 @@ public class DSLTest {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("my_closure = { String message, Integer... n -> \n" +
                                               "  println message \n" + 
-                                              "  println n \n" +
-                                              "  n.sum() \n" +
-                                              "}\n" + 
+                                              "  println n.sum() \n" +
+                                              "}\n" +
                                               "my_closure(\"testing\",1,2,3) ", false));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("testing", b);

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -316,6 +316,9 @@ public class DSLTest {
         r.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
+    /**
+    * Tests the ability to execute a user defined closure
+    */
     @Test public void userDefinedClosureInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("binding[\"my_closure\"] = { \n" +
@@ -326,7 +329,10 @@ public class DSLTest {
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("my closure!", b); 
     }
-
+    
+    /**
+    * Tests the ability to resolve DSL steps within a user defined closure
+    */
     @Test public void userDefinedClosurePwdInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("my_closure = { \n" +
@@ -338,7 +344,10 @@ public class DSLTest {
                                               "my_closure() ", false));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
-
+ 
+    /**
+    * Tests the ability to execute a user defined closure with no arguments
+    */
     @Test public void userDefinedClosure0ArgsExecution() throws Exception {
          WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
          p.setDefinition(new CpsFlowDefinition("binding.setVariable(\"my_closure\", { echo \"my closure!\" })\n my_closure() ", false));
@@ -346,6 +355,9 @@ public class DSLTest {
          r.assertLogContains("my closure!", b); 
     }
 
+    /**
+    * Tests the ability to execute a user defined closure with one arguments
+    */
     @Test public void userDefinedClosure1ArgInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("my_closure = { String message -> \n" +
@@ -356,6 +368,9 @@ public class DSLTest {
         r.assertLogContains("my message!", b); 
     }
 
+    /**
+    * Tests the ability to execute a user defined closure with 2 arguments
+    */
     @Test public void userDefinedClosure2ArgInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("my_closure = { String message1, String message2 -> \n" +
@@ -366,6 +381,11 @@ public class DSLTest {
         r.assertLogContains("my message is string1 and string2", b); 
     }
 
+    /**
+    * Tests the ability to execute a user defined closure with variable arguments
+    * note: currently fails because CpsClosure's don't currently work with varargs
+    *
+    */
 	@Ignore
     @Test public void userDefinedClosureVarArgInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -315,26 +315,26 @@ public class DSLTest {
         r.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
-	@Test public void userDefinedClosureInvocationExecution() throws Exception {
+    @Test public void userDefinedClosureInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("binding[\"my_closure\"] = { \n" +
-										       " sleep 1 \n" + 
-        									   " echo \"my closure!\" \n" + 
-        									   "}\n" + 
-        									   "my_closure() ", false));
+                                              " sleep 1 \n" + 
+                                              " echo \"my closure!\" \n" + 
+                                              "}\n" + 
+                                              "my_closure() ", false));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("my closure!", b); 
     }
 
-	@Test public void userDefinedClosureShellInvocationExecution() throws Exception {
+    @Test public void userDefinedClosureShellInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("my_closure = { \n" +
-										       " sleep 1 \n" + 
-        									   " node{ \n" + 
-        									   "   sh \"pwd\" \n" + 
-        									   " }\n" +
-        									   "}\n" + 
-        									   "my_closure() ", false));
+                                              " sleep 1 \n" + 
+                                              " node{ \n" + 
+                                              "   sh \"pwd\" \n" + 
+                                              " }\n" +
+                                              "}\n" + 
+                                              "my_closure() ", false));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
@@ -348,9 +348,9 @@ public class DSLTest {
     @Test public void userDefinedClosure1ArgInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("my_closure = { String message -> \n" +
-										       "  echo message \n" +
-        									   "}\n" + 
-        									   "my_closure(\"my message!\") ", false));
+                                              "  echo message \n" +
+                                              "}\n" + 
+                                              "my_closure(\"my message!\") ", false));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("my message!", b); 
     }
@@ -358,9 +358,9 @@ public class DSLTest {
     @Test public void userDefinedClosure2ArgInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("my_closure = { String message1, String message2 -> \n" +
-										       "  echo \"my message is ${message1} and ${message2}\" \n" +
-        									   "}\n" + 
-        									   "my_closure(\"string1\", \"string2\") ", false));
+                                              "  echo \"my message is ${message1} and ${message2}\" \n" +
+                                              "}\n" + 
+                                              "my_closure(\"string1\", \"string2\") ", false));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("my message is string1 and string2", b); 
     }
@@ -368,11 +368,11 @@ public class DSLTest {
     @Test public void userDefinedClosureVarArgInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("my_closure = { String message, Integer... n -> \n" +
-                                               "  println message \n" + 
-        									   "  println n \n" +
-										       "  n.sum() \n" +
-        									   "}\n" + 
-        									   "my_closure(\"testing\",1,2,3) ", false));
+                                              "  println message \n" + 
+                                              "  println n \n" +
+                                              "  n.sum() \n" +
+                                              "}\n" + 
+                                              "my_closure(\"testing\",1,2,3) ", false));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("testing", b)
         r.assertLogContains("6", b); 

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -47,7 +47,6 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
-import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import static org.junit.Assert.*;
 
 import org.junit.Assert;
@@ -321,8 +320,7 @@ public class DSLTest {
      */
     @Test public void userDefinedClosureExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        ScriptApproval.get().approveSignature("method groovy.lang.Binding setVariable java.lang.String java.lang.Object");
-        p.setDefinition(new CpsFlowDefinition("binding.setVariable(\"my_closure\", { echo \"my closure!\" })\n my_closure() ", true));
+        p.setDefinition(new CpsFlowDefinition("binding.setVariable(\"my_closure\", { echo \"my closure!\" })\n my_closure() ", false));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("my closure!", b); 
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -315,14 +315,67 @@ public class DSLTest {
         r.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
-    /**
-     *  Test user defined closure execution
-     */
-    @Test public void userDefinedClosureExecution() throws Exception {
+	@Test public void userDefinedClosureInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("binding.setVariable(\"my_closure\", { echo \"my closure!\" })\n my_closure() ", false));
+        p.setDefinition(new CpsFlowDefinition("binding[\"my_closure\"] = { \n" +
+										       " sleep 1 \n" + 
+        									   " echo \"my closure!\" \n" + 
+        									   "}\n" + 
+        									   "my_closure() ", false));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("my closure!", b); 
+    }
+
+	@Test public void userDefinedClosureShellInvocationExecution() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("my_closure = { \n" +
+										       " sleep 1 \n" + 
+        									   " node{ \n" + 
+        									   "   sh \"pwd\" \n" + 
+        									   " }\n" +
+        									   "}\n" + 
+        									   "my_closure() ", false));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test public void userDefinedClosure0ArgsExecution() throws Exception {
+         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+         p.setDefinition(new CpsFlowDefinition("binding.setVariable(\"my_closure\", { echo \"my closure!\" })\n my_closure() ", false));
+         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+         r.assertLogContains("my closure!", b); 
+    }
+
+    @Test public void userDefinedClosure1ArgInvocationExecution() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("my_closure = { String message -> \n" +
+										       "  echo message \n" +
+        									   "}\n" + 
+        									   "my_closure(\"my message!\") ", false));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("my message!", b); 
+    }
+
+    @Test public void userDefinedClosure2ArgInvocationExecution() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("my_closure = { String message1, String message2 -> \n" +
+										       "  echo \"my message is ${message1} and ${message2}\" \n" +
+        									   "}\n" + 
+        									   "my_closure(\"string1\", \"string2\") ", false));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("my message is string1 and string2", b); 
+    }
+
+    @Test public void userDefinedClosureVarArgInvocationExecution() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("my_closure = { String message, Integer... n -> \n" +
+                                               "  println message \n" + 
+        									   "  println n \n" +
+										       "  n.sum() \n" +
+        									   "}\n" + 
+        									   "my_closure(\"testing\",1,2,3) ", false));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("testing", b)
+        r.assertLogContains("6", b); 
     }
     
     public static class CLStep extends Step {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -53,6 +53,7 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.Ignore;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -326,12 +327,12 @@ public class DSLTest {
         r.assertLogContains("my closure!", b); 
     }
 
-    @Test public void userDefinedClosureShellInvocationExecution() throws Exception {
+    @Test public void userDefinedClosurePwdInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("my_closure = { \n" +
                                               " sleep 1 \n" + 
                                               " node{ \n" + 
-                                              "   sh \"pwd\" \n" + 
+                                              "   echo pwd() \n" + 
                                               " }\n" +
                                               "}\n" + 
                                               "my_closure() ", false));
@@ -365,6 +366,7 @@ public class DSLTest {
         r.assertLogContains("my message is string1 and string2", b); 
     }
 
+	@Ignore
     @Test public void userDefinedClosureVarArgInvocationExecution() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("my_closure = { String message, Integer... n -> \n" +

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -329,21 +329,6 @@ public class DSLTest {
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("my closure!", b); 
     }
-    
-    /**
-    * Tests the ability to resolve DSL steps within a user defined closure
-    */
-    @Test public void userDefinedClosurePwdInvocationExecution() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("my_closure = { \n" +
-                                              " sleep 1 \n" + 
-                                              " node{ \n" + 
-                                              "   echo pwd() \n" + 
-                                              " }\n" +
-                                              "}\n" + 
-                                              "my_closure() ", false));
-        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-    }
  
     /**
     * Tests the ability to execute a user defined closure with no arguments

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -374,7 +374,7 @@ public class DSLTest {
                                               "}\n" + 
                                               "my_closure(\"testing\",1,2,3) ", false));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("testing", b)
+        r.assertLogContains("testing", b);
         r.assertLogContains("6", b); 
     }
     


### PR DESCRIPTION
Method calls made in a pipeline get routed to CpsScript's invokeMethod before being executed.  

**Currently**:
The method checks to see if the method in question has been defined as a GlobalVariable and if not - checks the DSL where if not present, an error will be thrown. 

Given this flow - there is no room for user defined closures injected into the script binding to get executed in the pipeline. 

**Fix**:  
Check the script binding for variables named the same as the method name attempting to be invoked.  If the variable exists and it is of type CpsClosure2, execute the closure and pass in the arguments.  

User defined closures should take precedence over library methods or pipeline DSL steps as they were defined in the most local context to the script execution. 

**Reproduce:**
~~~ groovy
my_closure = { println "my closure!" }
my_closure()
~~~
fails with:  _java.lang.NoSuchMethodError: No such DSL method 'my_closure' found among steps_

but 
~~~ groovy
def my_closure = { println "my closure!" }
my_closure()
~~~
works as expected. 