### PR TITLE
Fix and test for JENKINS-50888 by supporting serialization of execution before onLoad was called

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1611,7 +1611,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             writeChild(w, context, "iota", e.iota.get(), Integer.class);
             synchronized (e) {
                 if (e.headsSerial != null && (e.heads == null || e.heads.isEmpty())) { // Persisting before onLoad has called to load up the real heads
-                    // Note: heads should not be empty
+                    // Note: unlike start nodes, heads should not be empty once onLoad loading has happened
                     for (Entry<Integer, String> entry : e.headsSerial.entrySet()) {
                         writeChild(w, context, "head", entry.getKey() + ":" + entry.getValue(), String.class);
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1610,11 +1610,24 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             }
             writeChild(w, context, "iota", e.iota.get(), Integer.class);
             synchronized (e) {
-                for (FlowHead h : e.heads.values()) {
-                    writeChild(w, context, "head", h.getId() + ":" + h.get().getId(), String.class);
+                if (e.headsSerial != null && (e.heads == null || e.heads.isEmpty())) { // Persisting before onLoad has called to load up the real heads
+                    for (Entry<Integer, String> entry : e.headsSerial.entrySet()) {
+                        writeChild(w, context, "head", entry.getKey() + ":" + entry.getValue(), String.class);
+                    }
+                } else {  // onLoad was invoked, we have real heads*/
+                    for (FlowHead h : e.heads.values()) {
+                        writeChild(w, context, "head", h.getId() + ":" + h.get().getId(), String.class);
+                    }
                 }
-                for (BlockStartNode st : e.startNodes) {
-                    writeChild(w, context, "start", st.getId(), String.class);
+
+                if (e.startNodesSerial != null && (e.startNodes == null)) {  // Start nodes have not been lazy-loaded yet
+                    for (String startId : e.startNodesSerial) {
+                        writeChild(w, context, "start", startId, String.class);
+                    }
+                } else {  // Start nodes were loaded, so we can convert back to serial form
+                    for (BlockStartNode st : e.startNodes) {
+                        writeChild(w, context, "start", st.getId(), String.class);
+                    }
                 }
                 writeChild(w, context, "done", e.done, Boolean.class);
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1611,10 +1611,11 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             writeChild(w, context, "iota", e.iota.get(), Integer.class);
             synchronized (e) {
                 if (e.headsSerial != null && (e.heads == null || e.heads.isEmpty())) { // Persisting before onLoad has called to load up the real heads
+                    // Note: heads should not be empty
                     for (Entry<Integer, String> entry : e.headsSerial.entrySet()) {
                         writeChild(w, context, "head", entry.getKey() + ":" + entry.getValue(), String.class);
                     }
-                } else {  // onLoad was invoked, we have real heads*/
+                } else {  // onLoad was invoked, we have real heads
                     for (FlowHead h : e.heads.values()) {
                         writeChild(w, context, "head", h.getId() + ":" + h.get().getId(), String.class);
                     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -341,7 +341,7 @@ public class PersistenceProblemsTest {
 
     @Issue("JENKINS-50888")  // Tried to modify build without lazy load being triggered
     @Test public void modifyBeforeLazyLoad() {
-        story.thenWithHardShutdown(r -> {  // Normal build
+        story.then(r -> {  // Normal build
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition("echo 'dosomething'", true));
             r.buildAndAssertSuccess(p);
@@ -350,7 +350,7 @@ public class PersistenceProblemsTest {
             WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
             WorkflowRun b = p.getBuildByNumber(1);
             b.setDescription("Bob");
-            b.save();  // Will trigger an IOException potentially
+            b.save();  // Before the JENKINS-50888 fix this would trigger an IOException
         });
         story.then( r-> {  // Verify that the FlowExecutionOwner can trigger lazy-load correctly
             WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);


### PR DESCRIPTION
[JENKINS-50888](https://issues.jenkins-ci.org/browse/JENKINS-50888)

We missed the case of someone immediately modifying the build and saving before we onLoad could get invoked. 