### PR TITLE
Add regression tests for SECURITY-1538

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.62</version>
+            <version>1.63</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
No actual fixes here, just regression tests for the fix in script-security 1.63.

Maybe useful to try to create something similar to `SandboxInterceptorTest` from script-security here to make these kinds of tests less expensive.