### PR TITLE
Fix more deadlocks

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -633,36 +633,32 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                 }
             }
 
-            try {
-                programPromise = Futures.immediateFailedFuture(new IllegalStateException("Failed loading heads", failureReason));
-                LOGGER.log(Level.INFO, "Creating placeholder flownodes for execution: " + this);
-                if (this.owner != null) {
-                    try {
-                        owner.getListener().getLogger().println("Creating placeholder flownodes because failed loading originals.");
-                    } catch (Exception ex) {
-                        // It's okay to fail to log
-                    }
+            programPromise = Futures.immediateFailedFuture(new IllegalStateException("Failed loading heads", failureReason));
+            LOGGER.log(Level.INFO, "Creating placeholder flownodes for execution: " + this);
+            if (this.owner != null) {
+                try {
+                    owner.getListener().getLogger().println("Creating placeholder flownodes because failed loading originals.");
+                } catch (Exception ex) {
+                    // It's okay to fail to log
                 }
-
-                // Switch to fallback storage so we don't delete original node data
-                this.storageDir = (this.storageDir != null) ? this.storageDir + "-fallback" : "workflow-fallback";
-                this.storage = createStorage();  // Empty storage
-
-                // Clear out old start nodes and heads
-                this.startNodes = new Stack<BlockStartNode>();
-                FlowHead head = new FlowHead(this);
-                this.heads = new TreeMap<Integer, FlowHead>();
-                heads.put(head.getId(), head);
-                FlowStartNode start = new FlowStartNode(this, iotaStr());
-                head.newStartNode(start);
-
-                // Create end
-                FlowNode end = new FlowEndNode(this, iotaStr(), (FlowStartNode) startNodes.pop(), result, getCurrentHeads().toArray(new FlowNode[0]));
-                end.addAction(new ErrorAction(failureReason));
-                head.setNewHead(end);
-            } catch (Exception ex) {
-                throw ex;
             }
+
+            // Switch to fallback storage so we don't delete original node data
+            this.storageDir = (this.storageDir != null) ? this.storageDir + "-fallback" : "workflow-fallback";
+            this.storage = createStorage();  // Empty storage
+
+            // Clear out old start nodes and heads
+            this.startNodes = new Stack<BlockStartNode>();
+            FlowHead head = new FlowHead(this);
+            this.heads = new TreeMap<Integer, FlowHead>();
+            heads.put(head.getId(), head);
+            FlowStartNode start = new FlowStartNode(this, iotaStr());
+            head.newStartNode(start);
+
+            // Create end
+            FlowNode end = new FlowEndNode(this, iotaStr(), (FlowStartNode) startNodes.pop(), result, getCurrentHeads().toArray(new FlowNode[0]));
+            end.addAction(new ErrorAction(failureReason));
+            head.setNewHead(end);
         }
         saveOwner();
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -620,47 +620,52 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
      * Bypasses {@link #croak(Throwable)} and {@link #onProgramEnd(Outcome)} to guarantee a clean path.
      */
     @GuardedBy("this")
-    synchronized void createPlaceholderNodes(Throwable failureReason) throws Exception {
-        this.done = true;
+    void createPlaceholderNodes(Throwable failureReason) throws Exception {
+        synchronized (this) {
+            this.done = true;
 
-        if (this.owner != null) {
-            // Ensure that the Run is marked as completed (failed) if it isn't already so it won't show as running
-            Queue.Executable ex = owner.getExecutable();
-            if (ex instanceof Run) {
-                Result res = ((Run)ex).getResult();
-                setResult(res != null ? res : Result.FAILURE);
-            }
-        }
-
-        try {
-            programPromise = Futures.immediateFailedFuture(new IllegalStateException("Failed loading heads", failureReason));
-            LOGGER.log(Level.INFO, "Creating placeholder flownodes for execution: "+this);
             if (this.owner != null) {
-                try {
-                    owner.getListener().getLogger().println("Creating placeholder flownodes because failed loading originals.");
-                } catch (Exception ex) {
-                    // It's okay to fail to log
+                // Ensure that the Run is marked as completed (failed) if it isn't already so it won't show as running
+                Queue.Executable ex = owner.getExecutable();
+                if (ex instanceof Run) {
+                    Result res = ((Run) ex).getResult();
+                    setResult(res != null ? res : Result.FAILURE);
                 }
             }
 
-            // Switch to fallback storage so we don't delete original node data
-            this.storageDir = (this.storageDir != null) ? this.storageDir+"-fallback" : "workflow-fallback";
-            this.storage = createStorage();  // Empty storage
+            try {
+                programPromise = Futures.immediateFailedFuture(new IllegalStateException("Failed loading heads", failureReason));
+                LOGGER.log(Level.INFO, "Creating placeholder flownodes for execution: " + this);
+                if (this.owner != null) {
+                    try {
+                        owner.getListener().getLogger().println("Creating placeholder flownodes because failed loading originals.");
+                    } catch (Exception ex) {
+                        // It's okay to fail to log
+                    }
+                }
 
-            // Clear out old start nodes and heads
-            this.startNodes = new Stack<BlockStartNode>();
-            FlowHead head = new FlowHead(this);
-            this.heads = new TreeMap<Integer, FlowHead>();
-            heads.put(head.getId(), head);
-            FlowStartNode start = new FlowStartNode(this, iotaStr());
-            head.newStartNode(start);
+                // Switch to fallback storage so we don't delete original node data
+                this.storageDir = (this.storageDir != null) ? this.storageDir + "-fallback" : "workflow-fallback";
+                this.storage = createStorage();  // Empty storage
 
-            // Create end
-            FlowNode end = new FlowEndNode(this, iotaStr(), (FlowStartNode)startNodes.pop(), result, getCurrentHeads().toArray(new FlowNode[0]));
-            end.addAction(new ErrorAction(failureReason));
-            head.setNewHead(end);
+                // Clear out old start nodes and heads
+                this.startNodes = new Stack<BlockStartNode>();
+                FlowHead head = new FlowHead(this);
+                this.heads = new TreeMap<Integer, FlowHead>();
+                heads.put(head.getId(), head);
+                FlowStartNode start = new FlowStartNode(this, iotaStr());
+                head.newStartNode(start);
+
+                // Create end
+                FlowNode end = new FlowEndNode(this, iotaStr(), (FlowStartNode) startNodes.pop(), result, getCurrentHeads().toArray(new FlowNode[0]));
+                end.addAction(new ErrorAction(failureReason));
+                head.setNewHead(end);
+            } catch (Exception ex) {
+                throw ex;
+            }
+        }
+        try {
             saveOwner();
-
         } catch (Exception ex) {
             throw ex;
         }
@@ -1072,13 +1077,17 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
      * of a FlowNode and thereby joining an another thread.
      */
     //
-    synchronized void addHead(FlowHead h) {
-        heads.put(h.getId(), h);
-        saveExecutionIfDurable(); // We need to save the mutated heads for the run
+    void addHead(FlowHead h) {
+        synchronized (this) {
+            heads.put(h.getId(), h);
+        }
+        saveExecutionIfDurable();
     }
 
-    synchronized void removeHead(FlowHead h) {
-        heads.remove(h.getId());
+    void removeHead(FlowHead h) {
+        synchronized (this) {
+            heads.remove(h.getId());
+        }
         saveExecutionIfDurable(); // We need to save the mutated heads for the run
     }
 
@@ -1217,7 +1226,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     }
 
     /**
-     * Record the end of the build.
+     * Record the end of the build.  Note: we should always follow this with a call to saveOwner to persist the result.
      * @param outcome success; or a normal failure (uncaught exception); or a fatal error in VM machinery
      */
     synchronized void onProgramEnd(Outcome outcome) {
@@ -1254,7 +1263,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         }
 
         this.persistedClean = Boolean.TRUE;
-        saveOwner();
     }
 
     void cleanUpHeap() {
@@ -1907,7 +1915,8 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         }
     }
 
-    /** Save the owner that holds this execution. */
+    /** Save the owner that holds this execution. Note: to avoid deadlocks we need to ensure we are never
+     *  holding a lock on the Execution when running this. */
     void saveOwner() {
         try {
             if (this.owner != null && this.owner.getExecutable() instanceof Saveable) {  // Null-check covers some anomalous cases we've seen

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1218,7 +1218,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     }
 
     /**
-     * Record the end of the build.  Note: we should always follow this with a call to saveOwner to persist the result.
+     * Record the end of the build.  Note: we should always follow this with a call to {@link #saveOwner()} to persist the result.
      * @param outcome success; or a normal failure (uncaught exception); or a fatal error in VM machinery
      */
     synchronized void onProgramEnd(Outcome outcome) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -664,11 +664,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                 throw ex;
             }
         }
-        try {
-            saveOwner();
-        } catch (Exception ex) {
-            throw ex;
-        }
+        saveOwner();
     }
 
     @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification="Storage does not actually NEED to be synchronized but the rest does.")
@@ -964,11 +960,11 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
 
     @Override
     public synchronized List<FlowNode> getCurrentHeads() {
-        List<FlowNode> r = new ArrayList<FlowNode>();
         if (heads == null) {
             LOGGER.log(Level.WARNING, null, new IllegalStateException("List of flow heads unset for " + this));
-            return r;
+            return Collections.emptyList();
         }
+        List<FlowNode> r = new ArrayList<FlowNode>(heads.size());
         for (FlowHead h : heads.values()) {
             r.add(h.get());
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1915,8 +1915,9 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         }
     }
 
-    /** Save the owner that holds this execution. Note: to avoid deadlocks we need to ensure we are never
-     *  holding a lock on the Execution when running this. */
+    /** Save the owner that holds this execution.
+     *  Key note: to avoid deadlocks we need to ensure that we don't hold a lock on this CpsFlowExecution when running saveOwner
+     *   or pre-emptively lock the run before locking the execution and saving. */
     void saveOwner() {
         try {
             if (this.owner != null && this.owner.getExecutable() instanceof Saveable) {  // Null-check covers some anomalous cases we've seen

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
@@ -18,6 +18,7 @@ import org.codehaus.groovy.control.CompilationFailedException;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.SourceUnit;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 
 /**
  * {@link GroovyShell} with additional tweaks necessary to run {@link CpsScript}
@@ -109,9 +110,10 @@ class CpsGroovyShell extends GroovyShell {
     @Override
     public Script parse(GroovyCodeSource codeSource) throws CompilationFailedException {
         Script s = doParse(codeSource);
-        if (execution!=null)
+        if (execution!=null) {
             execution.loadedScripts.put(s.getClass().getSimpleName(), codeSource.getScriptText());
-        this.execution.saveExecutionIfDurable();
+            execution.saveExecutionIfDurable();
+        }
         prepareScript(s);
         return s;
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
@@ -111,10 +111,7 @@ class CpsGroovyShell extends GroovyShell {
         Script s = doParse(codeSource);
         if (execution!=null)
             execution.loadedScripts.put(s.getClass().getSimpleName(), codeSource.getScriptText());
-        if (this.execution != null && !this.execution.getDurabilityHint().isPersistWithEveryStep()) {
-            // Ensure we persist new scripts
-            this.execution.saveOwner();
-        }
+        this.execution.saveExecutionIfDurable();
         prepareScript(s);
         return s;
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
@@ -18,7 +18,6 @@ import org.codehaus.groovy.control.CompilationFailedException;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.SourceUnit;
-import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 
 /**
  * {@link GroovyShell} with additional tweaks necessary to run {@link CpsScript}

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -356,7 +356,7 @@ public final class CpsThreadGroup implements Serializable {
                         try {
                             this.execution.saveOwner();
                         } catch (Exception ex) {
-                            LOGGER.log(Level.WARNING, "Error saving execution for "+this, ex);
+                            LOGGER.log(Level.WARNING, "Error saving execution for "+this.getExecution(), ex);
                         }
                         ending = true;
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -353,6 +353,11 @@ public final class CpsThreadGroup implements Serializable {
                     threads.remove(t.id);
                     if (threads.isEmpty()) {
                         execution.onProgramEnd(o);
+                        try {
+                            this.execution.saveOwner();
+                        } catch (Exception ex) {
+                            LOGGER.log(Level.WARNING, "Error saving execution for "+this, ex);
+                        }
                         ending = true;
                     }
                 } else {


### PR DESCRIPTION
See [deadlock file](https://issues.jenkins-ci.org/secure/attachment/42497/deadlock.txt) from [JENKINS-51132 comment](https://issues.jenkins-ci.org/browse/JENKINS-51132?focusedCommentId=337105&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-337105). 

This prevents deadlocks by ensuring we do not lock Execution before Run (usually by separating the synchronization scopes). 

Lock order should always be Run -> Execution when locks are nested, or locks should be separated (the approach generally used here).

Why aren't there testcases?   I have low confidence in our ability produce a testcase that replicates all these deadlocks.