### PR TITLE
Run workflow cps with Caffeine cache and unignore related tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.58</version>
+            <version>1.60-rc849.f3930bb98d3b</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.60-rc849.f3930bb98d3b</version>
+            <version>1.60-rc860.42e743108fee</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.60-rc860.42e743108fee</version>
+            <version>1.61</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -85,8 +85,6 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
      * Verify that we kill endlessly recursive CPS code cleanly.
      */
     @Test
-    @Ignore /** Intermittent failures because triggers a longstanding unrelated SandboxResolvingClassloader bug
-     resolved in https://github.com/jenkinsci/script-security-plugin/pull/160 */
     public void endlessRecursion() throws Exception {
         Assume.assumeTrue(!Functions.isWindows());  // Sidestep false failures specific to a few Windows build environments.
         String script = "def getThing(){return thing == null}; \n" +
@@ -115,8 +113,6 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
      *  we don't trigger other forms of failure with the StackOverflowError.
      */
     @Test
-    @Ignore  /** Intermittent failures because triggers a longstanding unrelated SandboxResolvingClassloader bug
-                 resolved in https://github.com/jenkinsci/script-security-plugin/pull/160 */
     public void endlessRecursionNonCPS() throws Exception {
         Assume.assumeTrue(!Functions.isWindows());  // Sidestep false failures specific to a few Windows build environments.
 


### PR DESCRIPTION
Test-only for https://github.com/jenkinsci/script-security-plugin/pull/160
