### PR TITLE
Making sure ArgumentsAction is attached in time for GraphListener.Synchronous notification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.1.0</git-plugin.version>
-        <workflow-support-plugin.version>2.17</workflow-support-plugin.version>
-        <scm-api-plugin.version>2.0.8</scm-api-plugin.version>
+        <workflow-support-plugin.version>2.21-rc578.95f4df4d2c32</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/75 -->
+        <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <groovy-cps.version>1.24</groovy-cps.version>
         <structs-plugin.version>1.15</structs-plugin.version>
     </properties>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/workflow-support-plugin/pull/75. Extracted from #252 as an independently releasable fix necessary to avoid regressing `StepNodeTest` (specifically, proper display of metasteps in the classic UI console) after changes in JEP-210. Specifically, as of https://github.com/jenkinsci/workflow-job-plugin/pull/27#discussion_r222405174 `FlowNode.getDisplayFunctionName` is called from within a synchronous listener. (Formerly this was an asynchronous listener, which sounds wrong but then again `copyLogs` was asynchronous too so who cared?) And this method call pays attention to `ArgumentsAction` to display, for example, `archiveArtifacts` rather than `step` (the generic function name of `CoreStep`). So we need to ensure that at least this basic metadata about the `FlowNode` is actually present by the time listeners are told about it. Some other metadata gets added later, like `LabelAction`, but we tolerate that—the new console UI renders the label via a `ConsoleNote`, potentially much later, at which point the label is known.