### PR TITLE
Avoid logging RejectedExecutionException from blocksRestart

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -135,6 +135,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
@@ -939,7 +940,8 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                 return getCurrentExecutions(false).get(1, TimeUnit.SECONDS).stream().anyMatch(StepExecution::blocksRestart);
             } catch (Exception x) {
                 // TODO RestartListener.Default.isReadyToRestart can throw checked exceptions, but AsynchronousExecution.blocksRestart does not currently allow it
-                LOGGER.log(Level.WARNING, "Not blocking restart due to problem checking running steps in " + this, x);
+                Level level = x.getCause() instanceof RejectedExecutionException ? /* stray Executor past program end? */ Level.FINE : Level.WARNING;
+                LOGGER.log(level, "Not blocking restart due to problem checking running steps in " + this, x);
                 return false;
             }
         }


### PR DESCRIPTION
Apparently ci.jenkins.io was logging a ton of noise of the form

```
org.jenkinsci.plugins.workflow.cps.CpsFlowExecution blocksRestart
WARNING: Not blocking restart due to problem checking running steps in CpsFlowExecution[Owner[…]]
java.util.concurrent.ExecutionException: org.jenkinsci.remoting.util.ExecutorServiceUtils$FatalRejectedExecutionException: Cannot execute the command java.util.concurrent.FutureTask@…. The executor service is shutting down
	at com.google.common.util.concurrent.AbstractFuture$Sync.getValue(AbstractFuture.java:289)
	at com.google.common.util.concurrent.AbstractFuture$Sync.get(AbstractFuture.java:262)
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:91)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.blocksRestart(CpsFlowExecution.java:939)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$2.blocksRestart(WorkflowRun.java:372)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$2.displayCell(WorkflowRun.java:375)
	at hudson.model.Executor.isDisplayCell(Executor.java:668)
	at hudson.model.Computer.getDisplayExecutors(Computer.java:1012)
	at …
Caused by: org.jenkinsci.remoting.util.ExecutorServiceUtils$FatalRejectedExecutionException: Cannot execute the command java.util.concurrent.FutureTask@…. The executor service is shutting down
	at hudson.remoting.SingleLaneExecutorService.execute(SingleLaneExecutorService.java:108)
	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:112)
	at com.google.common.util.concurrent.ForwardingExecutorService.submit(ForwardingExecutorService.java:110)
	at jenkins.util.InterceptingExecutorService.submit(InterceptingExecutorService.java:49)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4.onSuccess(CpsFlowExecution.java:903)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4.onSuccess(CpsFlowExecution.java:899)
	at org.jenkinsci.plugins.workflow.support.concurrent.Futures$1.run(Futures.java:150)
	at com.google.common.util.concurrent.MoreExecutors$SameThreadExecutorService.execute(MoreExecutors.java:253)
	at com.google.common.util.concurrent.ExecutionList$RunnableExecutorPair.execute(ExecutionList.java:149)
	at com.google.common.util.concurrent.ExecutionList.add(ExecutionList.java:105)
	at com.google.common.util.concurrent.AbstractFuture.addListener(AbstractFuture.java:155)
	at org.jenkinsci.plugins.workflow.support.concurrent.Futures.addCallback(Futures.java:160)
	at org.jenkinsci.plugins.workflow.support.concurrent.Futures.addCallback(Futures.java:90)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.runInCpsVmThread(CpsFlowExecution.java:899)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.getCurrentExecutions(CpsFlowExecution.java:987)
	... 142 more
```

due to what I presume is some race condition or a zombie `Executor`. Since this method is called repeatedly and it is not especially critical, it should not be repeatedly logging.

More generally, we ought to create a custom logging system for Jenkins that automatically detects duplicate or near-duplicate log messages coming in rapid succession and coalesces them, allowing the code to be kept simpler. (We would not need to use the idiom of setting a flag when a given condition is first logged.)