### PR TITLE
Switch Snippetizer sidepanel links to use an extension point

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.cps;
 
 import hudson.Extension;
+import hudson.ExtensionList;
 import hudson.Functions;
 import hudson.model.Action;
 import hudson.model.Describable;
@@ -45,6 +46,7 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.lang.model.SourceVersion;
 import jenkins.model.Jenkins;
 import jenkins.model.TransientActionFactory;
@@ -523,6 +525,14 @@ import org.kohsuke.stapler.StaplerRequest;
     @Restricted(DoNotUse.class) // for stapler
     public @CheckForNull Item getItem(StaplerRequest req) {
          return req.findAncestorObject(Item.class);
+    }
+
+    /**
+     * Used to generate the list of links on the sidepanel.
+     */
+    @Nonnull
+    public List<SnippetizerLink> getSnippetizerLinks() {
+        return ExtensionList.lookup(SnippetizerLink.class);
     }
 
     @Restricted(DoNotUse.class)

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/SnippetizerLink.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/SnippetizerLink.java
@@ -26,9 +26,8 @@ package org.jenkinsci.plugins.workflow.cps;
 
 import hudson.Extension;
 import hudson.ExtensionPoint;
-import hudson.Functions;
+import hudson.model.Item;
 import hudson.model.Job;
-import hudson.model.RootAction;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -78,11 +77,13 @@ public abstract class SnippetizerLink implements ExtensionPoint {
             return u;
         }
 
-        Job ancestor = req.findAncestorObject(Job.class);
-        if (ancestor == null) {
+        Item i = req.findAncestorObject(Item.class);
+
+        if (i == null) {
             return u;
         }
-        return "/" + ancestor.getUrl() + u;
+
+        return req.getContextPath() + "/" + i.getUrl() + u;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/SnippetizerLink.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/SnippetizerLink.java
@@ -1,0 +1,187 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import hudson.Extension;
+import hudson.ExtensionPoint;
+import hudson.Functions;
+import hudson.model.RootAction;
+
+import javax.annotation.Nonnull;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.jenkinsci.plugins.workflow.cps.Snippetizer.ACTION_URL;
+
+/**
+ * A link that will show up on the side panel of the snippet generator and other similar pages.
+ * Display order is determined by extension ordinal - highest ordinal first.
+ * 
+ * @author Andrew Bayer
+ */
+public abstract class SnippetizerLink implements ExtensionPoint {
+    private static final Logger LOGGER = Logger.getLogger(SnippetizerLink.class.getName());
+
+    /**
+     * Get the URL this link should point to.
+     */
+    @Nonnull
+    public abstract String getUrl();
+
+    /**
+     * Get the actual URL to use in sidepanel.jelly. If {@link #getUrl()} is not absolute, this will prepend "../" to
+     * {@link #getUrl()} to ensure it will work from the snippetizer and other similar pages. Otherwise it will just
+     * return {@link #getUrl()}.
+     */
+    @Nonnull
+    public final String getDisplayUrl() {
+        String u = getUrl();
+        try {
+            if (new URI(u).isAbsolute()) {
+                return u;
+            } else {
+                return "../" + u;
+            }
+        } catch (URISyntaxException e) {
+            LOGGER.log(Level.WARNING, "Failed to parse URL for {0}: {1}", new Object[] {u, e});
+            return "";
+        }
+    }
+
+    /**
+     * Get the icon information for the link.
+     */
+    @Nonnull
+    public String getIcon() {
+        return "icon-help icon-md";
+    }
+
+    /**
+     * Get the display name for the link.
+     */
+    @Nonnull
+    public abstract String getDisplayName();
+
+    /**
+     * Check whether the link should target a new window - this defaults to false;
+     */
+    public boolean inNewWindow() {
+        return false;
+    }
+
+    @Extension(ordinal = 1000L)
+    public static class GeneratorLink extends SnippetizerLink {
+        @Override
+        @Nonnull
+        public String getUrl() {
+            return ACTION_URL;
+        }
+
+        @Override
+        @Nonnull
+        public String getIcon() {
+            return "icon-gear2 icon-md";
+        }
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return Messages.SnippetizerLink_GeneratorLink_displayName();
+        }
+    }
+
+    @Extension(ordinal = 900L)
+    public static class StepReferenceLink extends SnippetizerLink {
+        @Override
+        @Nonnull
+        public String getUrl() {
+            return ACTION_URL + "/html";
+        }
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return Messages.SnippetizerLink_StepReferenceLink_displayName();
+        }
+    }
+
+    @Extension(ordinal = 800L)
+    public static class GlobalsReferenceLink extends SnippetizerLink {
+        @Override
+        @Nonnull
+        public String getUrl() {
+            return ACTION_URL + "/globals";
+        }
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return Messages.SnippetizerLink_GlobalsReferenceLink_displayName();
+        }
+    }
+
+    @Extension(ordinal = 700L)
+    public static class OnlineDocsLink extends SnippetizerLink {
+        @Override
+        @Nonnull
+        public String getUrl() {
+            return "https://jenkins.io/doc/pipeline/";
+        }
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return Messages.SnippetizerLink_OnlineDocsLink_displayName();
+        }
+
+        @Override
+        public boolean inNewWindow() {
+            return true;
+        }
+    }
+
+    @Extension(ordinal = 600L)
+    public static class GDSLLink extends SnippetizerLink {
+        @Override
+        @Nonnull
+        public String getUrl() {
+            return ACTION_URL + "/gdsl";
+        }
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return Messages.SnippetizerLink_GDSLLink_displayName();
+        }
+
+        @Override
+        public boolean inNewWindow() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/SnippetizerLink.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/SnippetizerLink.java
@@ -50,7 +50,8 @@ public abstract class SnippetizerLink implements ExtensionPoint {
     private static final Logger LOGGER = Logger.getLogger(SnippetizerLink.class.getName());
 
     /**
-     * Get the URL this link should point to.
+     * Get the URL this link should point to, which will be used by {@link #getDisplayUrl()}. If this is not absolute,
+     * {@link #getDisplayUrl()} will link to this within the current context.
      */
     @Nonnull
     public abstract String getUrl();
@@ -68,7 +69,7 @@ public abstract class SnippetizerLink implements ExtensionPoint {
                 return u;
             }
         } catch (URISyntaxException e) {
-            LOGGER.log(Level.WARNING, "Failed to parse URL for {0}: {1}", new Object[]{u, e});
+            LOGGER.log(Level.WARNING, "Failed to parse URL for " + u, e);
             return "";
         }
 
