### PR TITLE
Test flake

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpTest.java
@@ -119,7 +119,7 @@ public class CpsThreadDumpTest {
     @Test public void nativeMethods() throws Exception {
         p.setDefinition(new CpsFlowDefinition(
             "@NonCPS def untransformed() {Thread.sleep(Long.MAX_VALUE)}\n" +
-            "def helper() {echo 'sleeping'; /* flush output */ sleep 1; untransformed()}\n" +
+            "def helper() {echo 'sleeping'; untransformed()}\n" +
             "helper()", false));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         CpsFlowExecution e = (CpsFlowExecution) b.getExecutionPromise().get();


### PR DESCRIPTION
In #211 CI was sometimes getting

```
java.lang.AssertionError: expected:<[WorkflowScript.helper(WorkflowScript:2), WorkflowScript.run(WorkflowScript:3)]> but was:<[DSL.sleep(sleeping for another 0.99 sec), WorkflowScript.helper(WorkflowScript:2), WorkflowScript.run(WorkflowScript:3)]>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadDumpTest.assertStackTrace(CpsThreadDumpTest.java:140)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadDumpTest.nativeMethods(CpsThreadDumpTest.java:132)
```

and I saw some similar local failures. I think this should solve it. I cannot now recall why I thought the `sleep` was necessary to flush output, anyway—maybe to work around some pre-JEP-210 logging bug.