### PR TITLE
Use ACI agents to avoid disk space issues in CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(useAci: true, configurations: buildPlugin.recommendedConfigurations())


### PR DESCRIPTION
Trying to fix the build failures we've been seeing in PRs like #311 and #307. If this helps, we might want to go ahead and switch other Pipeline plugins as well.