@@ -79,11 +80,27 @@ public abstract class SnippetizerLink implements ExtensionPoint {
 
         Item i = req.findAncestorObject(Item.class);
 
-        if (i == null) {
-            return u;
+        StringBuilder toAppend = new StringBuilder();
+
+        toAppend.append(req.getContextPath());
+
+        if (!req.getContextPath().endsWith("/")) {
+            toAppend.append("/");
         }
 
-        return req.getContextPath() + "/" + i.getUrl() + u;
+        if (i == null) {
+            toAppend.append(u);
+        } else {
+            toAppend.append(i.getUrl());
+
+            if (!i.getUrl().endsWith("/")) {
+                toAppend.append("/");
+            }
+
+            toAppend.append(u);
+        }
+
+        return toAppend.toString();
     }
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
@@ -1,2 +1,7 @@
 Snippetizer.this_step_should_not_normally_be_used_in=This step should not normally be used in your script. Consult the inline help for details.
+SnippetizerLink.GeneratorLink.displayName=Snippet Generator
+SnippetizerLink.StepReferenceLink.displayName=Steps Reference
+SnippetizerLink.GlobalsReferenceLink.displayName=Global Variables Reference
+SnippetizerLink.OnlineDocsLink.displayName=Online Documentation
+SnippetizerLink.GDSLLink.displayName=IntelliJ IDEA GDSL
 SandboxContinuable.ScriptApprovalLink=Administrators can decide whether to approve or reject this signature.

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/sidepanel.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/sidepanel.jelly
@@ -38,11 +38,16 @@ THE SOFTWARE.
                 </d:tag>
             </d:taglib>
             <l:task href=".." icon="icon-up icon-md" title="${%Back}"/>
-            <l:task href="." icon="icon-gear2 icon-md" title="${%Snippet Generator}"/>
-            <l:task href="html" icon="icon-help icon-md" title="${%Step Reference}"/>
-            <l:task href="globals" icon="icon-help icon-md" title="${%Global Variables Reference}"/>
-            <local:taskWithTarget href="https://jenkins.io/doc/pipeline/" icon="icon-help icon-md" target="_blank" title="${%Online Documentation}"/>
-            <local:taskWithTarget href="gdsl" icon="icon-package icon-md" target="_blank" title="${%IntelliJ IDEA GDSL}"/>
+            <j:forEach var="link" items="${it.snippetizerLinks}">
+                <j:choose>
+                    <j:when test="${link.inNewWindow}">
+                        <local:taskWithTarget href="${link.displayUrl}" icon="${link.icon}" title="${link.displayName}" target="_blank" />
+                    </j:when>
+                    <j:otherwise>
+                        <l:task href="${link.displayUrl}" icon="${link.icon}" title="${link.displayName}" />
+                    </j:otherwise>
+                </j:choose>
+            </j:forEach>
             <!-- TODO not yet ready: <local:taskWithTarget href="dsld" icon="icon-package icon-md" target="_blank" title="${%Eclipse DSLD}"/> -->
         </l:tasks>
     </l:side-panel>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
@@ -376,5 +376,18 @@ public class SnippetizerTest {
                 containsString("href=\"https://jenkins.io/doc/pipeline/\""));
         assertThat("GDSL link is included", html,
                 containsString("href=\"" + r.contextPath + "/" + job.getUrl() + Snippetizer.ACTION_URL + "/gdsl\""));
+
+        // Now verify that the links are still present and correct when we're not within a job.
+        String rootHtml = wc.goTo(Snippetizer.ACTION_URL).getWebResponse().getContentAsString();
+        assertThat("Snippet Generator link is included", rootHtml,
+                containsString("href=\"" + r.contextPath + "/" + Snippetizer.ACTION_URL + "\""));
+        assertThat("Steps Reference link is included", rootHtml,
+                containsString("href=\"" + r.contextPath + "/" + Snippetizer.ACTION_URL + "/html\""));
+        assertThat("Globals Reference link is included", rootHtml,
+                containsString("href=\"" + r.contextPath + "/" + Snippetizer.ACTION_URL + "/globals\""));
+        assertThat("Online docs link is included", rootHtml,
+                containsString("href=\"https://jenkins.io/doc/pipeline/\""));
+        assertThat("GDSL link is included", rootHtml,
+                containsString("href=\"" + r.contextPath + "/" + Snippetizer.ACTION_URL + "/gdsl\""));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
@@ -37,6 +37,7 @@ import hudson.tasks.junit.JUnitResultArchiver;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.workflow.cps.steps.ParallelStep;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.steps.CatchErrorStep;
 import org.jenkinsci.plugins.workflow.steps.CoreStep;
 import org.jenkinsci.plugins.workflow.steps.EchoStep;
@@ -358,5 +359,22 @@ public class SnippetizerTest {
         st.assertRoundTrip(new CoreStep(a), "junit '*.xml'");
         a.setHealthScaleFactor(0.5);
         st.assertRoundTrip(new CoreStep(a), "junit healthScaleFactor: 0.5, testResults: '*.xml'");
+    }
+
+    @Test
+    public void snippetizerLinks() throws Exception {
+        WorkflowJob job = r.jenkins.createProject(WorkflowJob.class, "p");
+        JenkinsRule.WebClient wc = r.createWebClient();
+        String html = wc.getPage(job, Snippetizer.ACTION_URL).getWebResponse().getContentAsString();
+        assertThat("Snippet Generator link is included", html,
+                containsString("href=\"" + r.contextPath + "/" + job.getUrl() + Snippetizer.ACTION_URL + "\""));
+        assertThat("Steps Reference link is included", html,
+                containsString("href=\"" + r.contextPath + "/" + job.getUrl() + Snippetizer.ACTION_URL + "/html\""));
+        assertThat("Globals Reference link is included", html,
+                containsString("href=\"" + r.contextPath + "/" + job.getUrl() + Snippetizer.ACTION_URL + "/globals\""));
+        assertThat("Online docs link is included", html,
+                containsString("href=\"https://jenkins.io/doc/pipeline/\""));
+        assertThat("GDSL link is included", html,
+                containsString("href=\"" + r.contextPath + "/" + job.getUrl() + Snippetizer.ACTION_URL + "/gdsl\""));
     }
 }


### PR DESCRIPTION
This will allow Declarative to contribute its own links to the sidepanel as well.

Upstream of https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/250

cc @reviewbybees 