### PR TITLE
Added lost dependency on jquery-ui. (Hacktoberfest)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,11 @@
             <version>1.2.1</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jquery-ui</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
             <artifactId>ace-editor</artifactId>
             <version>1.0.1</version>


### PR DESCRIPTION
Hi!

This is my first pull request to the overall Jenkins project.

As I started using pipelines in Jenkins, I, as many other people, noticed the lack of re-sizable text window for the pipeline definition, as well as for the replay feature. I've been playing around learning how to even build and modify a plugin, and after countless hours I found a solution that I'm not entirely sure is the best way of doing it.

I've found the solution to be adding an extra dependency to the pom.xml file to which I believe was actually an old dependency: [jquery-ui-plugin](https://github.com/jenkinsci/jquery-ui-plugin), which was replaced by the more flexible js-libs plugin.

The result is the expected ability to expand and retract the size of the texbox:
![Alt Text](https://media.giphy.com/media/hu80d61PBKGWRVzgHn/giphy.gif)

The following Jira issues relate to this bug (and someone even mentions that installing the jquery-ui library fixes the problem): 
* [JENKINS-38276](https://issues.jenkins-ci.org/browse/JENKINS-38276).
* [JENKINS-31592](https://issues.jenkins-ci.org/browse/JENKINS-31592).

**This is probably not a good permanent solution**. There needs to be deeper exploration in to why the new jquery dependencies (js-libs, js-modules, etc.) are failing on the resizable window.

BTW, I've planned to do this for the Hacktoberfest 2019, but I think it was more than I could chew at the moment as I'm pretty much a newbie on javascript :P.

Thanks.
