### PR TITLE
Stop using junit in metastep tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
@@ -49,6 +49,7 @@ import org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStep;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStep;
 import org.jenkinsci.plugins.workflow.testMetaStep.Colorado;
 import org.jenkinsci.plugins.workflow.testMetaStep.EchoResultStep;
+import org.jenkinsci.plugins.workflow.testMetaStep.EchoStringAndDoubleStep;
 import org.jenkinsci.plugins.workflow.testMetaStep.Hawaii;
 import org.jenkinsci.plugins.workflow.testMetaStep.Island;
 import org.jenkinsci.plugins.workflow.testMetaStep.MonomorphicData;
@@ -355,10 +356,10 @@ public class SnippetizerTest {
 
     @Issue("JENKINS-31967")
     @Test public void testStandardJavaTypes() throws Exception {
-        JUnitResultArchiver a = new JUnitResultArchiver("*.xml");
-        st.assertRoundTrip(new CoreStep(a), "junit '*.xml'");
-        a.setHealthScaleFactor(0.5);
-        st.assertRoundTrip(new CoreStep(a), "junit healthScaleFactor: 0.5, testResults: '*.xml'");
+        EchoStringAndDoubleStep a = new EchoStringAndDoubleStep("some string");
+        st.assertRoundTrip(a, "echoStringAndDouble 'some string'");
+        a.setNumber(0.5);
+        st.assertRoundTrip(a, "echoStringAndDouble number: 0.5, string: 'some string'");
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNodeTest.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.workflow.cps.nodes;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import hudson.model.Result;
+import hudson.tasks.ArtifactArchiver;
 import hudson.tasks.junit.JUnitResultArchiver;
 import java.util.List;
 import java.util.logging.Level;
@@ -62,14 +63,14 @@ public class StepNodeTest {
             "node {\n" +
             "  configFileProvider([]) {\n" +
             "    writeFile text: '''<testsuite name='a'><testcase name='c'><error>failed</error></testcase></testsuite>''', file: 'x.xml'\n" +
-            "    junit 'x.xml'\n" +
+            "    archiveArtifacts 'x.xml'\n" +
             "  }\n" +
             "}", true));
-        WorkflowRun b = r.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
         List<FlowNode> coreStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("step"));
         assertThat(coreStepNodes, hasSize(1));
