### PR TITLE
[JENKINS-53333] Allow steps to be invoked using their full class name

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -171,8 +171,8 @@ public class DSL extends GroovyObjectSupport implements Serializable {
                 if (functions.containsKey(functionName)) {
                     ambiguousFunctionNames.add(functionName);
                 }
-                // TODO: Switch we switch to putIfAbsent so that the descriptor with the highest ordinal value is preferred for ambiguous functions?
-                functions.put(functionName, d);
+                // The step descriptor with the highest value for Extension#ordinal() is used in the case of ambiguity.
+                functions.putIfAbsent(functionName, d);
                 stepClassNames.put(d.clazz.getName(), d);
             }
             ambiguousFunctions = functions.keySet().stream()

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -444,6 +444,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
                         "For example: steps.'%2$s'(...)",
                         d.getFunctionName(), d.clazz.getName(), ambiguousClassNames);
                 listener.getLogger().println(message);
+                return;
             }
         } catch (InterruptedException | IOException temp) {
             e = temp;

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -425,7 +425,6 @@ public class DSLTest {
         r.assertLogContains("GOODBYE", b);
     }
 
-    @Ignore("Extension ordering is reversed with respect to Extension#ordinal, see DSL#invokeMethod")
     @Test public void ambiguousStepsRespectOrdinal() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("ambiguousEcho 'HeLlO'\n", true));

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -397,6 +397,32 @@ public class DSLTest {
         r.assertLogContains("6", b); 
     }
     
