### PR TITLE
[JENKINS-59398] Flatten UserIdCause into ReplayCause

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayCause.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayCause.java
@@ -31,6 +31,8 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.util.List;
+import java.lang.NoSuchMethodError;
 
 /**
  * Marker that a run is a replay of an earlier one.
@@ -67,6 +69,21 @@ public class ReplayCause extends Cause {
     }
 
     @Override public String getShortDescription() {
+        String user = "";
+        List<Cause> causes = this.run.getCauses();
+        for (Cause cause : causes) {
+            if (cause instanceof UserIdCause) {
+                UserIdCause userIdCause = (UserIdCause) cause;
+                user = userIdCause.getUserName();
+            }
+        }
+        if (!user.isEmpty()) {
+            try {
+                return org.jenkinsci.plugins.workflow.cps.replay.Messages.ReplayCauseWithUser_shortDescription(originalNumber, user);
+            } catch (NoSuchMethodError e) {
+                /* If a localization hasn't been updated to have this string, just use the older flavor. */
+            }
+        }
         return org.jenkinsci.plugins.workflow.cps.replay.Messages.ReplayCause_shortDescription(originalNumber);
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/Messages.properties
@@ -2,3 +2,4 @@ Replay.permission.description=Ability to perform a new Pipeline build with an ed
 ReplayCommand.shortDescription=Replay a Pipeline build with edited script taken from standard input
 ReplayAction.displayName=Replay
 ReplayCause.shortDescription=Replayed #{0}
+ReplayCauseWithUser.shortDescription={1} replayed #{0}


### PR DESCRIPTION
This is a proposal for https://issues.jenkins-ci.org/browse/JENKINS-59398

The other approach would be teaching blueocean to do the same work.