### PR TITLE
Add new public object2Groovy method for use in other contexts.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
@@ -80,6 +80,17 @@ import org.kohsuke.stapler.StaplerRequest;
     }
 
     /**
+     * Publicly accessible version of {@link #object2Groovy(StringBuilder, Object, boolean)} that translates an object into
+     * the equivalent Pipeline Groovy string.
+     *
+     * @param o The object to translate.
+     * @return A string translation of the object.
+     */
+    public static String object2Groovy(Object o) throws UnsupportedOperationException {
+        return object2Groovy(new StringBuilder(), o, false).toString();
+    }
+
+    /**
      * Renders the invocation syntax to re-create a given object 'o' into 'b'
      *
      * @param nestedExp


### PR DESCRIPTION
Specifically, I'm going to be consuming this in Declarative for a
Declarative-specific "directive generator" like the Snippet Generator,
but for Declarative directives like `options`, `triggers`, `when`, etc.

There'll eventually be a followup PR once that has been implemented in
Declarative to add a link to the Directive Generator or whatever we
end up calling it to the Pipeline Syntax sidepanel.jelly
(conditionally - i.e., if a new enough version of Declarative is
installed) but there's no point in doing that yet since I can't
actually implement it without this method being public. =)

cc @reviewbybees 