### PR TITLE
Add pipeline source: HTTP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,11 @@
             <version>2.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
+            <version>4.5.5-3.0</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition.java
@@ -1,0 +1,164 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.*;
+import hudson.scm.SCM;
+import hudson.scm.SCMDescriptor;
+import hudson.security.ACL;
+import hudson.slaves.WorkspaceList;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
+import org.jenkinsci.plugins.workflow.flow.*;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.JOB;
+
+@PersistIn(JOB)
+public class CpsHttpFlowDefinition extends FlowDefinition {
+
+    private final String scriptUrl;
+    private final String credentialsId;
+    private final int retryCount;
+
+    @DataBoundConstructor public CpsHttpFlowDefinition(String scriptUrl, String credentialsId, int retryCount) {
+        this.scriptUrl = scriptUrl.trim();
+        this.credentialsId = credentialsId;
+        this.retryCount = retryCount;
+    }
+
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    public String getScriptUrl() {
+        return scriptUrl;
+    }
+
+    public int getRetryCount() {
+        return retryCount;
+    }
+
+
+    @Override
+    public CpsFlowExecution create(FlowExecutionOwner owner, TaskListener listener, List<? extends Action> actions)
+            throws Exception {
+        URL url = new URL(scriptUrl);
+        listener.getLogger().println("Fetching pipeline from "+ scriptUrl);
+        int count = 0;
+        int maxTries = retryCount + 1;
+
+        while(true) {
+            try{
+                HttpURLConnection con = (HttpURLConnection) url.openConnection();
+                con.setRequestMethod("GET");
+
+                if (!StringUtils.isBlank(credentialsId)) {
+                    UsernamePasswordCredentials credentials = (UsernamePasswordCredentials) CredentialsMatchers.firstOrNull(
+                            CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class, Jenkins.getInstance(),
+                                    ACL.SYSTEM, Collections.emptyList()),
+                            CredentialsMatchers.withId(credentialsId));
+                    if(credentials != null) {
+                        String encoded = Base64.getEncoder().encodeToString((credentials.getUsername()+":"+credentials.getPassword()).getBytes(StandardCharsets.UTF_8));
+                        con.setRequestProperty("Authorization", "Basic "+encoded);
+                    }
+                }
+
+
+
+                BufferedReader rd = new BufferedReader(new InputStreamReader(con.getInputStream()));
+                StringBuilder response = new StringBuilder();
+                String line;
+                while ((line = rd.readLine()) != null) {
+                    response.append(line);
+                    response.append(System.lineSeparator());
+                }
+
+                rd.close();
+                con.disconnect();
+
+
+                Queue.Executable queueExec = owner.getExecutable();
+                FlowDurabilityHint hint = (queueExec instanceof Run)
+                        ? DurabilityHintProvider.suggestedFor(((Run) queueExec).getParent())
+                        : GlobalDefaultFlowDurabilityLevel.getDefaultDurabilityHint();
+                return new CpsFlowExecution(response.toString(), true, owner, hint);
+            } catch(Exception e) {
+                if(++count >= maxTries) throw e;
+                listener.getLogger().printf("Caught exception while fetching %2$s:%1$s %3$s%1$sRetrying%1$s", System.lineSeparator(),scriptUrl, e.getMessage());
+            }
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends FlowDefinitionDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Pipeline script from HTTP";
+        }
+
+        public Collection<? extends SCMDescriptor<?>> getApplicableDescriptors() {
+            StaplerRequest req = Stapler.getCurrentRequest();
+            Job<?, ?> job = req != null ? req.findAncestorObject(Job.class) : null;
+            return SCM._for(job);
+        }
+
+
+        public ListBoxModel doFillCredentialsIdItems(@QueryParameter String scriptUrl, @QueryParameter String credentialsId) {
+            return new StandardListBoxModel().includeEmptyValue().includeMatchingAs(ACL.SYSTEM,
+                    Jenkins.getInstance(), StandardUsernamePasswordCredentials.class,
+                    URIRequirementBuilder.fromUri(scriptUrl).build(),
+                    CredentialsMatchers.always()).includeCurrentValue(credentialsId);
+        }
+
+
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition.java
@@ -113,7 +113,7 @@ import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.
                     }
                 }
 
