### PR TITLE
Do not use com.google.common.io.NullOutputStream

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-3</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,12 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.4</version>
+        <version>3.13</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-cps</artifactId>
-    <version>2.54-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Groovy</name>
     <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Groovy+Plugin</url>
@@ -47,8 +47,8 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>${scmTag}</tag>
+    </scm>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -62,6 +62,8 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
+        <revision>2.54</revision>
+        <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.62</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
@@ -535,7 +535,7 @@ import org.kohsuke.stapler.StaplerRequest;
         return ExtensionList.lookup(SnippetizerLink.class);
     }
 
-    @Restricted(DoNotUse.class)
+    @Restricted(NoExternalUse.class)
     @Extension public static class PerJobAdder extends TransientActionFactory<Job> {
 
         @Override public Class<Job> type() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
@@ -25,19 +25,17 @@
 package org.jenkinsci.plugins.workflow.cps.actions;
 
 import com.google.common.collect.Maps;
-import com.google.common.io.NullOutputStream;
 import hudson.EnvVars;
 import jenkins.model.Jenkins;
+import org.apache.commons.io.output.NullOutputStream;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -276,8 +274,6 @@ public class ArgumentsActionImpl extends ArgumentsAction {
         }
     }
 
-    static final OutputStream NULL_STRM = new NullOutputStream();
-
     /** Verify that all the arguments WILL serialize and if not replace with {@link org.jenkinsci.plugins.workflow.actions.ArgumentsAction.NotStoredReason#UNSERIALIZABLE}
      *  See JENKINS-50752 for details, but the gist is we need to avoid problems before physical persistence to prevent data loss.
      *  @return Arguments
@@ -290,7 +286,7 @@ public class ArgumentsActionImpl extends ArgumentsAction {
             try {
                 if (val != null && !(val instanceof String) && !(val instanceof Boolean) && !(val instanceof Number) && !(val instanceof NotStoredReason) && !(val instanceof TimeUnit)) {
                     // We only need to check serialization for nontrivial types
-                    Jenkins.XSTREAM2.toXMLUTF8(entry.getValue(), NULL_STRM);  // Hacky but can't find a better way
+                    Jenkins.XSTREAM2.toXMLUTF8(entry.getValue(), new NullOutputStream());  // Hacky but can't find a better way
                 }
                 out.put(entry.getKey(), entry.getValue());
             } catch (Exception ex) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
@@ -286,7 +286,7 @@ public class ArgumentsActionImpl extends ArgumentsAction {
             try {
                 if (val != null && !(val instanceof String) && !(val instanceof Boolean) && !(val instanceof Number) && !(val instanceof NotStoredReason) && !(val instanceof TimeUnit)) {
                     // We only need to check serialization for nontrivial types
-                    Jenkins.XSTREAM2.toXMLUTF8(entry.getValue(), new NullOutputStream());  // Hacky but can't find a better way
+                    Jenkins.XSTREAM2.toXMLUTF8(entry.getValue(), NullOutputStream.NULL_OUTPUT_STREAM);  // Hacky but can't find a better way
                 }
                 out.put(entry.getKey(), entry.getValue());
             } catch (Exception ex) {


### PR DESCRIPTION
Subsumes #230 and amends a mistake in #220: use of a beta API from the version of Guava currently bundled in Jenkins core, which has [subsequently been deleted](https://google.github.io/guava/releases/14.0/api/docs/com/google/common/io/NullOutputStream.html), causing mayhem if you try to run Pipeline-based tests with a newer Guava in the test classpath.

From [this search](https://github.com/search?q=user%3Ajenkinsci+%22com.google.common.io.NullOutputStream%22&type=Code) this seems to be the only usage in non-test code of this class except for `openshift-deployer` which has not been touched in three years.