### PR TITLE
[JENKINS-53709] Pop context variables after CpsBodyExecution completes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/ContextVariableSet.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/ContextVariableSet.java
@@ -46,10 +46,6 @@ final class ContextVariableSet implements Serializable {
         this.parent = parent;
     }
 
-    ContextVariableSet getParent() {
-        return parent;
-    }
-
     <T> T get(Class<T> type) {
         for (ContextVariableSet s=this; s!=null; s=s.parent) {
             for (Object v : s.values) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/ContextVariableSet.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/ContextVariableSet.java
@@ -31,19 +31,23 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.NONE;
+import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.PROGRAM;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 @Immutable
-@PersistIn(NONE)
+@PersistIn(PROGRAM)
 final class ContextVariableSet implements Serializable {
     private final ContextVariableSet parent;
     private final List<Object> values = new ArrayList<Object>();
 
     ContextVariableSet(ContextVariableSet parent) {
         this.parent = parent;
+    }
+
+    ContextVariableSet getParent() {
+        return parent;
     }
 
     <T> T get(Class<T> type) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -348,7 +348,7 @@ class CpsBodyExecution extends BodyExecution {
             for (BodyExecutionCallback c : callbacks) {
                 c.onFailure(sc, t);
             }
-            synchronized (this) {
+            synchronized (CpsBodyExecution.this) {
                 thread.popContextVariables();
             }
             return Next.terminate(null);
@@ -367,7 +367,7 @@ class CpsBodyExecution extends BodyExecution {
             for (BodyExecutionCallback c : callbacks) {
                 c.onSuccess(sc, o);
             }
-            synchronized (this) {
+            synchronized (CpsBodyExecution.this) {
                 thread.popContextVariables();
             }
             return Next.terminate(null);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -348,7 +348,7 @@ class CpsBodyExecution extends BodyExecution {
             for (BodyExecutionCallback c : callbacks) {
                 c.onFailure(sc, t);
             }
-
+            thread.popContextVariables();
             return Next.terminate(null);
         }
 
@@ -365,6 +365,7 @@ class CpsBodyExecution extends BodyExecution {
             for (BodyExecutionCallback c : callbacks) {
                 c.onSuccess(sc, o);
             }
+            thread.popContextVariables();
             return Next.terminate(null);
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -348,7 +348,9 @@ class CpsBodyExecution extends BodyExecution {
             for (BodyExecutionCallback c : callbacks) {
                 c.onFailure(sc, t);
             }
-            thread.popContextVariables();
+            synchronized (this) {
+                thread.popContextVariables();
+            }
             return Next.terminate(null);
         }
 
@@ -365,7 +367,9 @@ class CpsBodyExecution extends BodyExecution {
             for (BodyExecutionCallback c : callbacks) {
                 c.onSuccess(sc, o);
             }
-            thread.popContextVariables();
+            synchronized (this) {
+                thread.popContextVariables();
+            }
             return Next.terminate(null);
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -140,9 +140,7 @@ public final class CpsThread implements Serializable {
      * that those variables will no longer be persisted as part of the program. See JENKINS-53709.
      */
     void popContextVariables() {
-        if (contextVariables != null) {
-            contextVariables = contextVariables.getParent();
-        }
+        contextVariables = null;
     }
 
     boolean isRunnable() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -97,7 +97,7 @@ public final class CpsThread implements Serializable {
     final FlowHead head;
 
     @Nullable
-    private final ContextVariableSet contextVariables;
+    private ContextVariableSet contextVariables;
 
     /**
      * If this thread is waiting for a {@link StepExecution} to complete (by invoking our callback),
@@ -133,6 +133,16 @@ public final class CpsThread implements Serializable {
 
     public ContextVariableSet getContextVariables() {
         return contextVariables;
+    }
+
+    /**
+     * Used to remove context variables after a {@link CpsBodyExecution} finishes executing so
+     * that those variables will no longer be persisted as part of the program. See JENKINS-53709.
+     */
+    void popContextVariables() {
+        if (contextVariables != null) {
+            contextVariables = contextVariables.getParent();
+        }
     }
 
     boolean isRunnable() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
@@ -203,7 +203,7 @@ public class CpsBodyExecutionTest {
                     "    echo '" + s.getNodeName() + "'\n" +
                     "  }\n" +
                     "}\n" +
-                    "semaphore 'wait'\n", false));
+                    "semaphore 'wait'\n", true));
             WorkflowRun b = p.scheduleBuild2(0).waitForStart();
             SemaphoreStep.waitForStart("wait/1", b);
             r.jenkins.removeNode(s);

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
@@ -4,13 +4,13 @@ import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 import groovy.lang.Closure;
 import hudson.model.Result;
+import hudson.slaves.DumbSlave;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
@@ -33,14 +33,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class CpsBodyExecutionTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
-    @Rule public JenkinsRule jenkins = new JenkinsRule();
+    @Rule public RestartableJenkinsRule rr = new RestartableJenkinsRule();
 
     /**
      * When the body of a step is synchronous and explodes, the failure should be recorded and the pipeline job
@@ -55,6 +55,7 @@ public class CpsBodyExecutionTest {
      */
     @Test
     public void synchronousExceptionInBody() throws Exception {
+        rr.then(jenkins -> {
         WorkflowJob p = jenkins.createProject(WorkflowJob.class);
         p.setDefinition(new CpsFlowDefinition("synchronousExceptionInBody()",true));
 
@@ -89,6 +90,7 @@ public class CpsBodyExecutionTest {
                 "FlowStartNode"
             ),nodes);
         }
+        });
     }
 
     public static class SynchronousExceptionInBodyStep extends AbstractStepImpl {
@@ -131,6 +133,7 @@ public class CpsBodyExecutionTest {
 
     @Issue("JENKINS-34637")
     @Test public void currentExecutions() throws Exception {
+        rr.then(jenkins -> {
         WorkflowJob p = jenkins.createProject(WorkflowJob.class);
         p.setDefinition(new CpsFlowDefinition("parallel main: {retainsBody {parallel a: {retainsBody {semaphore 'a'}}, b: {retainsBody {semaphore 'b'}}}}, aside: {semaphore 'c'}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
@@ -167,6 +170,7 @@ public class CpsBodyExecutionTest {
         execs[0].body.cancel();
         SemaphoreStep.success("c/1", null);
         jenkins.assertBuildStatus(Result.ABORTED, jenkins.waitForCompletion(b));
+        });
     }
     public static class RetainsBodyStep extends AbstractStepImpl {
         @DataBoundConstructor public RetainsBodyStep() {}
@@ -187,6 +191,34 @@ public class CpsBodyExecutionTest {
                 throw new AssertionError("block #" + count + " not supposed to be killed directly", cause);
             }
         }
+    }
+
+    @Issue("JENKINS-53709")
+    @Test public void popContextVarsOnBodyCompletion() {
+        rr.then(r -> {
+            DumbSlave s = r.createOnlineSlave();
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "demo");
+            p.setDefinition(new CpsFlowDefinition("node('" + s.getNodeName() + "') {\n" +
+                    "  parallel one: {\n" +
+                    "    echo '" + s.getNodeName() + "'\n" +
+                    "  }\n" +
+                    "}\n" +
+                    "semaphore 'wait'\n", false));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            SemaphoreStep.waitForStart("wait/1", b);
+            r.jenkins.removeNode(s);
+        });
+        rr.then(r -> {
+            WorkflowRun b = r.jenkins.getItemByFullName("demo", WorkflowJob.class).getBuildByNumber(1);
+            SemaphoreStep.waitForStart("wait/1", b);
+            SemaphoreStep.success("wait/1", null);
+            while (b.isBuilding()) {
+                // Before the fix for JENKINS-53709, the job hangs forever while attempting to rehydrate the agent.
+                r.assertLogNotContains("Jenkins doesn’t have label", b);
+                Thread.sleep(100);
+            }
+            r.assertBuildStatusSuccess(b);
+        });
     }
 
 }


### PR DESCRIPTION
See [JENKINS-53079](https://issues.jenkins-ci.org/browse/JENKINS-53709).

Despite being annotated with `@PersistIn(NONE)`, `ContextVariableSet`s appear to have been persisted as part of `CpsThread` since at least 2014. Marking that field transient produces a ton of test failures, so I am assuming that the annotation was just incorrect and that it is actually ok and intentional that they be serialized as part of the program.

However, the context variables need to be cleared after a `CpsBodyExecution` completes, or else the variables will still be persisted along with the CpsThread even if it is executing unrelated code. In particular, this persistence causes issues when the context variables include an executor, as `ExecutorPickle` will attempt to rehydrate the executor upon deserialization even if the current pipeline code does not require the executor at all.

@reviewbybees 