+    @Test public void quotedStep() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("'echo' 'Hello1'\n" +
+                                              "\"echo\" 'Hello2'", true));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("Hello1", b);
+        r.assertLogContains("Hello2", b);
+    }
+
+    @Test public void fullyQualifiedStep() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("'org.jenkinsci.plugins.workflow.steps.EchoStep' 'Hello, world!'", true));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("Hello, world!", b);
+    }
+
+    @Test public void fullyQualifiedAmbiguousStep() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "'org.jenkinsci.plugins.workflow.testMetaStep.AmbiguousEchoLowerStep' 'HeLlO'\n" +
+                "'org.jenkinsci.plugins.workflow.testMetaStep.AmbiguousEchoUpperStep' 'GoOdByE'", true));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("hello", b);
+        r.assertLogContains("GOODBYE", b);
+    }
+
     public static class CLStep extends Step {
         public final String name;
         @DataBoundConstructor public CLStep(String name) {this.name = name;}

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -423,6 +423,7 @@ public class DSLTest {
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("hello", b);
         r.assertLogContains("GOODBYE", b);
+        r.assertLogNotContains("Warning: Invoking ambiguous Pipeline Step", b);
     }
 
     @Test public void ambiguousStepsRespectOrdinal() throws Exception {
@@ -430,6 +431,8 @@ public class DSLTest {
         p.setDefinition(new CpsFlowDefinition("ambiguousEcho 'HeLlO'\n", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("HELLO", b);
+        r.assertLogContains("Warning: Invoking ambiguous Pipeline Step", b);
+        r.assertLogContains("any of the following steps: [" + AmbiguousEchoUpperStep.class.getName() + ", " + AmbiguousEchoLowerStep.class.getName() + "]", b);
     }
 
     public static class CLStep extends Step {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -47,6 +47,8 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
+import org.jenkinsci.plugins.workflow.testMetaStep.AmbiguousEchoLowerStep;
+import org.jenkinsci.plugins.workflow.testMetaStep.AmbiguousEchoUpperStep;
 import static org.junit.Assert.*;
 
 import org.junit.Assert;
@@ -421,6 +423,14 @@ public class DSLTest {
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("hello", b);
         r.assertLogContains("GOODBYE", b);
+    }
+
+    @Ignore("Extension ordering is reversed with respect to Extension#ordinal, see DSL#invokeMethod")
+    @Test public void ambiguousStepsRespectOrdinal() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("ambiguousEcho 'HeLlO'\n", true));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("HELLO", b);
     }
 
     public static class CLStep extends Step {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTester.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTester.java
@@ -101,7 +101,7 @@ public class SnippetizerTester {
         s.o = new DSL(new DummyOwner()) {
             // for testing, instead of executing the step just return an instantiated Step
             @Override
-            protected Object invokeStep(StepDescriptor d, Object args) {
+            protected Object invokeStep(StepDescriptor d, String name, Object args) {
                 try {
                     return d.newInstance(parseArgs(args, d).namedArgs);
                 } catch (Exception e) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/AmbiguousEchoLowerStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/AmbiguousEchoLowerStep.java
@@ -51,7 +51,7 @@ public class AmbiguousEchoLowerStep extends Step implements Serializable {
         return new Execution(message, context);
     }
 
-    @Extension
+    @Extension(ordinal = -1) // Invoking `ambiguousEcho` should execute AmbiguousEchoUpperStep instead of this step.
     public static class DescriptorImpl extends StepDescriptor {
 
         @Override

--- a/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/AmbiguousEchoLowerStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/AmbiguousEchoLowerStep.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.workflow.testMetaStep;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Set;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class AmbiguousEchoLowerStep extends Step implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private final String message;
+
+    @DataBoundConstructor
+    public AmbiguousEchoLowerStep(String message) {
+        this.message = message.toLowerCase(Locale.ENGLISH);
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new Execution(message, context);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "ambiguousEcho";
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.singleton(TaskListener.class);
+        }
+    }
+
+    public static class Execution extends SynchronousStepExecution<Void> {
+
+        private static final long serialVersionUID = 1L;
+        private final String message;
+
+        Execution(String message, StepContext context) {
+            super(context);
+            this.message = message;
+        }
+
+        @Override
+        protected Void run() throws Exception {
+            getContext().get(TaskListener.class).getLogger().println(message);
+            return null;
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/AmbiguousEchoUpperStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/AmbiguousEchoUpperStep.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.workflow.testMetaStep;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Set;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class AmbiguousEchoUpperStep extends Step implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private final String message;
+
+    @DataBoundConstructor
+    public AmbiguousEchoUpperStep(String message) {
+        this.message = message.toUpperCase(Locale.ENGLISH);
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new AmbiguousEchoLowerStep.Execution(message, context);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "ambiguousEcho";
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.singleton(TaskListener.class);
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/AmbiguousEchoUpperStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/AmbiguousEchoUpperStep.java
@@ -50,7 +50,7 @@ public class AmbiguousEchoUpperStep extends Step implements Serializable {
         return new AmbiguousEchoLowerStep.Execution(message, context);
     }
 
-    @Extension
+    @Extension(ordinal = 1) // Invoking `ambiguousEcho` should execute this step instead of AmbiguousEchoLowerStep.
     public static class DescriptorImpl extends StepDescriptor {
 
         @Override


### PR DESCRIPTION
See [JENKINS-53333](https://issues.jenkins-ci.org/browse/JENKINS-53333).

This PR allows Pipeline steps to be specified using the full class name, in case multiple steps exist in the Jenkins instance with the same function name.

For example, this PR allows the following:

    'org.jenkinsci.plugins.workflow.steps.EchoStep'('Hello, world!')
    'org.jenkinsci.plugins.workflow.steps.EchoStep' 'Hello, world!'
    steps.'org.jenkinsci.plugins.workflow.steps.EchoStep'('Hello, world!')
    // all are equivalent to:
    echo 'Hello, world!'

The syntax is weird to say the least, but the following already works today (Verified in `DSLTest#quotedStep`, maybe just Groovy weirdness), so it is at least consistent on that front:

    'echo' 'Hello, world!' // Quotes around echo?!
    steps.'echo' 'Hello, world!'

@jglick suggested something like the following:

    steps['org.jenkinsci.plugins.workflow.steps.EchoStep']('Hello, world!')

That syntax definitely looks better, but seemed a little trickier to implement, since it looks like we'd need to override `GroovyObjectSupport#getProperty` and return a temporary object that hooks back into `DSL#invokeStep` when called. I am happy to go down that route if preferred, but since the current approach was so simple to implement and this doesn't seem like a common use case anyway, I wanted to get some feedback on whether the current syntax is good enough before proceeding.

@reviewbybees 