### PR TITLE
JENKINS-48431 Support both lightweight checkout AND build parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,14 +68,25 @@
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
-        <git-plugin.version>3.1.0</git-plugin.version>
+        <git-plugin.version>3.13.0-SNAPSHOT</git-plugin.version>
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
-        <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
+        <scm-api-plugin.version>2.6.4-SNAPSHOT</scm-api-plugin.version>
         <groovy-cps.version>1.31</groovy-cps.version>
         <structs-plugin.version>1.20</structs-plugin.version>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>token-macro</artifactId>
+            <version>2.8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.3.0</version>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
@@ -94,7 +105,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.4</version>
+            <version>2.9</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -176,7 +187,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.15</version>
+            <version>1.20</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
@@ -110,7 +110,7 @@ public class CpsScmFlowDefinition extends FlowDefinition {
         Run<?,?> build = (Run<?,?>) _build;
         String expandedScriptPath = build.getEnvironment(listener).expand(scriptPath);
         if (isLightweight()) {
-            try (SCMFileSystem fs = SCMFileSystem.of(build.getParent(), scm)) {
+            try (SCMFileSystem fs = SCMFileSystem.of(build, scm)) {
                 if (fs != null) {
                     String script = fs.child(expandedScriptPath).contentAsString();
                     listener.getLogger().println("Obtained " + expandedScriptPath + " from " + scm.getKey());

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition/help-lightweight.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition/help-lightweight.html
@@ -2,6 +2,4 @@
     If selected, try to obtain the Pipeline script contents directly from the SCM without performing a full checkout.
     The advantage of this mode is its efficiency; however, you will not get any changelogs or polling based on the SCM.
     (If you use <code>checkout scm</code> during the build, this will populate the changelog and initialize polling.)
-    Also build parameters will not be substituted into SCM configuration in this mode.
-    Only selected SCM plugins support this mode.
 </div>


### PR DESCRIPTION
[JENKINS-48431](https://issues.jenkins-ci.org/browse/JENKINS-48431) To support both lightweight checkout AND build parameters, we need to:
- recover the environment parameters of the build
- evaluate the SCM structure according to the build environment parameters

This leads to implement a new method :
public static SCMFileSystem of(@NonNull Run build, @NonNull SCM scm, @CheckForNull SCMRevision rev)

This new method offer the capacity to recover the environments parameter of the build as the current build is propagated through the new method.

Note that this modification is in relation with two other pull requests that concerns:
- scm-api-plugin: https://github.com/jenkinsci/scm-api-plugin/pull/78
- git-plugin: https://github.com/jenkinsci/git-plugin/pull/772