### PR TITLE
[JENKINS-52189] Ensure GraphListeners are notified of the FlowStartNode too

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
@@ -74,7 +74,6 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockQueueItemAuthenticator;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
-import sun.jvm.hotspot.utilities.Assert;
 
 /**
  * Tests of workflows that involve restarting Jenkins in the middle.


### PR DESCRIPTION
[JENKINS-52189](https://issues.jenkins-ci.org/browse/JENKINS-52189)

We might consider initializing the CpsThreadGroup before the FlowStartNode (in CpsFlowExecution) to make this more "correct" but I'm a bit concerned that might have unintended consequences. 