### PR TITLE
Fixed i18n properties

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/Messages.properties
@@ -1,4 +1,4 @@
 Replay.permission.description=Ability to perform a new Pipeline build with an edited script.
 ReplayCommand.shortDescription=Replay a Pipeline build with edited script taken from standard input
 ReplayAction.displayName=Replay
-ReplayCause.shortDescription=Replayed # ${0}
+ReplayCause.shortDescription=Replayed #{0}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/Messages_zh_CN.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/Messages_zh_CN.properties
@@ -23,4 +23,4 @@
 Replay.permission.description=\u6267\u884C\u7F16\u8F91\u8FC7\u7684\u6D41\u6C34\u7EBF\u7684\u80FD\u529B\u3002
 ReplayCommand.shortDescription=\u4ECE\u6807\u51C6\u8F93\u5165\u4E2D\u83B7\u53D6\u7684\u811A\u672C\u5E76\u56DE\u653E\u6D41\u6C34\u7EBF\u6267\u884C
 ReplayAction.displayName=\u56DE\u653E
-ReplayCause.shortDescription=\u57FA\u4E8E# {0} \u56DE\u653E
+ReplayCause.shortDescription=\u57FA\u4E8E#{0} \u56DE\u653E


### PR DESCRIPTION
Removed the unnecessary / invalid Dollar sign in the English property file.
Also removed the additional space as it is a bit of unnecessary change and may break some tools working with the API.
These two things were introduced with #235.