### PR TITLE
Fix more subtle durability issues 

### DIFF
--- a/doc/persistence.md
+++ b/doc/persistence.md
@@ -1,0 +1,39 @@
+# The Pipeline Persistence Model
+
+# Data Model
+Running pipelines persist in 3 pieces:
+
+1. The FlowNodes - stored by a FlowNodeStorage - this holds the FlowNodes created to map to Steps, and for block scoped Steps, start and end of blocks
+2. The CpsFlowExecution - this is currently stored in the WorkflowRun, and the primary pieces of interest are:
+    * heads - the current "tips" of the Flow Graph, i.e. the FlowNodes that represent running steps and are appended to
+        - A head maps to a CpsThread in the Pipeline program, within the CPSThreadGroup
+    * starts - the BlockStartNodes marking the start(s) of the currently executing blocks
+    * scripts - the loaded Pipeline script files (text)
+    * persistedClean
+        - If true, Pipeline saved its execution cleanly to disk and we *might* be able to resume it
+        - If false, something went wrong saving the execution, so we cannot resume even if we'd otherwise be able to
+        - If null, probably the build dates back to before this field was added - we check to see if this is running in a highly persistent DurabilityMode (Max_survivability generally)
+    * done - if true, this execution completed, if false or un-set, the pipeline is a candidate to resume unless its only head is a FlowEndNode
+        - The handling of false is for legacy reasons, since it was only recently made persistent.
+    *
+    * various other boolean flags & settings for the execution (durability setting, user that started the build, is it sandboxed, etc)
+3. The Program -- this is the current execution state of the Pipeline
+    * This holds the Groovy state (transformed by CPS) plus the CPSThreadGroup for the running branches of the Pipeline
+    * The program depends on the FlowNodes from the FlowNodeStorage, since it reads them by ID rather than storing them in the program
+    * This also depends on the heads in the CpsFlowExecution, because its FlowHeads are loaded from the heads of the CpsFlowExecution
+    * Also holds the CpsStepContext, i.e. the variables such as EnvVars, Executor and Workspace uses (the latter stored as Pickles)
+        - The pickles will be specially restored when the Pipeline resumes since they don't serialize/deserialize normally
+
+## Persistence Issues And Logic
+
+Some basic rules:
+
+1. If the FlowNodeStorage is corrupt, incomplete, or un-persisted, all manner of heck will break loose
+    - In terms of Pipeline execution, the impact is like the Resonance Cascade from the Half-Life games
+    - The pipeline can never be resumed (the key piece is missing)
+    - Usually we fake up some placeholder FlowNodes to cover this situation and save them
+2. Whenever persisting data, the Pipeline *must* have the FlowNodes persisted on disk (via `storage.flush()` generally)
+in order to be able to load the heads and restore the program.
+3. Once we've set persistedClean as false and saved the FlowExecution, then it doesn't matter what we do -- the Pipeline will assume
+ it already has incomplete persistence data (as with 1) when trying to resume.  This is how we handle the low-durability modes, to
+  avoid resuming a stale state of the Pipeline simply because we have old data persisted and are not updating it.

--- a/doc/persistence.md
+++ b/doc/persistence.md
@@ -3,11 +3,11 @@
 # Data Model
 Running pipelines persist in 3 pieces:
 
-1. The FlowNodes - stored by a FlowNodeStorage - this holds the FlowNodes created to map to Steps, and for block scoped Steps, start and end of blocks
-2. The CpsFlowExecution - this is currently stored in the WorkflowRun, and the primary pieces of interest are:
+1. The `FlowNode`s - stored by a `FlowNodeStorage` - this holds the FlowNodes created to map to `Step`s, and for block scoped Steps, start and end of blocks
+2. The `CpsFlowExecution` - this is currently stored in the WorkflowRun, and the primary pieces of interest are:
     * heads - the current "tips" of the Flow Graph, i.e. the FlowNodes that represent running steps and are appended to
-        - A head maps to a CpsThread in the Pipeline program, within the CPSThreadGroup
-    * starts - the BlockStartNodes marking the start(s) of the currently executing blocks
+        - A head maps to a `CpsThread` in the Pipeline program, within the `CpsThreadGroup`
+    * starts - the `BlockStartNode`s marking the start(s) of the currently executing blocks
     * scripts - the loaded Pipeline script files (text)
     * persistedClean
         - If true, Pipeline saved its execution cleanly to disk and we *might* be able to resume it
@@ -18,7 +18,8 @@ Running pipelines persist in 3 pieces:
     *
     * various other boolean flags & settings for the execution (durability setting, user that started the build, is it sandboxed, etc)
 3. The Program -- this is the current execution state of the Pipeline
