### PR TITLE
[JENKINS-34973] RejectedAccessException recorded more reliably

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.57-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/script-security-plugin/pull/243 -->
+            <version>1.57-rc826.6238edae5b95</version> <!-- TODO https://github.com/jenkinsci/script-security-plugin/pull/243 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.56</version>
+            <version>1.57-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/script-security-plugin/pull/243 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.57-rc826.6238edae5b95</version> <!-- TODO https://github.com/jenkinsci/script-security-plugin/pull/243 -->
+            <version>1.58</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/SandboxContinuable.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/SandboxContinuable.java
@@ -3,33 +3,17 @@ package org.jenkinsci.plugins.workflow.cps;
 import com.cloudbees.groovy.cps.Continuable;
 import com.cloudbees.groovy.cps.Outcome;
 import groovy.lang.GroovyShell;
-
-import java.io.IOException;
-import java.util.List;
-
-import hudson.Extension;
 import hudson.MarkupText;
-import hudson.console.ConsoleAnnotationDescriptor;
 import hudson.console.ConsoleAnnotator;
 import hudson.console.ConsoleNote;
-import jenkins.model.Jenkins;
-import org.jenkinsci.Symbol;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox;
-import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
-import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
-import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-
-import java.util.concurrent.Callable;
+import java.io.IOException;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox;
 
 /**
  * {@link Continuable} that executes code inside sandbox execution.
- *
- * @author Kohsuke Kawaguchi
  */
 class SandboxContinuable extends Continuable {
     private final CpsThread thread;
@@ -42,96 +26,39 @@ class SandboxContinuable extends Continuable {
     @SuppressWarnings("rawtypes")
     @Override
     public Outcome run0(final Outcome cn, final List<Class> categories) {
+        CpsFlowExecution e = thread.group.getExecution();
+        if (e == null) {
+            throw new IllegalStateException("JENKINS-50407: no loaded execution");
+        }
+        GroovyShell shell = e.getShell();
+        if (shell == null) {
+            throw new IllegalStateException("JENKINS-50407: no loaded shell in " + e);
+        }
+        GroovyShell trustedShell = e.getTrustedShell();
+        if (trustedShell == null) {
+            throw new IllegalStateException("JENKINS-50407: no loaded trustedShell in " + e);
+        }
+        GroovySandbox sandbox = new GroovySandbox();
         try {
-            CpsFlowExecution e = thread.group.getExecution();
-            if (e == null) {
-                throw new IllegalStateException("JENKINS-50407: no loaded execution");
-            }
-            GroovyShell shell = e.getShell();
-            if (shell == null) {
-                throw new IllegalStateException("JENKINS-50407: no loaded shell in " + e);
-            }
-            GroovyShell trustedShell = e.getTrustedShell();
-            if (trustedShell == null) {
-                throw new IllegalStateException("JENKINS-50407: no loaded trustedShell in " + e);
-            }
-            return GroovySandbox.runInSandbox(() -> {
-                    Outcome outcome = SandboxContinuable.super.run0(cn, categories);
-                    RejectedAccessException x = findRejectedAccessException(outcome.getAbnormal());
-                    if (x != null) {
-                        ScriptApproval.get().accessRejected(x, ApprovalContext.create());
-                        try {
-                            e.getOwner().getListener().getLogger().println(x.getMessage() + ". " +
-                                    ScriptApprovalNote.encodeTo(Messages.SandboxContinuable_ScriptApprovalLink()));
-                        } catch (IOException ex) {
-                            LOGGER.log(Level.WARNING, null, ex);
-                        }
-                    }
-                    return outcome;
-            }, new GroovyClassLoaderWhitelist(CpsWhitelist.get(),
-                    trustedShell.getClassLoader(),
-                    shell.getClassLoader()));
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new AssertionError(e);    // Callable doesn't throw anything
+            sandbox.withTaskListener(e.getOwner().getListener());
+        } catch (IOException x) {
+            LOGGER.log(Level.WARNING, null, x);
+        }
+        sandbox.withWhitelist(new GroovyClassLoaderWhitelist(CpsWhitelist.get(),
+            trustedShell.getClassLoader(),
+            shell.getClassLoader()));
+        try (GroovySandbox.Scope scope = sandbox.enter()) {
+            return SandboxContinuable.super.run0(cn, categories);
         }
     }
 
-    private static @CheckForNull RejectedAccessException findRejectedAccessException(@CheckForNull Throwable t) {
-        if (t == null) {
-            return null;
-        } else if (t instanceof RejectedAccessException) {
-            return (RejectedAccessException) t;
-        } else {
-            return findRejectedAccessException(t.getCause());
-        }
-    }
-
-    public static final class ScriptApprovalNote extends ConsoleNote {
+    @SuppressWarnings("rawtypes")
+    @Deprecated
+    /** @deprecated Only here for serial compatibility. */
+    private static final class ScriptApprovalNote extends ConsoleNote {
         private int length;
-
-        public ScriptApprovalNote(int length) {
-            this.length = length;
-        }
-
-        @Override
-        public ConsoleAnnotator annotate(Object context, MarkupText text, int charPos) {
-            if (Jenkins.get().hasPermission(Jenkins.RUN_SCRIPTS)) {
-                String url = "/" + ScriptApproval.get().getUrlName();
-
-                StaplerRequest req = Stapler.getCurrentRequest();
-
-                if (req!=null) {
-                    // if we are serving HTTP request, we want to use app relative URL
-                    url = req.getContextPath()+url;
-                } else {
-                    // otherwise presumably this is rendered for e-mails and other non-HTTP stuff
-                    url = Jenkins.get().getRootUrl()+url.substring(1);
-                }
-
-                text.addMarkup(charPos, charPos + length, "<a href='" + url + "'>", "</a>");
-            }
-
+        @Override public ConsoleAnnotator annotate(Object context, MarkupText text, int charPos) {
             return null;
-        }
-
-        public static String encodeTo(String text) {
-            try {
-                return new ScriptApprovalNote(text.length()).encode()+text;
-            } catch (IOException e) {
-                // impossible, but don't make this a fatal problem
-                LOGGER.log(Level.WARNING, "Failed to serialize "+ScriptApprovalNote.class,e);
-                return text;
-            }
-        }
-
-        @Extension
-        @Symbol("scriptApprovalLink")
-        public static class DescriptorImpl extends ConsoleAnnotationDescriptor {
-            public String getDisplayName() {
-                return "Script Approval Link";
-            }
         }
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
@@ -5,5 +5,4 @@ SnippetizerLink.GlobalsReferenceLink.displayName=Global Variables Reference
 SnippetizerLink.OnlineDocsLink.displayName=Online Documentation
 SnippetizerLink.ExamplesLink.displayName=Examples Reference
 SnippetizerLink.GDSLLink.displayName=IntelliJ IDEA GDSL
-SandboxContinuable.ScriptApprovalLink=Administrators can decide whether to approve or reject this signature.
 Pipeline.Syntax=Pipeline Syntax

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages_zh_CN.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages_zh_CN.properties
@@ -20,11 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Snippetizer.this_step_should_not_normally_be_used_in=\u8BE5\u6B65\u9AA4\u901A\u5E38\u4E0D\u5E94\u8BE5\u5728\u60A8\u7684\u811A\u672C\u4E2D\u4F7F\u7528\u3002\u8BF7\u53C2\u8003\u5E2E\u52A9\u67E5\u770B\u8BE6\u60C5\u3002
-SnippetizerLink.GeneratorLink.displayName=\u7247\u6BB5\u751F\u6210\u5668
-SnippetizerLink.StepReferenceLink.displayName=\u6B65\u9AA4\u53C2\u8003
-SnippetizerLink.GlobalsReferenceLink.displayName=\u5168\u5C40\u53D8\u91CF\u53C2\u8003
-SnippetizerLink.OnlineDocsLink.displayName=\u5728\u7EBF\u6587\u6863
+Snippetizer.this_step_should_not_normally_be_used_in=\u8be5\u6b65\u9aa4\u901a\u5e38\u4e0d\u5e94\u8be5\u5728\u60a8\u7684\u811a\u672c\u4e2d\u4f7f\u7528\u3002\u8bf7\u53c2\u8003\u5e2e\u52a9\u67e5\u770b\u8be6\u60c5\u3002
+SnippetizerLink.GeneratorLink.displayName=\u7247\u6bb5\u751f\u6210\u5668
+SnippetizerLink.StepReferenceLink.displayName=\u6b65\u9aa4\u53c2\u8003
+SnippetizerLink.GlobalsReferenceLink.displayName=\u5168\u5c40\u53d8\u91cf\u53c2\u8003
+SnippetizerLink.OnlineDocsLink.displayName=\u5728\u7ebf\u6587\u6863
 SnippetizerLink.GDSLLink.displayName=IntelliJ IDEA GDSL
-SandboxContinuable.ScriptApprovalLink=\u7BA1\u7406\u5458\u53EF\u4EE5\u51B3\u5B9A\u662F\u5426\u5141\u8BB8\u6216\u8005\u62D2\u7EDD\u8BE5\u7B7E\u540D\u3002
-Pipeline.Syntax=\u6D41\u6C34\u7EBF\u8BED\u6CD5
+Pipeline.Syntax=\u6d41\u6c34\u7ebf\u8bed\u6cd5

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -25,24 +25,18 @@
 package org.jenkinsci.plugins.workflow.cps;
 
 import com.cloudbees.groovy.cps.CpsTransformer;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.html.DomNodeUtil;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.Functions;
 import hudson.model.Computer;
 import hudson.model.Executor;
-import hudson.model.Item;
 import hudson.model.Result;
 
 import java.util.logging.Level;
 
-import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
 
 import org.junit.Assert;
@@ -54,9 +48,7 @@ import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
-import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
 public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
 
@@ -180,10 +172,6 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
 
     @Test
     public void sandboxInvokerUsed() throws Exception {
-        jenkins.jenkins.setSecurityRealm(jenkins.createDummySecurityRealm());
-        jenkins.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
-                grant(Jenkins.RUN_SCRIPTS, Jenkins.READ, Item.READ).everywhere().to("runScriptsUser").
-                grant(Jenkins.READ, Item.READ).everywhere().to("otherUser"));
         WorkflowJob job = jenkins.jenkins.createProject(WorkflowJob.class, "p");
         job.setDefinition(new CpsFlowDefinition("[a: 1, b: 2].collectEntries { k, v ->\n" +
                 "  Jenkins.getInstance()\n" +
@@ -193,27 +181,6 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
         WorkflowRun r = jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
         jenkins.assertLogContains("org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance", r);
         jenkins.assertLogContains("Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance. " + org.jenkinsci.plugins.scriptsecurity.scripts.Messages.ScriptApprovalNote_message(), r);
-
-        // TODO push these tests down into script-security
-        JenkinsRule.WebClient wc = jenkins.createWebClient();
-
-        wc.login("runScriptsUser");
-        // make sure we see the annotation for the RUN_SCRIPTS user.
-        HtmlPage rsp = wc.getPage(r, "console");
-        assertEquals(1, DomNodeUtil.selectNodes(rsp, "//A[@href='" + jenkins.contextPath + "/scriptApproval']").size());
-
-        // make sure raw console output doesn't include the garbage and has the right message.
-        TextPage raw = (TextPage)wc.goTo(r.getUrl()+"consoleText","text/plain");
-        assertThat(raw.getContent(), containsString(" getInstance. " + org.jenkinsci.plugins.scriptsecurity.scripts.Messages.ScriptApprovalNote_message()));
-
-        wc.login("otherUser");
-        // make sure we don't see the link for the other user.
-        HtmlPage rsp2 = wc.getPage(r, "console");
-        assertEquals(0, DomNodeUtil.selectNodes(rsp2, "//A[@href='" + jenkins.contextPath + "/scriptApproval']").size());
-
-        // make sure raw console output doesn't include the garbage and has the right message.
-        TextPage raw2 = (TextPage)wc.goTo(r.getUrl()+"consoleText","text/plain");
-        assertThat(raw2.getContent(), containsString(" getInstance. " + org.jenkinsci.plugins.scriptsecurity.scripts.Messages.ScriptApprovalNote_message()));
     }
 
     @Issue("SECURITY-551")

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -192,8 +192,9 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
 
         WorkflowRun r = jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
         jenkins.assertLogContains("org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance", r);
-        jenkins.assertLogContains("Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance. " + Messages.SandboxContinuable_ScriptApprovalLink(), r);
+        jenkins.assertLogContains("Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance. " + org.jenkinsci.plugins.scriptsecurity.scripts.Messages.ScriptApprovalNote_message(), r);
 
+        // TODO push these tests down into script-security
         JenkinsRule.WebClient wc = jenkins.createWebClient();
 
         wc.login("runScriptsUser");
@@ -203,7 +204,7 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
 
         // make sure raw console output doesn't include the garbage and has the right message.
         TextPage raw = (TextPage)wc.goTo(r.getUrl()+"consoleText","text/plain");
-        assertThat(raw.getContent(), containsString(" getInstance. " + Messages.SandboxContinuable_ScriptApprovalLink()));
+        assertThat(raw.getContent(), containsString(" getInstance. " + org.jenkinsci.plugins.scriptsecurity.scripts.Messages.ScriptApprovalNote_message()));
 
         wc.login("otherUser");
         // make sure we don't see the link for the other user.
@@ -212,7 +213,7 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
 
         // make sure raw console output doesn't include the garbage and has the right message.
         TextPage raw2 = (TextPage)wc.goTo(r.getUrl()+"consoleText","text/plain");
-        assertThat(raw2.getContent(), containsString(" getInstance. " + Messages.SandboxContinuable_ScriptApprovalLink()));
+        assertThat(raw2.getContent(), containsString(" getInstance. " + org.jenkinsci.plugins.scriptsecurity.scripts.Messages.ScriptApprovalNote_message()));
     }
 
     @Issue("SECURITY-551")

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SandboxContinuableTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SandboxContinuableTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import hudson.model.Result;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class SandboxContinuableTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Ignore("TODO no aporovals, and no approval link")
+    @Issue("JENKINS-40333")
+    @Test public void scriptApproval() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("catchError {Jenkins.instance}", true));
+        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        r.assertLogContains(RejectedAccessException.class.getName() + ": Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance", b);
+        assertEquals(Collections.singleton("staticMethod jenkins.model.Jenkins getInstance"),
+            ScriptApproval.get().getPendingSignatures().stream().map(ps -> ps.signature).collect(Collectors.toSet()));
+        r.assertLogContains(Messages.SandboxContinuable_ScriptApprovalLink(), b);
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SandboxContinuableTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SandboxContinuableTest.java
@@ -34,7 +34,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.ClassRule;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
@@ -46,8 +45,7 @@ public class SandboxContinuableTest {
 
     @Rule public JenkinsRule r = new JenkinsRule();
 
-    @Ignore("TODO no aporovals, and no approval link")
-    @Issue("JENKINS-40333")
+    @Issue("JENKINS-34973")
     @Test public void scriptApproval() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("catchError {Jenkins.instance}", true));
@@ -55,7 +53,7 @@ public class SandboxContinuableTest {
         r.assertLogContains(RejectedAccessException.class.getName() + ": Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance", b);
         assertEquals(Collections.singleton("staticMethod jenkins.model.Jenkins getInstance"),
             ScriptApproval.get().getPendingSignatures().stream().map(ps -> ps.signature).collect(Collectors.toSet()));
-        r.assertLogContains(Messages.SandboxContinuable_ScriptApprovalLink(), b);
+        r.assertLogContains(org.jenkinsci.plugins.scriptsecurity.scripts.Messages.ScriptApprovalNote_message(), b);
     }
 
 }


### PR DESCRIPTION
[JENKINS-34973](https://issues.jenkins-ci.org/browse/JENKINS-34973): `ScriptApproval.accessRejected` not being called reliably. Downstream of https://github.com/jenkinsci/script-security-plugin/pull/243.