### PR TITLE
Add more tests for CPS mismatch warning false positives

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorServiceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorServiceTest.java
@@ -167,6 +167,24 @@ public class CpsVmExecutorServiceTest {
                 r.assertLogNotContains("methodMissing", b);
                 return null;
             });
+            errors.checkSucceeds(() -> {
+                p.setDefinition(new CpsFlowDefinition(
+                    "class C { def x }\n" +
+                    "def c = new C()\n" +
+                    "c.x = {-> echo 'test' }\n" +
+                    "c.x()", false));
+                WorkflowRun b = r.buildAndAssertSuccess(p);
+                r.assertLogNotContains(CpsVmExecutorService.mismatchMessage("C", "x", "org.jenkinsci.plugins.workflow.cps.CpsClosure2", "call"), b);
+                return null;
+            });
+            errors.checkSucceeds(() -> {
+                p.setDefinition(new CpsFlowDefinition(
+                    "def cs = [ action: {-> sleep(1) } ]\n" +
+                    "cs.action()", true));
+                WorkflowRun b = r.buildAndAssertSuccess(p);
+                r.assertLogNotContains(CpsVmExecutorService.mismatchMessage("java.util.LinkedHashMap", "action", "org.jenkinsci.plugins.workflow.cps.CpsClosure2", "call"), b);
+                return null;
+            });
         } finally {
             CpsVmExecutorService.FAIL_ON_MISMATCH = origFailOnMismatch;
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorServiceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorServiceTest.java
@@ -124,7 +124,7 @@ public class CpsVmExecutorServiceTest {
         }
     }
 
-    @Issue("JENKINS-58501")
+    @Issue(value = { "JENKINS-58501", "JENKINS-58407" })
     @Ignore
     @Test public void mismatchMetaProgrammingFalsePositives() throws Exception {
         boolean origFailOnMismatch = CpsVmExecutorService.FAIL_ON_MISMATCH;


### PR DESCRIPTION
Adds two more tests for false positives, one for [JENKINS-58407](https://issues.jenkins-ci.org/browse/JENKINS-58407) and one for https://groups.google.com/d/msg/jenkinsci-users/2m5JGYJfYRs/t1hRV-rhFAAJ.

I don't really have any good ideas of how we could fix these cases without also introducing a bunch of false negatives. I think any serious fix would require recreating a good amount of Groovy's method dispatch logic so that we could figure out what `object.x()` is doing behind the scenes (For example, in the first new test case it ends up being something like `(object.x)()`, and in the second case it is something like `(object.get('x'))()`).