-    * This holds the Groovy state (transformed by CPS) plus the CPSThreadGroup for the running branches of the Pipeline
+    * This holds the Groovy state - the `CpsThreadGroup` - with runtime calls transformed by CPS so they can persist
+        * The `CpsThread`s map to the running branches of the Pipeline
     * The program depends on the FlowNodes from the FlowNodeStorage, since it reads them by ID rather than storing them in the program
     * This also depends on the heads in the CpsFlowExecution, because its FlowHeads are loaded from the heads of the CpsFlowExecution
     * Also holds the CpsStepContext, i.e. the variables such as EnvVars, Executor and Workspace uses (the latter stored as Pickles)

--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <!-- Snapshot for better handling of onLoad errors -->
-            <version>2.21-20180501.222458-6</version>
+            <version>2.21</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <!-- Snapshot for better handling of onLoad error -->
-            <version>2.21-20180427.163721-4</version>
+            <!-- Snapshot for better handling of onLoad errors -->
+            <version>2.21-20180427.223321-5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
             <!-- Snapshot for better handling of onLoad errors -->
-            <version>2.21-20180427.223321-5</version>
+            <version>2.21-20180501.222458-6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
             <!-- Snapshot for better handling of onLoad error -->
-            <version>2.21-20180425.142151-3</version>
+            <version>2.21-20180427.163721-4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
             <!-- Snapshot for better handling of onLoad error -->
-            <version>2.21-20180425.020403-1</version>
+            <version>2.21-20180425.142151-3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.20</version>
+            <!-- Snapshot for better handling of onLoad error -->
+            <version>2.21-20180425.020403-1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -120,7 +120,6 @@ class CpsBodyExecution extends BodyExecution {
         }
 
         head.setNewHead(sn);
