### PR TITLE
Add `loadFromClasspath()` pipeline step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep.java
@@ -1,0 +1,106 @@
+package org.jenkinsci.plugins.workflow.cps.steps;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jenkinsci.plugins.workflow.cps.CpsStepContext;
+import org.jenkinsci.plugins.workflow.cps.CpsThreadGroup;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+
+/**
+ * Load the contents of some classpath resource and attempt to evaluate them as a Groovy Pipeline script in the current pipeline execution.
+ * 
+ * @author Austin Witt
+ * 
+ * @since 2.74
+ *
+ */
+public class LoadFromClasspathStep extends Step {
+
+	/**
+	 * The classpath of a Groovy Pipeline script
+	 */
+	protected String path;
+
+	/**
+	 * An object to use to get the classloader to use.
+	 * <br><br>
+	 * Since this will be targeting a Groovy script file (not bytecode) resource on the classpath,
+	 * a GroovyClassLoader must be used to look for the class to ensure that the Groovy script text is located and compiled.
+	 * <br><br>
+	 * Using a regular Java ClassLoader will only look for bytecode. 
+	 * This may fail - but if it does succeed, the resulting script's source code will not be able to be CPS-transformed
+	 * (since the source code was not loaded) and so it won't be able to be used by pipeline scripts without breaking the whole pipeline execution.
+	 * <br><br>
+	 * An easy way to find a GroovyClassLoader is to provide the current Groovy script (<code>this</code>) as the object.
+	 */
+	protected Object classloaderSource;
+	
+	/**
+	 * Whether properties from the loaded script should be unexported when serializing the pipeline.
+	 * Setting this to <code>true</code> may affect property availability after pipeline restarts.
+	 * Setting this to <code>false</code> may make some pipelines non-resumable.
+	 * 
+	 * @see CpsStepContext#newBodyInvoker(org.jenkinsci.plugins.workflow.cps.BodyReference, boolean)
+	 * @see CpsThreadGroup#unexport(org.jenkinsci.plugins.workflow.cps.BodyReference)
+	 */
+	protected boolean unexport = DescriptorImpl.DEFAULT_UNEXPORT;
+
+	@DataBoundConstructor
+	public LoadFromClasspathStep(String path) { this.path = path; }
+
+	public String getPath() { return path; }
+
+	public Object getClassloaderSource() { return classloaderSource; }
+
+	@DataBoundSetter
+	public void setClassloaderSource(Object classloaderSource) { this.classloaderSource = classloaderSource; }
+	
+	public boolean isUnexport() { return unexport; }
+	
+	@DataBoundSetter
+	public void setUnexport( boolean unexport ) { this.unexport = unexport; }
+
+	@Override
+	public StepExecution start(StepContext _context) throws Exception {
+		return new LoadFromClasspathStepExecution( _context, path, classloaderSource, unexport );
+	}
+
+	@Extension
+	public static class DescriptorImpl extends StepDescriptor {
+		
+		public static final boolean DEFAULT_UNEXPORT = false;
+
+		@Override
+		public Set<? extends Class<?>> getRequiredContext() {
+			return new HashSet<>(Arrays.asList(
+				TaskListener.class
+			));
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "loadFromClasspath";
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "Evaluate the contents of a classpath resource as a Groovy Pipeline script";
+		}
+
+		@Override
+		public boolean isAdvanced() {
+			return true;
+		}
+	}
+
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStepExecution.java
@@ -1,0 +1,134 @@
+package org.jenkinsci.plugins.workflow.cps.steps;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Scanner;
+
+import org.apache.tools.ant.taskdefs.Classloader;
+import org.codehaus.groovy.control.MultipleCompilationErrorsException;
+import org.jenkinsci.plugins.workflow.cps.CpsCompilationErrorsException;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+import org.jenkinsci.plugins.workflow.cps.CpsStepContext;
+import org.jenkinsci.plugins.workflow.cps.CpsThread;
+import org.jenkinsci.plugins.workflow.cps.replay.ReplayAction;
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+
+import groovy.lang.Script;
+import hudson.model.TaskListener;
+
+/**
+ * Execution implementation for {@link LoadFromClasspathStep}.
+ *
+ * @author Austin Witt
+ * 
+ * @since 2.74
+ *
+ */
+public class LoadFromClasspathStepExecution extends StepExecution {
+	
+	private static final long serialVersionUID = 1L;
+
+	protected String path;
+
+	protected Object classloaderSource;
+	
+	protected boolean unexport;
+	
+	protected transient TaskListener listener;
+
+	public LoadFromClasspathStepExecution(
+		StepContext _context, 
+		String _path, 
+		Object _classloaderSource,
+		boolean _unexport)
+			throws
+				IOException,
+				InterruptedException
+	{
+		super( _context );
+
+		path = _path;
+		classloaderSource = _classloaderSource;
+		listener = _context.get( TaskListener.class );
+	}
+
+	@Override
+	public boolean start() throws Exception {
+		
+		CpsStepContext cps = (CpsStepContext) getContext();
+		CpsThread t = CpsThread.current();
+		CpsFlowExecution execution = t.getExecution();
+
+		String text = get_classpath_resource_contents( classloaderSource != null ? classloaderSource : this, path );
+		String clazz = execution.getNextScriptName( path );
+		String newText = ReplayAction.replace( execution, clazz );
+		if( newText != null ) {
+			listener.getLogger().println( "Replacing Groovy text with edited version" );
+			text = newText;
+		}
+
+		Script script;
+		try {
+			script = execution.getShell().parse(text);
+		} catch (MultipleCompilationErrorsException e) {
+			// Convert to a serializable exception, see JENKINS-40109.
+			throw new CpsCompilationErrorsException(e);
+		}
+
+		// execute body as another thread that shares the same head as this thread
+		// as the body can pause.
+		cps.newBodyInvoker(t.getGroup().export( script ), unexport )
+			.withDisplayName( path )
+			.withCallback(BodyExecutionCallback.wrap( cps ) )
+			.start(); // when the body is done, the load step is done
+
+		return false;
+	}
+
+	@Override
+	public void stop(Throwable cause) throws Exception {
+		// noop
+		//
+		// the head of the CPS thread that's executing the body should stop and that's all we need to do.
+	}
+
+	/**
+	 * Load the contents of a classpath resource as a String.
+	 *
+	 * @param _use_my_classloader An object to use to get a {@link Classloader} (via {@link Class#getClassLoader()}) to look for the _resource
+	 * @param _resource The path to the classpath resource to read as a String.
+	 *
+	 * @return The contents of the classpath _resource
+	 *
+	 * @throws FileNotFoundException If the {@link Classloader} of _use_my_classloader cannot locate the _resource.
+	 */
+	protected String get_classpath_resource_contents(Object _use_my_classloader, String _resource) throws FileNotFoundException {
+
+		if( null == _resource || _resource.trim().equalsIgnoreCase( "" ) ) {
+			throw new IllegalStateException( "You must provide a _resource to load." );
+		}
+
+		ClassLoader classloader = _use_my_classloader.getClass().getClassLoader();
+
+		if( null == classloader ) {
+			classloader = getClass().getClassLoader();
+		}
+
+		if( null == classloader ) {
+			throw new IllegalStateException( "Unable to find a java.lang.Classloader to use to look for [" + _resource + "]." );
+		}
+
+		InputStream resource_stream = classloader.getResourceAsStream( _resource );
+
+		if( null == resource_stream ) {
+			throw new FileNotFoundException( "Unable to locate classpath resource [" + _resource + "]." );
+		}
+		try( Scanner s = new Scanner( resource_stream, "UTF-8") ) {
+			return s.useDelimiter("\\A").next();
+		}
+	}
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep/config.jelly
@@ -1,0 +1,20 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+
+	<f:entry field="path" title="${%Classpath Resource Path}" description="The classpath location of the Groovy Pipeline Script to load">
+	    <f:textbox/>
+	</f:entry>
+	
+	<f:entry field="classloaderSource" title="${%Classpath Hint Object}" description="An object to grab a ClassLoader from to use to load the script">
+	    <f:textbox default="null"/>
+	</f:entry>
+	
+	<f:advanced>
+	
+		<f:entry field="unexport" title="${%Unexport properties when done?}" description="Whether properties from the loaded script should be un-exported when the pipeline is serialized">
+			<f:checkbox checked="${descriptor.DEFAULT_UNEXPORT}" />
+		</f:entry>
+	
+	</f:advanced>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep/help-classloaderSource.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep/help-classloaderSource.html
@@ -1,0 +1,22 @@
+<p>
+An object to use to get the classloader to use to look for the classpath resource.
+<br><br>
+Since this will be targeting a Groovy script file (not bytecode) resource on the classpath, 
+you must use a <a target="_blank" href="http://docs.groovy-lang.org/2.4.10/html/api/groovy/lang/GroovyClassLoader.html">GroovyClassLoader</a>
+to look for the class to ensure that the Groovy script text is located and compiled.
+Using a regular Java ClassLoader will only look for bytecode. This may fail - but if it does succeed, the resulting script's source code will 
+not be able to be CPS-transformed (since the source code was not loaded) and so it won't be able to be used by pipeline scripts without breaking the whole pipeline execution.
+An easy way to find a <code>GroovyClassLoader</code> is to provide the current Groovy script (<code>this</code>) as the hint object.
+</p>
+<p>
+I haven't figured out how to get the Snippet Generator to accept arbitrary variable names (that of course are not defined right now),
+so it will fail to generate a snippet unless you set "null" for the hint.
+Proper usage might look like
+</p>
+<code>
+<pre>
+loadFromClasspath(
+	classloaderSource: this,
+	path: "com/example/some/classpath/resource/Pipeline.groovy" )
+</pre>
+</code>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep/help-path.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep/help-path.html
@@ -1,0 +1,1 @@
+The path on the classpath to a Groovy script.

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep/help-unexport.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep/help-unexport.html
@@ -1,0 +1,3 @@
+Whether properties from the loaded script should be unexported when serializing the pipeline. 
+Setting this to <code>true</code> may affect property availability after pipeline restarts.
+Setting this to <code>false</code> may make some pipelines non-resumable.

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/steps/LoadFromClasspathStep/help.html
@@ -1,0 +1,6 @@
+<p>
+Load text from a classpath resource and evaluate it as a Groovy script.
+Normally, pipeline scripts that you would write don't have a way to put resources onto the classpath, so this ability wouldn't be useful.
+However, Groovy scripts and pipelines provided through a Jenkins plugin <i>do</i> have a mechanism to put text resources
+on the classpath (simply by packaging them up in the plugin) and might want to evaluate some of them from a Groovy pipeline.
+</p> 


### PR DESCRIPTION
This adds a `loadFromClasspath(...)` pipeline step. It's just like the `load(...)` step, except it loads from the Jenkins master's classpath instead of from an agent's disk.

Usage
=====

```groovy
loadFromClasspath(
    classloaderSource: this,
    path: 'com/example/Pipeline.groovy' )
```

![loadFromClasspath Title](https://user-images.githubusercontent.com/25155847/64034740-da136780-cb14-11e9-9ab7-753aa0e00948.png)

![loadFromClasspath description](https://user-images.githubusercontent.com/25155847/64034756-e1d30c00-cb14-11e9-99f6-86237baee9cb.png)

Motivation
=====

I have Groovy pipeline scripts provided to my Jenkins masters' classpaths, and I need a way to run them from other pipeline scripts.

Per a conversation with @jglick about the interface changes to `CpsStepContext#newBodyInvoker` that "nobody should be using methods like this from external code," I'd like to see the capability I need become _internal_ to `workflow-cps`.

I Have Questions
=====

I have _not_ written tests for this step yet, because I don't fully understand the semantics of the new `unexport` option on `CpsStepContext#newBodyInvoker`. I'd like to understand that better (and be able to update the accompanying documentation and comments) before moving forward.

Please see the specific line-comments for the uncertainties I still have.