### PR TITLE
JENKINS-55424 - Putting a space at the end of Script Path causes java.io.FileNotFoundException

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
@@ -73,7 +73,7 @@ public class CpsScmFlowDefinition extends FlowDefinition {
 
     @DataBoundConstructor public CpsScmFlowDefinition(SCM scm, String scriptPath) {
         this.scm = scm;
-        this.scriptPath = scriptPath;
+        this.scriptPath = scriptPath.trim();
     }
 
     public SCM getScm() {


### PR DESCRIPTION
See [JENKINS-55424](https://issues.jenkins-ci.org/browse/JENKINS-55424?jql=project%20%3D%20JENKINS%20AND%20assignee%20in%20(sagarailani)).

**Proposed Changelog entries**
- `Internal:` Trimmed Spaces from scriptPath String in the constructor.

**Submitter Checklist**

- [x] JIRA issue is well described

- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).

- ~~Appropriate autotests or explanation to why this change has no tests~~

- ~~For dependency updates: links to external changelogs and, if possible, full diffs~~

**Desired Reviewers**
@jglick 
@abayer 