-        CpsFlowExecution.maybeAutoPersistNode(sn);
 
         StepContext sc = new CpsBodySubContext(context, sn);
         for (BodyExecutionCallback c : callbacks) {
@@ -366,7 +365,6 @@ class CpsBodyExecution extends BodyExecution {
             for (BodyExecutionCallback c : callbacks) {
                 c.onSuccess(sc, o);
             }
-
             return Next.terminate(null);
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -337,7 +337,6 @@ class CpsBodyExecution extends BodyExecution {
                 FlowHead h = CpsThread.current().head;
                 StepStartNode ssn = addBodyStartFlowNode(h);
                 h.setNewHead(ssn);
-                CpsFlowExecution.maybeAutoPersistNode(ssn);
             }
 
             StepEndNode en = addBodyEndFlowNode();

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -621,6 +621,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
      */
     @GuardedBy("this")
     void createPlaceholderNodes(Throwable failureReason) throws Exception {
+        this.done = true;
         try {
             programPromise = Futures.immediateFailedFuture(new IllegalStateException("Failed loading heads", failureReason));
             LOGGER.log(Level.INFO, "Creating placeholder flownodes for execution: "+this);
@@ -655,7 +656,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             saveOwner();
 
         } catch (Exception ex) {
-            this.done = true;
             throw ex;
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -730,10 +730,10 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         try {
             if (isComplete()) {
                 if (done == Boolean.TRUE && !super.isComplete()) {
-                    LOGGER.log(Level.WARNING, "Completed flow without FlowEndNode: "+this+" heads:"+getHeadsAsString());
+                    LOGGER.log(Level.INFO, "Completed flow without FlowEndNode: "+this+" heads:"+getHeadsAsString());
                 }
                 if (super.isComplete() && done != Boolean.TRUE) {
-                    LOGGER.log(Level.WARNING, "Flow has FlowEndNode, but is not marked as done, fixing this for"+this);
+                    LOGGER.log(Level.FINE, "Flow has FlowEndNode, but is not marked as done, fixing this for"+this);
                     done = true;
                     saveOwner();
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -616,6 +616,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     /** Handle failures where we can't load heads. */
     private void rebuildEmptyGraph() {
         synchronized (this) {
+            this.done = Boolean.TRUE;  // Ensures that the flow does not show as incomplete if the graph data is corrupt
             // something went catastrophically wrong and there's no live head. fake one
             LOGGER.log(Level.WARNING, "Failed to load pipeline heads/start nodes, so faking some up for execution " + this.toString());
             if (this.startNodes == null) {
@@ -689,6 +690,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             startNodesSerial = null;
 
         } catch (Exception ioe) {
+            this.done = Boolean.TRUE;
             LOGGER.log(Level.WARNING, "Error initializing storage and loading nodes for "+this, ioe);
             storageErrors = true;
         }
@@ -732,6 +734,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
 
             try {
                 if (!isComplete()) {
+                    // FOR SOME REASON we're arriving here even for *completed* builds sometimes, hopefully logging above helps
                     if (canResume()) {
                         loadProgramAsync(getProgramDataFile());
                     } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -624,6 +624,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         this.done = true;
 
         if (this.owner != null) {
+            // Ensure that the Run is marked as completed (failed) if it isn't already so it won't show as running
             Queue.Executable ex = owner.getExecutable();
             if (ex instanceof Run) {
                 Result res = ((Run)ex).getResult();
@@ -746,7 +747,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                     throw new IOException("Cannot resume build -- was not cleanly saved when Jenkins shut down.");
                 }
             }
-        } catch (Exception e) {  // Multicatch ensures that failure to load does not nuke the master
+        } catch (Exception e) {  // Broad catch ensures that failure to load do NOT nuke the master
             SettableFuture<CpsThreadGroup> p = SettableFuture.create();
             programPromise = p;
             loadProgramFailed(e, p);
@@ -930,7 +931,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         try {
             g = programPromise.get();
         } catch (Exception x) {
-            // FIXME check this won't cause issues due to depickling delays etc
+            // TODO Check this won't cause issues due to depickling delays etc
             LOGGER.log(Level.FINE, "Not blocking restart due to exception in ProgramPromise: "+this, x);
             return false;
         }
@@ -1228,7 +1229,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         // shrink everything into a single new head
         try {
             if (heads != null) {
-                // Below does not look correct to me
                 FlowHead first = getFirstHead();
                 first.setNewHead(head);
                 done = true;  // After setting the final head

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1809,7 +1809,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                 saveable.save();
             }
         } catch (IOException ex) {
-            LOGGER.log(Level.WARNING, "Error persisting Run before shutdown", ex);
+            LOGGER.log(Level.WARNING, "Error persisting Run "+owner, ex);
             persistedClean = false;
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -35,7 +35,6 @@ import com.cloudbees.groovy.cps.sandbox.SandboxInvoker;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.FutureCallback;
@@ -234,7 +233,6 @@ import org.kohsuke.accmod.restrictions.DoNotUse;
  * @author Kohsuke Kawaguchi
  */
 @PersistIn(RUN)
-@SuppressFBWarnings(value = "IS_FIELD_NOT_GUARDED", justification = "temporary only")
 public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     /**
      * Groovy script of the main source file (that the user enters in the GUI)

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -623,9 +623,12 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     void createPlaceholderNodes(Throwable failureReason) throws Exception {
         this.done = true;
 
-        if (this.owner != null && this.owner.getExecutable() instanceof Run) {
-            Run r = (Run)(owner.getExecutable());
-            setResult(r.getResult() != null ? r.getResult() : Result.FAILURE);
+        if (this.owner != null) {
+            Queue.Executable ex = owner.getExecutable();
+            if (ex instanceof Run) {
+                Result res = ((Run)ex).getResult();
+                setResult(res != null ? res : Result.FAILURE);
+            }
         }
 
         try {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -620,7 +620,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
      * Bypasses {@link #croak(Throwable)} and {@link #onProgramEnd(Outcome)} to guarantee a clean path.
      */
     @GuardedBy("this")
-    void createPlaceholderNodes(Throwable failureReason) throws Exception {
+    synchronized void createPlaceholderNodes(Throwable failureReason) throws Exception {
         this.done = true;
 
         if (this.owner != null) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -719,6 +719,17 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         this.owner = owner;
         try {
             initializeStorage();
+            if (heads == null) {
+                LOGGER.log(Level.WARNING, "Null Flow heads after initializing storage for FlowExecution "+this);
+            } else if (heads.isEmpty()) {
+                LOGGER.log(Level.INFO, "Empty flow heads after initializing storage - not necessarily an error, but odd - for FlowExecution "+this);
+            }
+            if (startNodes == null) {
+                LOGGER.log(Level.WARNING, "Null block start nodes after initializing storage for FlowExecution "+this);
+            } else if (startNodes.isEmpty()) {
+                LOGGER.log(Level.INFO, "Empty block start nodes after initializing storage - not necessarily an error, but odd - for FlowExecution "+this);
+            }
+
             try {
                 if (!isComplete()) {
                     if (canResume()) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
@@ -436,7 +436,6 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
                                 g.getExecution().subsumeHead(parents.get(i));
                             StepEndNode en = new StepEndNode(flow, (StepStartNode) n, parents);
                             thread.head.setNewHead(en);
-                            CpsFlowExecution.maybeAutoPersistNode(en);
                         }
                         thread.head.markIfFail(getOutcome());
                         thread.setStep(null);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -577,6 +577,9 @@ public class DSL extends GroovyObjectSupport implements Serializable {
             // the first one can reuse the current thread, but other ones need to create new heads
             // we want to do this first before starting body so that the order of heads preserve
             // natural ordering.
+
+            // FIXME give this javadocs worth a darn, because this is how we create parallel branches and the docs are crypic.
+            // Also we need to double-check this logic because this might cause a failure of persistence
             FlowHead[] heads = new FlowHead[context.bodyInvokers.size()];
             for (int i = 0; i < heads.length; i++) {
                 heads[i] = i==0 ? cur.head : cur.head.fork();

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -578,7 +578,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
             // we want to do this first before starting body so that the order of heads preserve
             // natural ordering.
 
-            // FIXME give this javadocs worth a darn, because this is how we create parallel branches and the docs are crypic.
+            // TODO give this javadocs worth a darn, because this is how we create parallel branches and the docs are cryptic as can be!
             // Also we need to double-check this logic because this might cause a failure of persistence
             FlowHead[] heads = new FlowHead[context.bodyInvokers.size()];
             for (int i = 0; i < heads.length; i++) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.cps;
 
 import com.cloudbees.groovy.cps.Outcome;
+import com.google.common.annotations.VisibleForTesting;
 import hudson.model.Action;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -69,7 +70,8 @@ final class FlowHead implements Serializable {
     private /*almost final except for serialization*/ int id;
     private /*almost final except for serialization*/ transient CpsFlowExecution execution;
 
-    private FlowNode head; // TODO: rename to node
+    @VisibleForTesting
+    FlowNode head; // TODO: rename to node
 
     FlowHead(CpsFlowExecution execution, int id) {
         this.id = id;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
@@ -129,7 +129,9 @@ final class FlowHead implements Serializable {
             execution.storage.storeNode(v, true);
             assert execution.storage.getNode(v.getId()) != null;
             v.addAction(new TimingAction());
-            CpsFlowExecution.maybeAutoPersistNode(v); // Persist node before changing head, otherwise Program can have unpersisted nodes.
+            CpsFlowExecution.maybeAutoPersistNode(v); // Persist node before changing head, otherwise Program can have unpersisted nodes and will fail to deserialize
+            // NOTE: we may also need to persist the FlowExecution by persisting its owner (which will be a WorkflowRun)
+            // But this will be handled by the WorkflowRun GraphListener momentarily
         } catch (Exception e) {
             LOGGER.log(Level.FINE, "Failed to record new head or persist old: " + v, e);
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/FlowHead.java
@@ -197,7 +197,7 @@ final class FlowHead implements Serializable {
             }
             return myHead;
         } else {
-            LOGGER.log(Level.WARNING, "Tried to load a FlowHead from program with no Execution in PROGRAM_STATE_SERIALIZTION");
+            LOGGER.log(Level.WARNING, "Tried to load a FlowHead from program with no Execution in PROGRAM_STATE_SERIALIZATION");
             return this;
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/PersistanceController.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/PersistanceController.java
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.workflow.cps.actions;
+
+/**
+ * @author Sam Van Oort
+ */
+public class PersistanceController {
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/PersistanceController.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/PersistanceController.java
@@ -1,7 +1,0 @@
-package org.jenkinsci.plugins.workflow.cps.actions;
-
-/**
- * @author Sam Van Oort
- */
-public class PersistanceController {
-}

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -605,6 +605,7 @@ public class FlowDurabilityTest {
 
     /** Verify that if we bomb out because we cannot resume, we at least try to finish the flow graph if we have something to work with. */
     @Test
+    @Ignore
     // Can be fleshed out later if we have a valid need for it.
     public void testPipelineFinishesFlowGraph() throws Exception {
         final String[] logStart = new String[1];

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -794,11 +794,7 @@ public class FlowDurabilityTest {
 
     private static void assertBuildNotHung(@Nonnull RestartableJenkinsRule story, @Nonnull  WorkflowRun run, int timeOutMillis) throws Exception {
         if (run.isBuilding()) {
-            try {
-                story.j.waitUntilNoActivityUpTo(timeOutMillis);
-            } catch (AssertionError ase) {  // Allows attaching a debugger here
-                throw new AssertionError("Build hung: " + run, ase);
-            }
+            story.j.waitUntilNoActivityUpTo(timeOutMillis);
         }
     }
 
@@ -877,7 +873,7 @@ public class FlowDurabilityTest {
             @Override
             public void evaluate() throws Throwable {
                 WorkflowRun run = story.j.jenkins.getItemByFullName(jobName, WorkflowJob.class).getLastBuild();
-                if (run == null) {
+                if (run == null) {   // Build killed so early the Run did not get to persist
                     return;
                 }
                 if (run.getExecution() != null) {
@@ -925,7 +921,7 @@ public class FlowDurabilityTest {
             @Override
             public void evaluate() throws Throwable {
                 WorkflowRun run = story.j.jenkins.getItemByFullName(jobName, WorkflowJob.class).getLastBuild();
-                if (run == null) {
+                if (run == null) {   // Build killed so early the Run did not get to persist
                     return;
                 }
                 if (run.getExecution() != null) {
@@ -983,7 +979,7 @@ public class FlowDurabilityTest {
             @Override
             public void evaluate() throws Throwable {
                 WorkflowRun run = story.j.jenkins.getItemByFullName(jobName, WorkflowJob.class).getLastBuild();
-                if (run == null) {
+                if (run == null) {   // Build killed so early the Run did not get to persist
                     return;
                 }
                 if (run.getExecution() != null) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -839,7 +839,7 @@ public class FlowDurabilityTest {
      * May fail rarely due to files being copied in a different order than they are modified as part of simulating a dirty restart.
      * See {@link RestartableJenkinsRule#simulateAbruptShutdown()} for why that copying happens. */
     @Test
-    //Too long to run as part of main suite
+    @Ignore //Too long to run as part of main suite
     @TimedRepeatRule.RepeatForTime(repeatMillis = 150_000)
     public void fuzzTimingDurable() throws Exception {
         final String jobName = "NestedParallelDurableJob";
@@ -890,7 +890,7 @@ public class FlowDurabilityTest {
      *  May fail rarely due to files being copied in a different order than they are modified as part of simulating a dirty restart.
      *  See {@link RestartableJenkinsRule#simulateAbruptShutdown()} for why that copying happens. */
     @Test
-    //Too long to run as part of main suite
+    @Ignore //Too long to run as part of main suite
     @TimedRepeatRule.RepeatForTime(repeatMillis = 150_000)
     public void fuzzTimingNonDurable() throws Exception {
         final String jobName = "NestedParallelDurableJob";
@@ -942,7 +942,7 @@ public class FlowDurabilityTest {
 
     /** Test interrupting build by randomly restarting *cleanly* at unpredictable times and verify we stick pick up and resume. */
     @Test
-    //Too long to run as part of main suite
+    @Ignore //Too long to run as part of main suite
     @TimedRepeatRule.RepeatForTime(repeatMillis = 150_000)
     public void fuzzTimingNonDurableWithCleanRestart() throws Exception {
         final String jobName = "NestedParallelDurableJob";

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -877,6 +877,9 @@ public class FlowDurabilityTest {
             @Override
             public void evaluate() throws Throwable {
                 WorkflowRun run = story.j.jenkins.getItemByFullName(jobName, WorkflowJob.class).getLastBuild();
+                if (run == null) {
+                    return;
+                }
                 if (run.getExecution() != null) {
                     Assert.assertEquals(FlowDurabilityHint.MAX_SURVIVABILITY, run.getExecution().getDurabilityHint());
                 }
@@ -922,6 +925,9 @@ public class FlowDurabilityTest {
             @Override
             public void evaluate() throws Throwable {
                 WorkflowRun run = story.j.jenkins.getItemByFullName(jobName, WorkflowJob.class).getLastBuild();
+                if (run == null) {
+                    return;
+                }
                 if (run.getExecution() != null) {
                     Assert.assertEquals(FlowDurabilityHint.PERFORMANCE_OPTIMIZED, run.getExecution().getDurabilityHint());
                 }
@@ -936,6 +942,9 @@ public class FlowDurabilityTest {
                 // Verify build doesn't resume at next restart, see JENKINS-50199
                 Assert.assertFalse(FlowExecutionList.get().iterator().hasNext());
                 WorkflowRun run = story.j.jenkins.getItemByFullName(jobName, WorkflowJob.class).getLastBuild();
+                if (run == null) {
+                    return;
+                }
                 Assert.assertFalse(run.isBuilding());
                 Assert.assertTrue(run.getExecution().isComplete());
                 if (run.getExecution() instanceof  CpsFlowExecution) {
@@ -974,6 +983,9 @@ public class FlowDurabilityTest {
             @Override
             public void evaluate() throws Throwable {
                 WorkflowRun run = story.j.jenkins.getItemByFullName(jobName, WorkflowJob.class).getLastBuild();
+                if (run == null) {
+                    return;
+                }
                 if (run.getExecution() != null) {
                     Assert.assertEquals(FlowDurabilityHint.PERFORMANCE_OPTIMIZED, run.getExecution().getDurabilityHint());
                 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -605,7 +605,7 @@ public class FlowDurabilityTest {
 
     /** Verify that if we bomb out because we cannot resume, we at least try to finish the flow graph if we have something to work with. */
     @Test
-    @Ignore // Can be fleshed out later if we have a valid need for it.
+    // Can be fleshed out later if we have a valid need for it.
     public void testPipelineFinishesFlowGraph() throws Exception {
         final String[] logStart = new String[1];
         final List<FlowNode> nodesOut = new ArrayList<FlowNode>();

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -39,7 +39,7 @@ public class PersistenceProblemsTest {
     static void assertCompletedCleanly(WorkflowRun run) throws Exception {
         if (run.isBuilding()) {
             System.out.println("Run initially building, going to wait a second to see if it finishes, run="+run);
-            Thread.sleep(1);
+            Thread.sleep(1000);
         }
         Assert.assertFalse(run.isBuilding());
         Assert.assertNotNull(run.getResult());
@@ -54,7 +54,7 @@ public class PersistenceProblemsTest {
         if (fe instanceof CpsFlowExecution) {
             CpsFlowExecution cpsExec = (CpsFlowExecution)fe;
             Assert.assertTrue(cpsExec.isComplete());
-//            Assert.assertEquals(Boolean.TRUE, cpsExec.persistedClean);
+            Assert.assertEquals(Boolean.TRUE, cpsExec.persistedClean);
             Assert.assertEquals(Boolean.TRUE, cpsExec.done);
             Assert.assertEquals(1, cpsExec.getCurrentHeads().size());
             Assert.assertTrue(cpsExec.getCurrentHeads().get(0) instanceof FlowEndNode);

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -15,6 +15,7 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
 import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -54,9 +55,9 @@ public class PersistenceProblemsTest {
         if (fe instanceof CpsFlowExecution) {
             CpsFlowExecution cpsExec = (CpsFlowExecution)fe;
             Assert.assertTrue(cpsExec.isComplete());
-            Assert.assertEquals(Boolean.TRUE, cpsExec.persistedClean);
             Assert.assertEquals(Boolean.TRUE, cpsExec.done);
             Assert.assertEquals(1, cpsExec.getCurrentHeads().size());
+            Assert.assertTrue(cpsExec.isComplete());
             Assert.assertTrue(cpsExec.getCurrentHeads().get(0) instanceof FlowEndNode);
             Assert.assertTrue(cpsExec.startNodes == null || cpsExec.startNodes.isEmpty());
             Assert.assertFalse(cpsExec.blocksRestart());
@@ -209,6 +210,7 @@ public class PersistenceProblemsTest {
     }
 
     @Test
+    @Ignore
     public void inProgressMaxPerfCleanShutdown() throws Exception {
         final int[] build = new int[1];
         story.then( j -> {
@@ -228,6 +230,7 @@ public class PersistenceProblemsTest {
     }
 
     @Test
+    @Ignore
     public void inProgressMaxPerfDirtyShutdown() throws Exception {
         final int[] build = new int[1];
         final String[] finalNodeId = new String[1];
@@ -238,6 +241,7 @@ public class PersistenceProblemsTest {
         story.then( j->{
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
+            Thread.sleep(1000);
             j.waitForCompletion(run);
             assertCompletedCleanly(run);
             Assert.assertEquals(Result.FAILURE, run.getResult());

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -1,0 +1,274 @@
+package org.jenkinsci.plugins.workflow.cps;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import hudson.model.Queue;
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
+import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
+import org.jenkinsci.plugins.workflow.graph.FlowStartNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.job.properties.DurabilityHintJobProperty;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Verifies we can cope with all the bizarre quirks that occur when persistence fails or something unexpected happens.
+ */
+public class PersistenceProblemsTest {
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    /** Verifies all the assumptions about a cleanly finished build. */
+    static void assertCompletedCleanly(WorkflowRun run) throws Exception {
+        if (run.isBuilding()) {
+            System.out.println("Run initially building, going to wait a second to see if it finishes, run="+run);
+            Thread.sleep(1);
+        }
+        Assert.assertFalse(run.isBuilding());
+        Assert.assertNotNull(run.getResult());
+        FlowExecution fe = run.getExecution();
+        FlowExecutionList.get().forEach(f -> {
+            if (fe != null && f == fe) {
+                Assert.fail("FlowExecution still in FlowExecutionList!");
+            }
+        });
+        Assert.assertTrue("Queue not empty after completion!", Queue.getInstance().isEmpty());
+
+        if (fe instanceof CpsFlowExecution) {
+            CpsFlowExecution cpsExec = (CpsFlowExecution)fe;
+            Assert.assertTrue(cpsExec.isComplete());
+            Assert.assertEquals(Boolean.TRUE, cpsExec.persistedClean);
+            Assert.assertEquals(Boolean.TRUE, cpsExec.done);
+            Assert.assertEquals(1, cpsExec.getCurrentHeads().size());
+            Assert.assertTrue(cpsExec.getCurrentHeads().get(0) instanceof FlowEndNode);
+            Assert.assertTrue(cpsExec.startNodes == null || cpsExec.startNodes.isEmpty());
+            Assert.assertFalse(cpsExec.blocksRestart());
+        } else {
+            System.out.println("WARNING: no FlowExecutionForBuild");
+        }
+    }
+
+    static void assertCleanInProgress(WorkflowRun run) throws Exception {
+        Assert.assertTrue(run.isBuilding());
+        Assert.assertNull(run.getResult());
+        FlowExecution fe = run.getExecution();
+        AtomicBoolean hasExecutionInList = new AtomicBoolean(false);
+        FlowExecutionList.get().forEach(f -> {
+            if (fe != null && f == fe) {
+                hasExecutionInList.set(true);
+            }
+        });
+        if (!hasExecutionInList.get()) {
+            Assert.fail("Build completed but should still show in FlowExecutionList");
+        }
+        CpsFlowExecution cpsExec = (CpsFlowExecution)fe;
+        Assert.assertFalse(cpsExec.isComplete());
+        Assert.assertEquals(Boolean.FALSE, cpsExec.done);
+        Assert.assertFalse(cpsExec.getCurrentHeads().get(0) instanceof FlowEndNode);
+        Assert.assertTrue(cpsExec.startNodes != null && !cpsExec.startNodes.isEmpty());
+    }
+
+    /** Create and run a basic build before we mangle its persisted contents.  Stores job number to jobIdNumber index 0. */
+    private static WorkflowRun runBasicBuild(JenkinsRule j, String jobName, int[] jobIdNumber) throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, jobName);
+        job.setDefinition(new CpsFlowDefinition("echo 'doSomething'", true));
+        job.addProperty(new DurabilityHintJobProperty(FlowDurabilityHint.MAX_SURVIVABILITY));
+        WorkflowRun run = j.buildAndAssertSuccess(job);
+        jobIdNumber[0] = run.getNumber();
+        assertCompletedCleanly(run);
+        return run;
+    }
+
+    /** Sets up a running build that is waiting on input. */
+    private static WorkflowRun runBasicPauseOnInput(JenkinsRule j, String jobName, int[] jobIdNumber) throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, jobName);
+        job.setDefinition(new CpsFlowDefinition("input 'pause'", true));
+        job.addProperty(new DurabilityHintJobProperty(FlowDurabilityHint.MAX_SURVIVABILITY));
+
+        WorkflowRun run = job.scheduleBuild2(0).getStartCondition().get();
+        ListenableFuture<FlowExecution> listener = run.getExecutionPromise();
+        FlowExecution exec = listener.get();
+        while(run.getAction(InputAction.class) != null) {  // Wait until input step starts
+            Thread.sleep(50);
+        }
+        Thread.sleep(1000L);
+        jobIdNumber[0] = run.getNumber();
+        return run;
+    }
+
+    private static InputStepExecution getInputStepExecution(WorkflowRun run, String inputMessage) throws Exception {
+        InputAction ia = run.getAction(InputAction.class);
+        List<InputStepExecution> execList = ia.getExecutions();
+        return execList.stream().filter(e -> inputMessage.equals(e.getInput().getMessage())).findFirst().orElse(null);
+    }
+
+    final  static String DEFAULT_JOBNAME = "testJob";
+
+    /** Simulates something happening badly during final shutdown, which may cause build to not appear done. */
+    @Test
+    public void completedFinalFlowNodeNotPersisted() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicBuild(j, DEFAULT_JOBNAME, build);
+            String finalId = run.getExecution().getCurrentHeads().get(0).getId();
+
+            // Hack but deletes the file from disk
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            File f = new File(cpsExec.getStorageDir(), finalId+".xml");
+            f.delete();
+        });
+        story.then(j-> {
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+            Assert.assertEquals(Result.SUCCESS, run.getResult());
+        });
+    }
+    /** Perhaps there was a serialization error breaking the FlowGraph persistence for non-durable mode. */
+    @Test
+    public void completedNoNodesPersisted() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicBuild(j, DEFAULT_JOBNAME, build);
+
+            // Hack but deletes the FlowNodeStorage from disk
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            cpsExec.getStorageDir().delete();
+        });
+        story.then(j-> {
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+            Assert.assertEquals(Result.SUCCESS, run.getResult());
+        });
+    }
+
+    /** Unserializable flownodes or other errors */
+    public void errorSavingNodes() throws Exception {
+        // TODO new step that generates a readResolve error when loaded
+    }
+
+    /** Simulates case where done flag was not persisted. */
+    @Test
+    public void completedButWrongDoneStatus() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicBuild(j, DEFAULT_JOBNAME, build);
+            String finalId = run.getExecution().getCurrentHeads().get(0).getId();
+
+            // Hack but deletes the FlowNodeStorage from disk
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            cpsExec.done = false;
+            cpsExec.saveOwner();
+        });
+        story.then(j-> {
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+            Assert.assertEquals(Result.SUCCESS, run.getResult());
+        });
+    }
+
+    @Test
+    public void inProgressNormal() throws Exception {
+        final int[] build = new int[1];
+        story.then( j -> {
+            WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build);
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCleanInProgress(run);
+            InputStepExecution exec = getInputStepExecution(run, "pause");
+            exec.doProceedEmpty();
+            j.waitForCompletion(run);
+            assertCompletedCleanly(run);
+            Assert.assertEquals(Result.SUCCESS, run.getResult());
+        });
+    }
+
+    @Test
+    public void inProgressButFlowNodesLost() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build);
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            cpsExec.getStorageDir().delete();
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+        });
+    }
+
+    /** Failed to save the Execution after the Program bumped the FlowHeads */
+    @Test
+    public void inProgressButProgramAheadOfExecutionLost() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build);
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            FlowHead currHead = cpsExec.heads.firstEntry().getValue();
+
+            // Set the head to the previous value and SAVE
+            currHead.head = cpsExec.getCurrentHeads().get(0).getParents().get(0);
+            run.save();
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+        });
+    }
+
+    @Test
+    /** Build okay but program fails to load */
+    public void inProgressButProgramLoadFailure() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build);
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            cpsExec.getProgramDataFile().delete();
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+        });
+    }
+
+    @Test
+    /** Build okay but then the start nodes get screwed up */
+    public void inProgressButStartBlocksLost() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build);
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            cpsExec.startNodes.push(new FlowStartNode(cpsExec, cpsExec.iotaStr()));
+            run.save();
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+        });
+    }
+}


### PR DESCRIPTION
Addresses the following root causes of problems in Pipeline persistence/durability:

* Pipelines which modify the heads in an execution *without* ensuring the corresponding FlowNodes are also saved to disk - this will cause issues when trying to load the execution -- applies only to the fully durable modes (since non-durable just won't persist period)
* Pipelines which modify the `CPSThread.head` `FlowHead` and its `FlowNode` without ensuring the CpsFlowExecution is saved (via `saveOwner()` that saves the `WorkflowRun`).  This causes an NPE loading the program, because the FlowHead may map to a head in the CpsFlowExecution that will not exist at time of deserialization. 
* Provides some documentation on the persistence model so others do not endure my pain
* Removes explicit persistence calls after `FlowHead#setNewHead(FlowNode)` calls because `setNewHead` now forces flownodes to be saved *before* the head is mutated, guaranteeing an always-usable state.
* Expand the fuzzTesting cases
* Consolidate all shutdown-time persistence into the main `CpsFlowExecution#suspendAll()` terminator - *may* help avoid the occasional ConcurrentModificationException we were seeing at serialize, and is more "correct" and safer generally

TARGETTED AT:

* [JENKINS-46986](https://issues.jenkins-ci.org/browse/JENKINS-46986) specifically, and I no longer see NPEs thanks to this


TODO:

- [x] Fix this error seen at shutdown-timer persistence in live testing: 

> Apr 18, 2018 1:01:08 AM hudson.model.Executor finish1
SEVERE: Executor threw an exception
java.lang.IllegalStateException: Jenkins has not been started, or was already shut down
    at jenkins.model.Jenkins.getActiveInstance(Jenkins.java:762)
    at com.cloudbees.hudson.plugins.folder.AbstractFolder.getDescriptor(AbstractFolder.java:605)
    at jenkins.branch.MultiBranchProject.getDescriptor(MultiBranchProject.java:863)
    at jenkins.branch.MultiBranchProject.getDescriptor(MultiBranchProject.java:124)
    at com.cloudbees.hudson.plugins.folder.AbstractFolder.childNameGenerator(AbstractFolder.java:597)
    at com.cloudbees.hudson.plugins.folder.AbstractFolder.getRootDirFor(AbstractFolder.java:640)
    at jenkins.branch.MultiBranchProject.getRootDirFor(MultiBranchProject.java:843)
    at jenkins.branch.MultiBranchProject.getRootDirFor(MultiBranchProject.java:124)
    at hudson.model.AbstractItem.getRootDir(AbstractItem.java:192)
    at hudson.model.Job.getBuildDir(Job.java:845)
    at hudson.model.Run.getRootDir(Run.java:1028)
    at org.jenkinsci.plugins.workflow.job.WorkflowRun.setResult(WorkflowRun.java:738)
    at org.jenkinsci.plugins.workflow.job.WorkflowRun.finish(WorkflowRun.java:747)
    at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:325)
    at hudson.model.ResourceController.execute(ResourceController.java:97)
    at hudson.model.Executor.run(Executor.java:421)

> Apr 18, 2018 1:01:08 AM jenkins.plugins.git.AbstractGitSCMSource getCacheDir
SEVERE: Jenkins instance is null in AbstractGitSCMSource.getCacheDir
Apr 18, 2018 1:01:08 AM jenkins.util.AtmostOneTaskExecutor$1 call
WARNING: null
java.lang.NullPointerException
    at hudson.model.Queue.maintain(Queue.java:1426)
    at hudson.model.Queue$1.call(Queue.java:320)
    at hudson.model.Queue$1.call(Queue.java:317)
    at jenkins.util.AtmostOneTaskExecutor$1.call(AtmostOneTaskExecutor.java:108)
    at jenkins.util.AtmostOneTaskExecutor$1.call(AtmostOneTaskExecutor.java:98)
    at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:71)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at hudson.remoting.AtmostOneThreadExecutor$Worker.run(AtmostOneThreadExecutor.java:110)
    at java.lang.Thread.run(Thread.java:748)