### PR TITLE
[JENKINS-53917] DescribableModel again treating ChoiceParameterDefinition.choices as an object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <workflow-support-plugin.version>2.21-beta-1</workflow-support-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <groovy-cps.version>1.24</groovy-cps.version>
-        <structs-plugin.version>1.15</structs-plugin.version>
+        <structs-plugin.version>1.17</structs-plugin.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <workflow-support-plugin.version>2.21-beta-1</workflow-support-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <groovy-cps.version>1.24</groovy-cps.version>
-        <structs-plugin.version>1.16</structs-plugin.version>
+        <structs-plugin.version>1.15</structs-plugin.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
See https://github.com/jenkinsci/structs-plugin/pull/42. Adjusts tests from #252 to handle a new core, whether using `structs` 1.15, 1.16, or upcoming 1.17.