### PR TITLE
More graceful handling in PipelineTimings on incomplete/broken builds

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1901,7 +1901,14 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                             if (run instanceof FlowExecutionOwner.Executable) {
                                 FlowExecutionOwner owner = ((FlowExecutionOwner.Executable) run).asFlowExecutionOwner();
                                 if (owner != null) {
-                                    FlowExecution exec = owner.get();
+                                    FlowExecution exec;
+                                    try {
+                                        exec = owner.get();
+                                    } catch (IOException x) {
+                                        pw.println("No timings available for " + run + ": " + x);
+                                        pw.println();
+                                        continue;
+                                    }
                                     if (exec instanceof CpsFlowExecution) {
                                         Map<String, Long> timings = ((CpsFlowExecution) exec).timings;
                                         if (timings != null) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -257,6 +257,9 @@ public class CpsFlowExecutionTest {
                 WorkflowRun b = p.getLastBuild();
                 SemaphoreStep.success("wait/1", null);
                 story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b));
+                while (logger.getRecords().isEmpty()) {
+                    Thread.sleep(100); // apparently a race condition between CpsVmExecutorService.tearDown and WorkflowRun.finish
+                }
                 assertThat(logger.getRecords(), Matchers.hasSize(Matchers.equalTo(1)));
                 assertEquals(CpsFlowExecution.TimingKind.values().length, ((CpsFlowExecution) b.getExecution()).timings.keySet().size());
             }


### PR DESCRIPTION
While reproducing JENKINS-43802 I happened to have a build which had failed during library checkout, prior to the program starting, and noticed in the log:

```
… com.cloudbees.jenkins.support.SupportPlugin writeBundle
WARNING: Could not attach ''nodes/master/pipeline-timings.txt'' to support bundle
java.io.IOException: …/…/master #1 did not yet start
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.get(WorkflowRun.java:928)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$PipelineTimings$1.writeTo(CpsFlowExecution.java:1904)
```

This should not break generation of the entire bundle entry, but merely print a note for that build.