### PR TITLE
Avoid Groovy interpolation in samples

### DIFF
--- a/src/main/js/samples.js
+++ b/src/main/js/samples.js
@@ -67,10 +67,12 @@ samples.push({
         "   }\n" +
         "   stage('Build') {\n" +
         "      // Run the maven build\n" +
-        "      if (isUnix()) {\n" +
-        "         sh \"'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean package\"\n" +
-        "      } else {\n" +
-        "         bat(/\"${mvnHome}\\bin\\mvn\" -Dmaven.test.failure.ignore clean package/)\n" +
+        "      withEnv([\"MVN_HOME=$mvnHome\"]) {\n" +
+        "         if (isUnix()) {\n" +
+        "            sh '\"$MVN_HOME/bin/mvn\" -Dmaven.test.failure.ignore clean package'\n" +
+        "         } else {\n" +
+        "            bat(/\"%MVN_HOME%\\bin\\mvn\" -Dmaven.test.failure.ignore clean package/)\n" +
+        "         }\n" +
         "      }\n" +
         "   }\n" +
         "   stage('Results') {\n" +


### PR DESCRIPTION
For a variety of reasons it is poor form to use Groovy interpolation in the arguments to `sh` etc. steps. Better to pass in environment variables and expand those in the host shell.

Tested on both Linux and Windows 10 using a Maven installation located in a directory with a space in the name, to exercise the quoting logic a bit.