### PR TITLE
[JENKINS-33217] Pass TaskListener to DescribableModel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <groovy-cps.version>1.29</groovy-cps.version>
-        <structs-plugin.version>1.20-rc294.782175d40f81</structs-plugin.version> <!-- TODO https://github.com/jenkinsci/structs-plugin/pull/49 -->
+        <structs-plugin.version>1.20-rc297.69da1904839b</structs-plugin.version> <!-- TODO https://github.com/jenkinsci/structs-plugin/pull/49 -->
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <groovy-cps.version>1.29</groovy-cps.version>
-        <structs-plugin.version>1.20-rc297.69da1904839b</structs-plugin.version> <!-- TODO https://github.com/jenkinsci/structs-plugin/pull/49 -->
+        <structs-plugin.version>1.20</structs-plugin.version>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <groovy-cps.version>1.29</groovy-cps.version>
-        <structs-plugin.version>1.18</structs-plugin.version>
+        <structs-plugin.version>1.20-rc293.e3faccddadc2</structs-plugin.version>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <groovy-cps.version>1.29</groovy-cps.version>
-        <structs-plugin.version>1.20-rc293.e3faccddadc2</structs-plugin.version>
+        <structs-plugin.version>1.20-rc294.782175d40f81</structs-plugin.version> <!-- TODO https://github.com/jenkinsci/structs-plugin/pull/49 -->
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
     </properties>
     <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -264,7 +264,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
                 s = d.newInstance(ps.namedArgs);
             } else {
                 DescribableModel<? extends Step> stepModel = DescribableModel.of(d.clazz);
-                s = stepModel.instantiate(ps.namedArgs, handle.getListener());
+                s = stepModel.instantiate(ps.namedArgs, context.get(TaskListener.class));
             }
 
             // Persist the node - block start and end nodes do their own persistence.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -263,8 +263,8 @@ public class DSL extends GroovyObjectSupport implements Serializable {
             if (Util.isOverridden(StepDescriptor.class, d.getClass(), "newInstance", Map.class)) {
                 s = d.newInstance(ps.namedArgs);
             } else {
-                DescribableModel<?> stepModel = DescribableModel.of(d.clazz);
-                s = (Step) stepModel.instantiate(ps.namedArgs, handle.getListener());
+                DescribableModel<? extends Step> stepModel = DescribableModel.of(d.clazz);
+                s = stepModel.instantiate(ps.namedArgs, handle.getListener());
             }
 
             // Persist the node - block start and end nodes do their own persistence.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -260,7 +260,12 @@ public class DSL extends GroovyObjectSupport implements Serializable {
             }
             d.checkContextAvailability(context);
             Thread.currentThread().setContextClassLoader(CpsVmExecutorService.ORIGINAL_CONTEXT_CLASS_LOADER.get());
-            s = d.newInstance(ps.namedArgs);
+            if (Util.isOverridden(StepDescriptor.class, d.getClass(), "newInstance", Map.class)) {
+                s = d.newInstance(ps.namedArgs);
+            } else {
+                DescribableModel<?> stepModel = DescribableModel.of(d.clazz);
+                s = (Step) stepModel.instantiate(ps.namedArgs, handle.getListener());
+            }
 
             // Persist the node - block start and end nodes do their own persistence.
             CpsFlowExecution.maybeAutoPersistNode(an);

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -440,13 +440,10 @@ public class DSLTest {
 
     @Test public void  strayParameters() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        try {
-            p.setDefinition(new CpsFlowDefinition("node {sleep time: 1, units: 'SECONDS', comment: 'units is a typo'}", true));
-        } catch (Exception e) {
-            assertThat(e, instanceOf(IllegalArgumentException.class));
-            assertThat(e.getMessage(), Matchers.is("Unknown parameter(s) found for class type 'org.jenkinsci.plugins.workflow.steps.SleepStep': comment,units"));
-        }
+        p.setDefinition(new CpsFlowDefinition("node {sleep time: 1, units: 'SECONDS', comment: 'units is a typo'}", true));
         WorkflowRun b =  r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        r.assertLogContains("IllegalArgumentException: WARNING: Unknown parameter(s) found for class type " +
+                "'org.jenkinsci.plugins.workflow.steps.SleepStep': comment,units", b);
     }
 
     public static class CLStep extends Step {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -33,9 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import static org.hamcrest.Matchers.containsString;
 
-import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.LinearScanner;
 import org.jenkinsci.plugins.workflow.graphanalysis.NodeStepTypePredicate;
@@ -51,7 +49,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
 import org.jenkinsci.plugins.workflow.testMetaStep.AmbiguousEchoLowerStep;
 import org.jenkinsci.plugins.workflow.testMetaStep.AmbiguousEchoUpperStep;
 
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.*;
 
 import org.junit.Assert;


### PR DESCRIPTION
Passing `FlowExecution`'s `TaskListener` down to `DescribableModel.instantiate` to allow pipeline visibility of stray parameter warnings.

These changes rely on the following `structs-plugin` changes: https://github.com/jenkinsci/structs-plugin/pull/49 