-        assertEquals("junit", coreStepNodes.get(0).getDisplayFunctionName());
-        assertEquals(r.jenkins.getDescriptor(JUnitResultArchiver.class).getDisplayName(), coreStepNodes.get(0).getDisplayName());
+        assertEquals("archiveArtifacts", coreStepNodes.get(0).getDisplayFunctionName());
+        assertEquals(r.jenkins.getDescriptor(ArtifactArchiver.class).getDisplayName(), coreStepNodes.get(0).getDisplayName());
         List<FlowNode> coreWrapperStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), Predicates.and(new NodeStepTypePredicate("wrap"), new Predicate<FlowNode>() {
             @Override public boolean apply(FlowNode n) {
                 return n instanceof StepStartNode && !((StepStartNode) n).isBody();
@@ -78,7 +79,7 @@ public class StepNodeTest {
         assertThat(coreWrapperStepNodes, hasSize(1));
         assertEquals("configFileProvider", coreWrapperStepNodes.get(0).getDisplayFunctionName());
         assertEquals(r.jenkins.getDescriptor(ConfigFileBuildWrapper.class).getDisplayName() + " : Start", coreWrapperStepNodes.get(0).getDisplayName());
-        r.assertLogContains("[Pipeline] junit", b);
+        r.assertLogContains("[Pipeline] archiveArtifacts", b);
         r.assertLogContains("[Pipeline] configFileProvider", b);
         r.assertLogContains("[Pipeline] // configFileProvider", b);
     }
@@ -89,14 +90,14 @@ public class StepNodeTest {
             "node {\n" +
             "  wrap([$class: 'ConfigFileBuildWrapper', managedFiles: []]) {\n" +
             "    writeFile text: '''<testsuite name='a'><testcase name='c'><error>failed</error></testcase></testsuite>''', file: 'x.xml'\n" +
-            "    step([$class: 'JUnitResultArchiver', testResults: 'x.xml'])\n" +
+            "    step([$class: 'ArtifactArchiver', artifacts: 'x.xml'])\n" +
             "  }\n" +
             "}", true));
-        WorkflowRun b = r.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
         List<FlowNode> coreStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("step"));
         assertThat(coreStepNodes, hasSize(1));
-        assertEquals("junit", coreStepNodes.get(0).getDisplayFunctionName());
-        assertEquals(r.jenkins.getDescriptor(JUnitResultArchiver.class).getDisplayName(), coreStepNodes.get(0).getDisplayName());
+        assertEquals("archiveArtifacts", coreStepNodes.get(0).getDisplayFunctionName());
+        assertEquals(r.jenkins.getDescriptor(ArtifactArchiver.class).getDisplayName(), coreStepNodes.get(0).getDisplayName());
         List<FlowNode> coreWrapperStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), Predicates.and(new NodeStepTypePredicate("wrap"), new Predicate<FlowNode>() {
             @Override public boolean apply(FlowNode n) {
                 return n instanceof StepStartNode && !((StepStartNode) n).isBody();
@@ -105,7 +106,7 @@ public class StepNodeTest {
         assertThat(coreWrapperStepNodes, hasSize(1));
         assertEquals("configFileProvider", coreWrapperStepNodes.get(0).getDisplayFunctionName());
         assertEquals(r.jenkins.getDescriptor(ConfigFileBuildWrapper.class).getDisplayName() + " : Start", coreWrapperStepNodes.get(0).getDisplayName());
-        r.assertLogContains("[Pipeline] junit", b);
+        r.assertLogContains("[Pipeline] archiveArtifacts", b);
         r.assertLogContains("[Pipeline] configFileProvider", b);
         r.assertLogContains("[Pipeline] // configFileProvider", b);
     }
@@ -116,14 +117,14 @@ public class StepNodeTest {
             "node {\n" +
             "  wrap(new org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper([])) {\n" +
             "    writeFile text: '''<testsuite name='a'><testcase name='c'><error>failed</error></testcase></testsuite>''', file: 'x.xml'\n" +
-            "    step(new hudson.tasks.junit.JUnitResultArchiver('x.xml'))\n" +
+            "    step(new hudson.tasks.ArtifactArchiver('x.xml'))\n" +
             "  }\n" +
             "}", false));
-        WorkflowRun b = r.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
         List<FlowNode> coreStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("step"));
         assertThat(coreStepNodes, hasSize(1));
-        assertEquals("junit", coreStepNodes.get(0).getDisplayFunctionName());
-        assertEquals(r.jenkins.getDescriptor(JUnitResultArchiver.class).getDisplayName(), coreStepNodes.get(0).getDisplayName());
+        assertEquals("archiveArtifacts", coreStepNodes.get(0).getDisplayFunctionName());
+        assertEquals(r.jenkins.getDescriptor(ArtifactArchiver.class).getDisplayName(), coreStepNodes.get(0).getDisplayName());
         List<FlowNode> coreWrapperStepNodes = new DepthFirstScanner().filteredNodes(b.getExecution(), Predicates.and(new NodeStepTypePredicate("wrap"), new Predicate<FlowNode>() {
             @Override public boolean apply(FlowNode n) {
                 return n instanceof StepStartNode && !((StepStartNode) n).isBody();
@@ -132,7 +133,7 @@ public class StepNodeTest {
         assertThat(coreWrapperStepNodes, hasSize(1));
         assertEquals("configFileProvider", coreWrapperStepNodes.get(0).getDisplayFunctionName());
         assertEquals(r.jenkins.getDescriptor(ConfigFileBuildWrapper.class).getDisplayName() + " : Start", coreWrapperStepNodes.get(0).getDisplayName());
-        r.assertLogContains("[Pipeline] junit", b);
+        r.assertLogContains("[Pipeline] archiveArtifacts", b);
         r.assertLogContains("[Pipeline] configFileProvider", b);
         r.assertLogContains("[Pipeline] // configFileProvider", b);
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/EchoStringAndDoubleStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/EchoStringAndDoubleStep.java
@@ -1,0 +1,78 @@
+package org.jenkinsci.plugins.workflow.testMetaStep;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
+
+public class EchoStringAndDoubleStep extends Step implements Serializable {
+
+    private double number;
+    private String string;
+
+    @DataBoundConstructor
+    public EchoStringAndDoubleStep(String string) {
+        this.string = string;
+    }
+
+    public String getString() {
+        return string;
+    }
+
+    @DataBoundSetter
+    public void setNumber(double number) {
+        this.number = number;
+    }
+
+    public double getNumber() {
+        return number;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new EchoStringAndDoubleStepExecution(this, context);
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends StepDescriptor {
+        @Override
+        public String getFunctionName() {
+            return "echoStringAndDouble";
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.singleton(TaskListener.class);
+        }
+    }
+
+    public static class EchoStringAndDoubleStepExecution extends StepExecution {
+        private final EchoStringAndDoubleStep step;
+
+        public EchoStringAndDoubleStepExecution(EchoStringAndDoubleStep s, StepContext context) {
+            super(context);
+            this.step = s;
+        }
+
+        @Override
+        public boolean start() throws Exception {
+            TaskListener listener = getContext().get(TaskListener.class);
+
+            if (listener != null)
+                listener.getLogger().println("String is " + step.getString() + ", number is " + step.getNumber());
+
+            return true;
+        }
+    }
+
+    private static final long serialVersionUID = 1L;
+
+}


### PR DESCRIPTION
Newer versions of junit plugin have `junit` as an actual `Step`, so
anything expecting a metastep when using `junit` will not get a
metastep. So, let's stop using `junit` in tests in general. This is
relevant now in the PCT, will be relevant eventually when we bump the
junit dependency here as well.

cc @reviewbybees 