### PR TITLE
JENKINS-59762 Replace static initialization block to allow for CpsThread mocking

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -159,13 +159,6 @@ public final class CpsThread implements Serializable {
         this.step = step;
     }
 
-    private static final List<Class> categories;
-    static {
-        categories = new ArrayList<>();
-        categories.addAll(Continuable.categories);
-        categories.add(IteratorHack.class);
-    }
-
     /**
      * Executes CPS code synchronously a little bit more, until it hits
      * the point the workflow needs to be dehydrated.
@@ -183,7 +176,7 @@ public final class CpsThread implements Serializable {
             LOGGER.log(FINE, "runNextChunk on {0}", resumeValue);
             final Outcome o = resumeValue;
             resumeValue = null;
-            outcome = program.run0(o, categories);
+            outcome = program.run0(o, getCategories());
             if (outcome.getAbnormal() != null) {
                 LOGGER.log(FINE, "ran and produced error", outcome.getAbnormal());
             } else {
@@ -329,6 +322,12 @@ public final class CpsThread implements Serializable {
     @CpsVmThreadOnly
     public static CpsThread current() {
         return CURRENT.get();
+    }
+
+    private static List<Class> getCategories() {
+        List<Class> categories = new ArrayList<>(Continuable.categories);
+        categories.add(IteratorHack.class);
+        return categories;
     }
 
     @Override public String toString() {


### PR DESCRIPTION
This change makes it possible to test scripted pipelines (e.g. with jenkins-spock library).
Without it any mocking attempt results in:
```
Could not initialize class org.jenkinsci.plugins.workflow.cps.CpsThread
java.lang.NoClassDefFoundError: Could not initialize class org.jenkinsci.plugins.workflow.cps.CpsThread
	at org.jenkinsci.plugins.workflow.cps.CpsScript.<init>(CpsScript.java:69)
	at org.spockframework.mock.runtime.MockInstantiator.instantiate(MockInstantiator.java:33)
	at org.spockframework.mock.runtime.ProxyBasedMockFactory$CglibMockFactory.createMock(ProxyBasedMockFactory.java:155)
	at org.spockframework.mock.runtime.ProxyBasedMockFactory.create(ProxyBasedMockFactory.java:68)
	at org.spockframework.mock.runtime.JavaMockFactory.createInternal(JavaMockFactory.java:59)
	at org.spockframework.mock.runtime.JavaMockFactory.create(JavaMockFactory.java:40)
	at org.spockframework.mock.runtime.CompositeMockFactory.create(CompositeMockFactory.java:44)
	at org.spockframework.lang.SpecInternals.createMock(SpecInternals.java:51)
	at org.spockframework.lang.SpecInternals.createMockImpl(SpecInternals.java:296)
	at org.spockframework.lang.SpecInternals.createMockImpl(SpecInternals.java:286)
	at org.spockframework.lang.SpecInternals.SpyImpl(SpecInternals.java:161)
	at com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification.setup(JenkinsPipelineSpecification.groovy:1025)
```