-                BufferedReader rd = new BufferedReader(new InputStreamReader(con.getInputStream()));
+                BufferedReader rd = new BufferedReader(new InputStreamReader(con.getInputStream(), "UTF-8"));
                 StringBuilder response = new StringBuilder();
                 String line;
                 while ((line = rd.readLine()) != null) {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition/config.jelly
@@ -2,7 +2,7 @@
 <!--
 The MIT License
 
-Copyright 2019 Cloudbees Inc.
+Copyright 2019 Coveo Solutions Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition/config.jelly
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2019 Cloudbees Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:st="jelly:stapler">
+    <f:entry field="scriptUrl" title="${%Script URL}">
+        <f:textbox default="https://example.com/Jenkinsfile"/>
+    </f:entry>
+    <f:entry title="${%GET Retry Count}" field="retryCount">
+      <f:number clazz="number" name="retryCount" value="${it.retryCount}" min="0" step="1"/>
+    </f:entry>
+    <f:entry field="credentialsId" title="${%Credentials}" description="Basic auth credentials">
+        <c:select />
+    </f:entry>
+    <f:block>
+        <a href="pipeline-syntax" target="_blank">${%Pipeline Syntax}</a>
+    </f:block>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition/help-retryCount.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition/help-retryCount.html
@@ -1,0 +1,3 @@
+<div>
+    The number of times Jenkins will try again to fetch the pipeline if the GET operation fails
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition/help-scriptUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition/help-scriptUrl.html
@@ -1,4 +1,4 @@
 <div>
-    Full URL to your script
+    Full URL to your script.
     Note that it will always be run inside a Groovy sandbox.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition/help-scriptUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinition/help-scriptUrl.html
@@ -1,0 +1,4 @@
+<div>
+    Full URL to your script
+    Note that it will always be run inside a Groovy sandbox.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinitionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinitionTest.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import hudson.model.Result;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+
+public class CpsHttpFlowDefinitionTest {
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void testRunJenkinsHomePageAsPipeline() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        CpsHttpFlowDefinition def = new CpsHttpFlowDefinition(r.jenkins.getRootUrl(), "", 3);
+        p.setDefinition(def);
+        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        r.assertLogContains("unexpected token", b);
+    }
+
+    @Test public void testRetryCount() throws Exception {
+        String scriptUrl = "https://bad-website-jenkins-test.com/Jenkinsfile";
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        CpsHttpFlowDefinition def = new CpsHttpFlowDefinition(scriptUrl, "", 3);
+        p.setDefinition(def);
+        WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        r.assertLogContains("Caught exception while fetching " + scriptUrl, b);
+        assertEquals(3, StringUtils.countMatches(r.getLog(b), "Retrying"));
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinitionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsHttpFlowDefinitionTest.java
@@ -68,8 +68,7 @@ public class CpsHttpFlowDefinitionTest {
         CpsHttpFlowDefinition def = new CpsHttpFlowDefinition(scriptUrl, 3);
         p.setDefinition(def);
         WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
-        r.assertLogContains("Caught exception while fetching " + scriptUrl, b);
-        assertEquals(3, StringUtils.countMatches(r.getLog(b), "Retrying"));
+        assertEquals(3, StringUtils.countMatches(r.getLog(b), "Retrying get pipeline"));
     }
 
 }


### PR DESCRIPTION
Allows fetching a Jenkinsfile from a given HTTP URL
Basic auth credentials can be set
Usecases:
- SCM Host APIs provide full files (faster than checkout)
- Amazon S3 (or other cloud file storage providers)

![image](https://user-images.githubusercontent.com/29210090/59051502-0b083700-885b-11e9-8987-78f4c69f65a0.png)
