### PR TITLE
[JENKINS-56890] CpsThreadGroup: use synchronizedNavigableMap

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -102,7 +102,7 @@ public final class CpsThreadGroup implements Serializable {
     /**
      * All the member threads by their {@link CpsThread#id}
      */
-    final NavigableMap<Integer,CpsThread> threads = new TreeMap<Integer, CpsThread>();
+    final NavigableMap<Integer,CpsThread> threads = Collections.synchronizedNavigableMap(new TreeMap<Integer, CpsThread>());
 
     /**
      * Unique thread ID generator.


### PR DESCRIPTION
since TreeMap is NOT a synchronized collection (as called out, rather loudly, in [the TreeMap documentation](https://docs.oracle.com/javase/8/docs/api/java/util/TreeMap.html)).

see: https://issues.jenkins-ci.org/browse/JENKINS-56890

NOTE: I have not tested this change (as I have no experience whatsoever with Jenkins development) and, as such, do not claim that it fixes the issue mentioned above.

However, `threads` _is_ currently being manipulated in a non-threadsafe manner in `CpsThreadGroup.java`, and though this change alone does not exhaustively address that (as iteration over the collection's views is still being performed without explicit synchronization ([for example](https://github.com/wdforson/workflow-cps-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java#L345))), I don't see how it could do anything but help.