### PR TITLE
[JENKINS-58501] Add whitelist for exotic cases throwing CPS mismatch warning logs 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/AbstractMismatchWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/AbstractMismatchWhitelist.java
@@ -1,0 +1,16 @@
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import hudson.ExtensionPoint;
+import hudson.ExtensionList;
+import jenkins.model.Jenkins; 
+
+public abstract class AbstractMismatchWhitelist implements ExtensionPoint {
+    public Boolean ignoreCpsMismatch(String expectedReceiver, String expectedMethodName, String actualReceiver, String actualMethodName){
+        return false; 
+    }
+
+    public static ExtensionList<AbstractMismatchWhitelist> all(){
+        return Jenkins.getActiveInstance().getExtensionList(AbstractMismatchWhitelist.class);
+    }
+}


### PR DESCRIPTION
As described in [JENKINS-58501](https://issues.jenkins-ci.org/browse/JENKINS-58501), the [Templating Engine Plugin](https://plugins.jenkins.io/templating-engine) utilizes metaprogramming techniques to control program flow. 

The introduction of logging CPS mismatches has flooded the console log with false positive warnings that come about from how the plugin executes pipeline code. 

Rather than try to handle every edge case that may throw a false positive for the CPS mismatch warning logs, I think it would be a good approach to add a ``AbstractMismatchWhitelist`` extension that allows plugins to register their own edge cases that should prevent the log from being printed. 

Tests have been added that confirm the warning log is printed for cases not caught by a registered extension of the whitelist, and that mismatches that are caught prevent the log from being printed. 