### PR TITLE
[JENKINS-56890] Make access to CpsThreadGroup.threads thread-safe

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -208,7 +208,7 @@ class CpsBodyExecution extends BodyExecution {
                     List<StepExecution> executions = new ArrayList<>();
                     // cf. trick in CpsFlowExecution.getCurrentExecutions(true)
                     Map<FlowHead, CpsThread> m = new LinkedHashMap<>();
-                    for (CpsThread t : g.threads.values()) {
+                    for (CpsThread t : g.getThreads()) {
                         m.put(t.head, t);
                     }
                     for (CpsThread t : m.values()) {
@@ -260,7 +260,7 @@ class CpsBodyExecution extends BodyExecution {
                 public void onSuccess(CpsThreadGroup g) {
                     // Similar to getCurrentExecutions but we want the raw CpsThread, not a StepExecution; cf. CpsFlowExecution.interrupt
                     Map<FlowHead, CpsThread> m = new LinkedHashMap<>();
-                    for (CpsThread t : thread.group.threads.values()) {
+                    for (CpsThread t : thread.group.getThreads()) {
                         m.put(t.head, t);
                     }
                     for (CpsThread t : Iterators.reverse(ImmutableList.copyOf(m.values()))) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -993,7 +993,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                     // to exclude outer StepExecutions, first build a map by FlowHead
                     // younger threads with their StepExecutions will overshadow old threads, leaving inner-most threads alone.
                     Map<FlowHead, StepExecution> m = new LinkedHashMap<FlowHead, StepExecution>();
-                    for (CpsThread t : g.threads.values()) {
+                    for (CpsThread t : g.getThreads()) {
                         StepExecution e = t.getStep();
                         if (e != null) {
                             m.put(t.head, e);
@@ -1002,7 +1002,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                     r.set(ImmutableList.copyOf(m.values()));
                 } else {
                     List<StepExecution> es = new ArrayList<StepExecution>();
-                    for (CpsThread t : g.threads.values()) {
+                    for (CpsThread t : g.getThreads()) {
                         StepExecution e = t.getStep();
                         if (e != null) {
                             es.add(e);
@@ -1142,7 +1142,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             public void onSuccess(CpsThreadGroup g) {
                 // don't touch outer ones. See JENKINS-26148
                 Map<FlowHead, CpsThread> m = new LinkedHashMap<>();
-                for (CpsThread t : g.threads.values()) {
+                for (CpsThread t : g.getThreads()) {
                     m.put(t.head, t);
                 }
                 // for each inner most CpsThread, from young to old...

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
@@ -215,17 +215,12 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
 
     /**
      * Returns the thread that is executing this step.
-     * Needs to take {@link CpsThreadGroup} as a parameter to prove that the caller is in CpsVmThread.
      *
      * @return
      *      null if the thread has finished executing.
      */
     @CheckForNull CpsThread getThread(CpsThreadGroup g) {
-        CpsThread thread = g.threads.get(threadId);
-        if (thread == null) {
-            LOGGER.log(Level.FINE, "no thread " + threadId + " among " + g.threads.keySet(), new IllegalStateException());
-        }
-        return thread;
+        return g.getThread(threadId);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -245,7 +245,7 @@ public final class CpsThread implements Serializable {
      * Cannot be {@code this}.
      */
     @CheckForNull CpsThread getNextInner() {
-        for (CpsThread t : group.threads.values()) {
+        for (CpsThread t : group.getThreads()) {
             if (t.id <= this.id) continue;
             if (t.head==this.head)  return t;
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDump.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDump.java
@@ -128,7 +128,7 @@ public final class CpsThreadDump {
     public static CpsThreadDump from(CpsThreadGroup g) {
         // all the threads that share the same head form a logically single thread
         Map<FlowHead, List<CpsThread>> m = new LinkedHashMap<FlowHead,List<CpsThread>>();
-        for (CpsThread t : g.threads.values()) {
+        for (CpsThread t : g.getThreads()) {
             List<CpsThread> l = m.get(t.head);
             if (l==null)    m.put(t.head, l = new ArrayList<CpsThread>());
             l.add(t);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDump.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDump.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 
@@ -128,8 +127,12 @@ public final class CpsThreadDump {
 
     public static CpsThreadDump from(CpsThreadGroup g) {
         // all the threads that share the same head form a logically single thread
-        Map<FlowHead, List<CpsThread>> m = g.safelyApplyToThreads(threads -> threads.stream()
-                .collect(Collectors.groupingBy(thread -> thread.head, LinkedHashMap::new, Collectors.toList())));
+        Map<FlowHead, List<CpsThread>> m = new LinkedHashMap<FlowHead,List<CpsThread>>();
+        for (CpsThread t : g.getThreads()) {
+            List<CpsThread> l = m.get(t.head);
+            if (l==null)    m.put(t.head, l = new ArrayList<CpsThread>());
+            l.add(t);
+        }
 
         CpsThreadDump td = new CpsThreadDump();
         for (List<CpsThread> e : m.values())

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -102,7 +102,7 @@ public final class CpsThreadGroup implements Serializable {
     /**
      * All the member threads by their {@link CpsThread#id}
      */
-    final NavigableMap<Integer,CpsThread> threads = new TreeMap<Integer, CpsThread>();
+    final NavigableMap<Integer,CpsThread> threads = Collections.synchronizedNavigableMap(new TreeMap<Integer, CpsThread>());
 
     /**
      * Unique thread ID generator.


### PR DESCRIPTION
See [JENKINS-56890](https://issues.jenkins-ci.org/browse/JENKINS-56890). Subsumes #287 (CC @wdforson).

Assuming that the issue has to do with reading from the map while it is being updated, this PR makes `CpsThreadGroup.thread` private and wraps it using `Collections.unmodifiableNavigableMap` to synchronize reads and writes (if the issue is instead a timing issue and the value is not yet in the map when the lookup occurs then this wouldn't help, but that seems less likely to me). All existing mutation occurs only on the CPS VM thread, so I think that as long as all iteration and read accesses that happen off of the CPS VM thread are synchronized we are safe. I was not able to reproduce the reported issue in a test, but here is the basis of what I was using to try to reproduce the issue:

```java
@Issue("JENKINS-56890")
@Test public void generalNonBlockingStepExecutionThreadSafety() {
    rr.then(r -> {
        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "demo");
        p.setDefinition(new CpsFlowDefinition(
        // I tried various combinations of hundreds of parallel/sequential blocks
        // with synchronous and asynchronous bodies but was unable to reproduce
        // the issue.
                "nonBlocking {\n" +
                "  echo 'foo'\n" +
                "}\n", true));
        WorkflowRun b = r.buildAndAssertSuccess(p);
        r.assertLogNotContains("cannot find current thread", b);
    });
}

/**
 * Step that uses {@link StepContext} in GeneralNonBlockingStepExecution.TailCall while not on the CPS VM thread
 * to demonstrate a concurrency issue in {@link CpsStepContext}.
 */
public static class NonBlockingStep extends Step {
    @DataBoundConstructor
    public NonBlockingStep() { }
    @Override
    public StepExecution start(StepContext context) throws Exception {
        return new Execution(context);
    }
    private static class Execution extends GeneralNonBlockingStepExecution {
        public Execution(StepContext context) {
            super(context);
        }
        @Override
        public boolean start() throws Exception {
            run(() -> {
                getContext().newBodyInvoker().withCallback(new Callback()).start();
            });
            return false;
        }
        private final class Callback extends TailCall {
            @Override
            protected void finished(StepContext context) throws Exception {
                Run<?, ?> run = context.get(Run.class);
                TaskListener listener = context.get(TaskListener.class);
                //listener.getLogger().println("Finished executing nonBlockingStep in " + run);
            }
        }
    }
    @TestExtension("generalNonBlockingStepExecutionThreadSafety")
    public static class DescriptorImpl extends StepDescriptor {
        @Override
        public String getFunctionName() {
            return "nonBlocking";
        }
        @Override
        public boolean takesImplicitBlockArgument() {
            return true;
        }
        @Override
        public Set<? extends Class<?>> getRequiredContext() {
            return ImmutableSet.of(Run.class, TaskListener.class);
        }
    }
}
```