### PR TITLE
[JENKINS-58878] Make DSL$ThreadTaskImpl.eval and CpsBodyInvoker.start atomic with respect to both CpsStepContext.bodyInvokers and CpsStepContext.sync

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -297,7 +297,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         }
 
         if (sync) {
-            assert context.bodyInvokers.isEmpty() : "If a step claims synchronous completion, it shouldn't invoke body";
+            assert context.withBodyInvokers(List::isEmpty) : "If a step claims synchronous completion, it shouldn't invoke body";
 
             if (context.getOutcome()==null) {
                 context.onFailure(new AssertionError("Step "+s+" claimed to have ended synchronously, but didn't set the result via StepContext.onSuccess/onFailure"));
@@ -612,9 +612,9 @@ public class DSL extends GroovyObjectSupport implements Serializable {
 
         @Override
         protected ThreadTaskResult eval(CpsThread cur) {
-            invokeBody(cur);
+            boolean switchToAsync = invokeBodyAndSwitchToAsyncMode(cur);
 
-            if (!context.switchToAsyncMode()) {
+            if (!switchToAsync) {
                 // we have a result now, so just keep executing
                 // TODO: if this fails with an exception, we need ability to resume by throwing an exception
                 return resumeWith(context.getOutcome());
@@ -628,7 +628,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
             }
         }
 
-        private void invokeBody(CpsThread cur) {
+        private boolean invokeBodyAndSwitchToAsyncMode(CpsThread cur) {
             // prepare enough heads for all the bodies
             // the first one can reuse the current thread, but other ones need to create new heads
             // we want to do this first before starting body so that the order of heads preserve
@@ -636,21 +636,24 @@ public class DSL extends GroovyObjectSupport implements Serializable {
 
             // TODO give this javadocs worth a darn, because this is how we create parallel branches and the docs are cryptic as can be!
             // Also we need to double-check this logic because this might cause a failure of persistence
-            FlowHead[] heads = new FlowHead[context.bodyInvokers.size()];
-            for (int i = 0; i < heads.length; i++) {
-                heads[i] = i==0 ? cur.head : cur.head.fork();
-            }
+            return context.withBodyInvokers(bodyInvokers -> {
+                FlowHead[] heads = new FlowHead[bodyInvokers.size()];
+                for (int i = 0; i < heads.length; i++) {
+                    heads[i] = i==0 ? cur.head : cur.head.fork();
+                }
 
-            int idx=0;
-            for (CpsBodyInvoker b : context.bodyInvokers) {
-                // don't collect the first head, which is what we borrowed from our parent.
-                FlowHead h = heads[idx];
-                b.launch(cur, h);
-                context.bodyHeads.add(h.getId());
-                idx++;
-            }
+                int idx=0;
+                for (CpsBodyInvoker b : bodyInvokers) {
+                    // don't collect the first head, which is what we borrowed from our parent.
+                    FlowHead h = heads[idx];
+                    b.launch(cur, h);
+                    context.bodyHeads.add(h.getId());
+                    idx++;
+                }
 
-            context.bodyInvokers.clear();
+                bodyInvokers.clear();
+                return context.switchToAsyncMode();
+            });
         }
 
         /**


### PR DESCRIPTION
See [JENKINS-58878](https://issues.jenkins-ci.org/browse/JENKINS-58878) and https://github.com/jenkinsci/workflow-step-api-plugin/pull/49.

The problem AIUI was that `CpsBodyInvoker.start` could try to synchronously add a body invoker after `DSL$ThreadTaskImpl.invokeBody` had completed (or in the middle of it, leading to things like the `ArrayIndexOutOfBoundsException` described in [this comment](https://issues.jenkins-ci.org/browse/JENKINS-58878?focusedCommentId=378651&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-378651)), but before the step has switched to async mode by calling `CpsStepContext.switchToAsyncMode` in `DSL$ThreadTaskImpl.eval`, and so the body invoker would be ignored forever, since the step had switched to async mode. This only appears to  happen for implementations of `GeneralizedNonBlockingStepExecution` where the body executes very quickly (e.g. Uses of `withCredentials` where the list of credentials is empty).

The fix in this PR is to make sure that operations involving both of `CpsStepContext.bodyInvokers` and `CpsStepContext.sync` are atomic, so that `CpsBodyInvoker.start` does not try to add a synchronous body after `bodyInvokers` has been cleared but before the step has switched to async mode.

I'll update https://github.com/jenkinsci/workflow-step-api-plugin/pull/49 to pull in an incremental build from this PR and unignore the test once I have an incremental build. I'm not sure if it makes sense to add tests here, https://github.com/jenkinsci/workflow-step-api-plugin/pull/49 has a regression test for the specific bug (we could move it here instead if desired), and the existing tests in this plugin verify that this didn't break any existing behavior.