### PR TITLE
[JENKINS-58501] Update to groovy-cps 1.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <git-plugin.version>3.1.0</git-plugin.version>
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
-        <groovy-cps.version>1.29</groovy-cps.version>
+        <groovy-cps.version>1.30</groovy-cps.version>
         <structs-plugin.version>1.18</structs-plugin.version>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
     </properties>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorServiceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorServiceTest.java
@@ -48,7 +48,7 @@ public class CpsVmExecutorServiceTest {
         r.buildAndAssertSuccess(p);
     }
 
-    @Issue({"JENKINS-31314", "JENKINS-27306", "JENKINS-26313"})
+    @Issue({"JENKINS-31314", "JENKINS-27306", "JENKINS-26313", "JENKINS-58501"})
     @Test public void wrongCatcher() throws Exception {
         boolean origFailOnMismatch = CpsVmExecutorService.FAIL_ON_MISMATCH;
         CpsVmExecutorService.FAIL_ON_MISMATCH = false;
@@ -119,18 +119,6 @@ public class CpsVmExecutorServiceTest {
                 r.assertLogContains(CpsVmExecutorService.mismatchMessage("C", "<init>", null, "sleep"), b);
                 return null;
             });
-        } finally {
-            CpsVmExecutorService.FAIL_ON_MISMATCH = origFailOnMismatch;
-        }
-    }
-
-    @Issue(value = { "JENKINS-58501", "JENKINS-58407" })
-    @Ignore
-    @Test public void mismatchMetaProgrammingFalsePositives() throws Exception {
-        boolean origFailOnMismatch = CpsVmExecutorService.FAIL_ON_MISMATCH;
-        CpsVmExecutorService.FAIL_ON_MISMATCH = false;
-        try {
-            WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             errors.checkSucceeds(() -> {
                 p.setDefinition(new CpsFlowDefinition(
                     "import org.codehaus.groovy.runtime.InvokerHelper \n" + 
@@ -167,6 +155,18 @@ public class CpsVmExecutorServiceTest {
                 r.assertLogNotContains("methodMissing", b);
                 return null;
             });
+        } finally {
+            CpsVmExecutorService.FAIL_ON_MISMATCH = origFailOnMismatch;
+        }
+    }
+
+    @Issue("JENKINS-58407")
+    @Ignore
+    @Test public void mismatchFalsePositives() throws Exception {
+        boolean origFailOnMismatch = CpsVmExecutorService.FAIL_ON_MISMATCH;
+        CpsVmExecutorService.FAIL_ON_MISMATCH = false;
+        try {
+            WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             errors.checkSucceeds(() -> {
                 p.setDefinition(new CpsFlowDefinition(
                     "class C { def x }\n" +


### PR DESCRIPTION
See [JENKINS-58501](https://issues.jenkins-ci.org/browse/JENKINS-58501).

Picks up https://github.com/cloudbees/groovy-cps/pull/99 from @steven-terrana to suppress the mismatch warnings for some kinds of metaprogramming that confuse the mismatch detection code.