### PR TITLE
[JENKINS-40109] Make compilation errors serializable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsCompilationErrorsException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsCompilationErrorsException.java
@@ -1,0 +1,24 @@
+package org.jenkinsci.plugins.workflow.cps;
+
+import org.codehaus.groovy.control.MultipleCompilationErrorsException;
+import java.io.NotSerializableException;
+
+/**
+ * An exception that replaces Groovy's {@link MultipleCompilationErrorsException},
+ * because that is not serializable (which would, under certain circumstances,
+ * lead to the user being presented with a {@link NotSerializableException} instead
+ * of a compilation error -- see JENKINS-40109).
+ */
+public class CpsCompilationErrorsException extends RuntimeException {
+    public CpsCompilationErrorsException(MultipleCompilationErrorsException original) {
+        super(original.getMessage());
+        setStackTrace(original.getStackTrace());
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+
+    public static final long serialVersionUID = 1;
+}


### PR DESCRIPTION
See [JENKINS-40109](https://issues.jenkins-ci.org/browse/JENKINS-40109).

This PR makes compilation errors thrown by `LoadStep` serializable, and exposes an exception that is reused to fix similar errors when loading shared libraries in jenkinsci/workflow-cps-global-lib-plugin#54

@reviewbybees 