### PR TITLE
Do not store enums defined in Pipeline scripts in ArgumentsActionImpl

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.cps.actions;
 
 import com.google.common.collect.Maps;
+import groovy.lang.GroovyClassLoader;
 import hudson.EnvVars;
 import hudson.model.Describable;
 import hudson.model.Result;
@@ -128,8 +129,13 @@ public class ArgumentsActionImpl extends ArgumentsAction {
                 || ob instanceof URL || ob instanceof Result) {
             return true;
         }
+        if (ob instanceof Enum) {
+            // We use getDeclaringClass instead of getClass to handle enums with value-specific class bodies like TimeUnit.
+            Class enumClass = ((Enum) ob).getDeclaringClass();
+            return !(enumClass.getClassLoader() instanceof GroovyClassLoader);
+        }
         Class c = ob.getClass();
-        return c.isPrimitive() || c.isEnum() || (c.isArray() && !(c.getComponentType().isPrimitive()));  // Primitive arrays are not legal here
+        return c.isPrimitive() || (c.isArray() && !(c.getComponentType().isPrimitive()));  // Primitive arrays are not legal here
     }
 
     /** Normal environment variables, as opposed to ones that might come from credentials bindings */


### PR DESCRIPTION
An investigation into a memory leak revealed that in some cases, `ArgumentsActionImpl` could store references to objects defined in the Pipeline script, preventing the class loader for the Pipeline from being garbage collected.

I also fixed a subtle bug while I was here that prevented some kinds of enums from being stored at all, although maybe it would be better to keep that behavior the same as before?