### PR TITLE
[JENKINS-53358] Remove bogus persistence calls due to notifyListeners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.54</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.62</jenkins.version>
+        <jenkins.version>2.73.3</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.1.0</git-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.1.0</git-plugin.version>
-        <workflow-support-plugin.version>2.17</workflow-support-plugin.version>
-        <scm-api-plugin.version>2.0.8</scm-api-plugin.version>
+        <workflow-support-plugin.version>2.20</workflow-support-plugin.version>
+        <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <groovy-cps.version>1.24</groovy-cps.version>
         <jenkins-test-harness.version>2.37</jenkins-test-harness.version>
     </properties>
@@ -143,7 +143,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.23</version>
+            <!--<version>2.23</version> -->
+            <version>2.25-rc775.35b435d87ee7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -260,6 +261,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>config-file-provider</artifactId>
             <version>2.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>command-launcher</artifactId>
+            <version>1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.21</version>
+            <version>2.23</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -264,12 +264,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>command-launcher</artifactId>
-            <version>1.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.cloudbees</groupId>
             <artifactId>groovy-cps</artifactId>
             <version>${groovy-cps.version}</version>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1497,10 +1497,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         return false;
     }
 
-    private void setPersistedClean(boolean persistedClean) {  // Workaround for some issues with anonymous classes.
-        this.persistedClean = persistedClean;
-    }
-
     /**
      * Pause or unpause the execution.
      *

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1440,7 +1440,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                     }
                 }
             } finally {
-                if (synchronous) {
+                if (synchronous || !(getDurabilityHint().isPersistWithEveryStep())) {
                     bc.abort(); // hack to skip save—we are holding a lock
                 } else {
                     try {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1440,8 +1440,12 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                     }
                 }
             } finally {
-                if (synchronous || !(getDurabilityHint().isPersistWithEveryStep())) {
-                    bc.abort(); // hack to skip save—we are holding a lock
+                if (synchronous) {
+                    bc.abort(); //// hack to skip save—we are holding a lock
+                } else if (!(getDurabilityHint().isPersistWithEveryStep()) && !(nodes.stream().anyMatch(x->x instanceof FlowEndNode))) {
+                    // We do not want to invoke gratuitous save calls if we aren't set to persist with every step
+                    // Except that we MUST trigger a persistence call at the very end of the execution
+                    bc.abort();
                 } else {
                     try {
                         bc.commit();

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -367,10 +367,6 @@ public final class CpsThreadGroup implements Serializable {
             }
         }
 
-        if (changed && !stillRunnable) {
-            execution.persistedClean = null;
-            saveProgramIfPossible(false);
-        }
         if (ending) {
             execution.cleanUpHeap();
             if (scripts != null) {
@@ -382,6 +378,9 @@ public final class CpsThreadGroup implements Serializable {
             } catch (IOException x) {
                 LOGGER.log(Level.WARNING, "Failed to delete program.dat in " + execution, x);
             }
+        } else if (changed && !stillRunnable) {
+            execution.persistedClean = null;
+            saveProgramIfPossible(false);
         }
 
         return stillRunnable;

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -75,6 +75,7 @@ public class PersistenceProblemsTest {
             Assert.assertTrue(cpsExec.getCurrentHeads().get(0) instanceof FlowEndNode);
             Assert.assertTrue(cpsExec.startNodes == null || cpsExec.startNodes.isEmpty());
             Assert.assertFalse(cpsExec.blocksRestart());
+            Assert.assertEquals(Boolean.TRUE, cpsExec.persistedClean);
         } else {
             System.out.println("WARNING: no FlowExecutionForBuild");
         }


### PR DESCRIPTION
[JENKINS-53358](https://issues.jenkins-ci.org/browse/JENKINS-53358)

These should not be invoked in performance-optimized durability mode -- if we're not trying to save with each step run, we shouldn't do it due to listeners firing.  This was an issue that degraded the IO improvements for performance-optimized mode and greatly increased IO calls.  The phrase "CD-660" may be meaningful to some here. 

Also fixes a buglet noted with the persistedClean flag handling.