### PR TITLE
[JENKINS-41791] Leaked closures from parallel & load steps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -360,11 +360,6 @@ class CpsBodyExecution extends BodyExecution {
             for (BodyExecutionCallback c : callbacks) {
                 c.onFailure(sc, t);
             }
-            synchronized (CpsBodyExecution.this) {
-                if (thread != null) {
-                    thread.popContextVariables();
-                }
-            }
             return Next.terminate(null);
         }
 
@@ -380,9 +375,6 @@ class CpsBodyExecution extends BodyExecution {
             StepContext sc = new CpsBodySubContext(context, en);
             for (BodyExecutionCallback c : callbacks) {
                 c.onSuccess(sc, o);
-            }
-            synchronized (CpsBodyExecution.this) {
-                thread.popContextVariables();
             }
             return Next.terminate(null);
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -324,10 +324,10 @@ class CpsBodyExecution extends BodyExecution {
     }
 
     private void setOutcome(Outcome o) {
-        if (bodyToUnexport != null && thread != null) {
-            thread.group.unexport(bodyToUnexport);
-        }
         synchronized (this) {
+            if (bodyToUnexport != null && thread != null) {
+                thread.group.unexport(bodyToUnexport);
+            }
             if (outcome!=null)
                 throw new IllegalStateException("Outcome is already set");
             this.outcome = o;
@@ -360,8 +360,8 @@ class CpsBodyExecution extends BodyExecution {
             for (BodyExecutionCallback c : callbacks) {
                 c.onFailure(sc, t);
             }
-            if (thread != null) {
-                synchronized (CpsBodyExecution.this) {
+            synchronized (CpsBodyExecution.this) {
+                if (thread != null) {
                     thread.popContextVariables();
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
@@ -282,11 +282,11 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
         if (body == null) {
             throw new IllegalStateException("There is no body to invoke");
         }
-        return newBodyInvoker(body);
+        return newBodyInvoker(body, false);
     }
 
-    public @Nonnull CpsBodyInvoker newBodyInvoker(@Nonnull BodyReference body) {
-        return new CpsBodyInvoker(this,body);
+    public @Nonnull CpsBodyInvoker newBodyInvoker(@Nonnull BodyReference body, boolean unexport) {
+        return new CpsBodyInvoker(this, body, unexport);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -97,7 +97,7 @@ public final class CpsThread implements Serializable {
     final FlowHead head;
 
     @Nullable
-    private ContextVariableSet contextVariables;
+    private final ContextVariableSet contextVariables;
 
     /**
      * If this thread is waiting for a {@link StepExecution} to complete (by invoking our callback),
@@ -133,14 +133,6 @@ public final class CpsThread implements Serializable {
 
     public ContextVariableSet getContextVariables() {
         return contextVariables;
-    }
-
-    /**
-     * Used to remove context variables after a {@link CpsBodyExecution} finishes executing so
-     * that those variables will no longer be persisted as part of the program. See JENKINS-53709.
-     */
-    void popContextVariables() {
-        contextVariables = null;
     }
 
     boolean isRunnable() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
@@ -3,7 +3,16 @@ package org.jenkinsci.plugins.workflow.cps;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
+import com.google.common.util.concurrent.FutureCallback;
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.Functions;
 import hudson.model.Action;
 import hudson.security.Permission;
 import java.io.IOException;
@@ -12,11 +21,19 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.Charsets;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
+import org.jenkinsci.plugins.workflow.pickles.Pickle;
+import org.jenkinsci.plugins.workflow.support.pickles.SingleTypedPickleFactory;
+import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.WebMethod;
 
 /**
  * Shows thread dump for {@link CpsFlowExecution}.
@@ -55,6 +72,58 @@ public final class CpsThreadDumpAction implements Action {
 
     public String getThreadDump() {
         return execution.getThreadDump().toString();
+    }
+
+    @WebMethod(name = "program.xml") public void doProgramDotXml(StaplerRequest req, StaplerResponse rsp) throws Exception {
+        Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
+        XStream xs = new XStream();
+        // Could not handle a general PickleFactory without doing something weird with XStream
+        // and there is no apparent way to make a high-priority generic Convertor delegate to others.
+        // Anyway the only known exceptions are ThrowablePickle, which we are unlikely to need,
+        // and RealtimeJUnitStep.Pickler which could probably be replaced by a DescribablePickleFactory
+        // (and anyway these Describable objects would be serialized fine by XStream, just not JBoss Marshalling).
+        for (SingleTypedPickleFactory<?> stpf : ExtensionList.lookup(SingleTypedPickleFactory.class)) {
+            Class<?> factoryType = Functions.getTypeParameter(stpf.getClass(), SingleTypedPickleFactory.class, 0);
+            xs.registerConverter(new Converter() {
+                @Override public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+                    Pickle p = stpf.writeReplace(source);
+                    assert p != null : "failed to pickle " + source + " using " + stpf;
+                    context.convertAnother(p);
+                }
+                @Override public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+                    throw new UnsupportedOperationException(); // unused
+                }
+                @SuppressWarnings("rawtypes")
+                @Override public boolean canConvert(Class type) {
+                    return factoryType.isAssignableFrom(type);
+                }
+            });
+        }
+        // Could also register a convertor for FlowExecutionOwner, though it seems harmless.
+        CompletableFuture<String> f = new CompletableFuture<>();
+        execution.runInCpsVmThread(new FutureCallback<CpsThreadGroup>() {
+            @Override public void onSuccess(CpsThreadGroup g) {
+                try {
+                    f.complete(xs.toXML(g));
+                } catch (Throwable t) {
+                    f.completeExceptionally(t);
+                }
+            }
+            @Override public void onFailure(Throwable t) {
+                f.completeExceptionally(t);
+            }
+        });
+        String xml;
+        try {
+            xml = f.get(1, TimeUnit.MINUTES);
+        } catch (Exception x) {
+            HttpResponses.error(x).generateResponse(req, rsp, this);
+            return;
+        }
+        rsp.setContentType("text/xml;charset=UTF-8");
+        PrintWriter pw = rsp.getWriter();
+        pw.print(xml);
+        pw.flush();
     }
 
     @Extension(optional=true) public static class PipelineThreadDump extends Component {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -209,6 +209,7 @@ public final class CpsThreadGroup implements Serializable {
         assertVmThread();
         int id = iota++;
         closures.put(id, body);
+        LOGGER.log(FINE, "exporting {0}", id);
         return new StaticBodyReference(id,body);
     }
 
@@ -227,7 +228,11 @@ public final class CpsThreadGroup implements Serializable {
     public void unexport(BodyReference ref) {
         assertVmThread();
         if (ref==null)      return;
-        closures.remove(ref.id);
+        if (closures.remove(ref.id) != null) {
+            LOGGER.log(FINE, "unexporting {0}", ref.id);
+        } else {
+            LOGGER.log(WARNING, "double unexport of {0}", ref.id);
+        }
     }
 
     /**
@@ -387,7 +392,7 @@ public final class CpsThreadGroup implements Serializable {
                 scripts.clear();
             }
             if (!closures.isEmpty()) {
-                LOGGER.log(WARNING, "Stale closures in {0}", execution);
+                LOGGER.log(WARNING, "Stale closures in {0}: {1}", new Object[] {execution, closures.keySet()});
                 closures.clear();
             }
             try {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -518,6 +518,7 @@ public final class CpsThreadGroup implements Serializable {
         }
     }
 
+    @CpsVmThreadOnly
     String asXml() {
         XStream xs = new XStream();
         // Could not handle a general PickleFactory without doing something weird with XStream

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -386,7 +386,10 @@ public final class CpsThreadGroup implements Serializable {
             if (scripts != null) {
                 scripts.clear();
             }
-            closures.clear();
+            if (!closures.isEmpty()) {
+                LOGGER.log(WARNING, "Stale closures in {0}", execution);
+                closures.clear();
+            }
             try {
                 Util.deleteFile(execution.getProgramDataFile());
             } catch (IOException x) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/LoadStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/LoadStepExecution.java
@@ -54,7 +54,7 @@ public class LoadStepExecution extends AbstractStepExecutionImpl {
 
         // execute body as another thread that shares the same head as this thread
         // as the body can pause.
-        cps.newBodyInvoker(t.getGroup().export(script))
+        cps.newBodyInvoker(t.getGroup().export(script), true)
                 .withDisplayName(step.getPath())
                 .withCallback(BodyExecutionCallback.wrap(cps))
                 .start(); // when the body is done, the load step is done

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepExecution.java
@@ -50,7 +50,7 @@ class ParallelStepExecution extends StepExecution {
         ResultHandler r = new ResultHandler(cps, this, parallelStep.isFailFast());
 
         for (Entry<String,Closure> e : parallelStep.closures.entrySet()) {
-            BodyExecution body = cps.newBodyInvoker(t.getGroup().export(e.getValue()))
+            BodyExecution body = cps.newBodyInvoker(t.getGroup().export(e.getValue()), true)
                     .withStartAction(new ParallelLabelAction(e.getKey()))
                     .withCallback(r.callbackFor(e.getKey()))
                     .start();

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction/index.jelly
@@ -42,6 +42,10 @@
       <pre class="console">
         ${td}
       </pre>
+
+      <l:hasPermission permission="${app.RUN_SCRIPTS}">
+        <a href="program.xml">Serialized program state</a>
+      </l:hasPermission>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpActionTest.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import static org.hamcrest.Matchers.*;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class CpsThreadDumpActionTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void doProgramDotXml() throws Exception {
+        WorkflowJob p = r.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("node {semaphore 'wait'}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait/1", b);
+        String xml = r.createWebClient().goTo(b.getUrl() + b.getAction(CpsThreadDumpAction.class).getUrlName() + "/program.xml", "text/xml").getWebResponse().getContentAsString();
+        System.out.println(xml);
+        assertThat(xml, containsString("SemaphoreStep"));
+    }
+
+}


### PR DESCRIPTION
[JENKINS-41791](https://issues.jenkins-ci.org/browse/JENKINS-41791)

Have you ever wondered what, exactly, is inside `program.dat`? Well I have. Alas, it is in a binary format used by a relatively obscure serialization framework, and I have never managed to write a translator to a human-readable format. So this `threadDump/program.xml` instead lets you use XStream to see the same information on a running program. You will be **shocked** at what you find after running `parallel` if you do not have this fix. Amends #245 & #83.