### PR TITLE
[JENKINS-58643] Ignore mismatch warnings when receiver is a plugin

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
+import jenkins.model.Jenkins;
 import jenkins.util.InterceptingExecutorService;
 
 /**
@@ -112,6 +113,11 @@ class CpsVmExecutorService extends InterceptingExecutorService {
     }
 
     private void handleMismatch(Object expectedReceiver, String expectedMethodName, Object actualReceiver, String actualMethodName) {
+        Class receiverClass = expectedReceiver.getClass();
+        if (Jenkins.get().getPluginManager().whichPlugin(receiverClass) != null) {
+            // Plugin code is opaque to the mismatch detector.
+            return;
+        }
         String mismatchMessage = mismatchMessage(className(expectedReceiver), expectedMethodName, className(actualReceiver), actualMethodName);
         if (FAIL_ON_MISMATCH) {
             throw new IllegalStateException(mismatchMessage);


### PR DESCRIPTION
This patch was proposed by @dwnusbaum in [JENKINS-58643](https://issues.jenkins-ci.org/browse/JENKINS-58643), and it successfully resolves the issue described there.

When handling CPS mismatch, warnings are ignored whenever the receiver is a plugin.