### PR TITLE
[JENKINS-59083] Do not try to open the listener for a completed build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
@@ -73,7 +73,7 @@ public class EnvActionImpl extends GroovyObjectSupport implements EnvironmentAct
         TaskListener listener;
         if (owner instanceof FlowExecutionOwner.Executable) {
             FlowExecutionOwner executionOwner = ((FlowExecutionOwner.Executable) owner).asFlowExecutionOwner();
-            if (executionOwner != null) {
+            if (executionOwner != null && owner.isBuilding()) {
                 listener = executionOwner.getListener();
             } else {
                 listener = new LogTaskListener(LOGGER, Level.INFO);


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-job-plugin/pull/140.