### PR TITLE
[JENKINS-51170] Enable the usage of the StepEnvironmentContributor extensionpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.28</version>
+        <version>3.32</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -68,7 +68,7 @@
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.1.0</git-plugin.version>
-        <workflow-support-plugin.version>2.21</workflow-support-plugin.version>
+        <workflow-support-plugin.version>3.2-rc711.a7efba98306d</workflow-support-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <groovy-cps.version>1.25</groovy-cps.version>
         <structs-plugin.version>1.17</structs-plugin.version>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.18</version>
+            <version>2.19-rc508.410020b15345</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Support the new StepEnvironmentContributor hook introduced in
jenkinsci/workflow-step-api-plugin#36.

This depends on jenkinsci/workflow-step-api-plugin#36.
The dependency version number used depends on the incrementalifyiation (JEP 305).
If requested I can perform this and submit another PR.