### PR TITLE
use ABORTED icon color for interrupted steps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -25,10 +25,12 @@
 package org.jenkinsci.plugins.workflow.cps.nodes;
 
 import hudson.model.Action;
+import hudson.model.BallColor;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.graph.AtomNode;
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -143,4 +145,17 @@ public class StepAtomNode extends AtomNode implements StepNode {
         return null;
     }
 
+    /**
+     * Override default method to return proper icon color for interrupted steps.
+     */
+    @Override
+    public BallColor getIconColor() {
+        if(getError() != null) {
+            if(getError().getError() instanceof FlowInterruptedException) {
+                return BallColor.ABORTED;
+
+            }
+        }
+        return super.getIconColor();
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/nodes/StepAtomNode.java
@@ -28,12 +28,14 @@ import hudson.model.Action;
 import hudson.model.BallColor;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+
 
 import java.io.ObjectStreamException;
 import java.util.Collections;
@@ -150,8 +152,9 @@ public class StepAtomNode extends AtomNode implements StepNode {
      */
     @Override
     public BallColor getIconColor() {
-        if(getError() != null) {
-            if(getError().getError() instanceof FlowInterruptedException) {
+        ErrorAction error = getError();
+        if(error != null) {
+            if(error.getError() instanceof FlowInterruptedException) {
                 return BallColor.ABORTED;
 
             }


### PR DESCRIPTION
parallel() aborts branch execution when failFast == true and another
branch failed. In this case RED color is used in 'Pipeline Steps' view.
It makes more difficult to find real reason of failure because some of
red dots are misleading.

With this change we use BallColor.ABORTED when FlowInterruptedException
is the reason of step failure. Thanks to this user can easier find root
cause of build failure.

Signed-off-by: Artur Harasimiuk <artur.harasimiuk@intel.com>