### PR TITLE
 JENKINS-58620 Test for the GroovyShell.evaluate mismatch ignore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <git-plugin.version>3.1.0</git-plugin.version>
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
-        <groovy-cps.version>1.30</groovy-cps.version>
+        <groovy-cps.version>1.31</groovy-cps.version>
         <structs-plugin.version>1.20</structs-plugin.version>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
     </properties>


### PR DESCRIPTION
See [JENKINS-58620](https://issues.jenkins-ci.org/browse/JENKINS-58620).

CpsGroovyShell test required never version of groovy-cps plugin
Please do not merge until cloudbees/groovy-cps#101 will be accepted and new groovy-cps will be released.