### PR TITLE
[JENKINS-34256] Resume Pipeline execution if quiet mode is canceled

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -2112,7 +2112,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                             }
                             @Override
                             public void onFailure(Throwable x) {
-                                LOGGER.log(Level.WARNING, "cannot resume " + exec + " after cancelling quiet mode", x);
+                                LOGGER.log(Level.WARNING, "cannot resume " + exec + " after canceling quiet mode", x);
                             }
                         });
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -2103,17 +2103,16 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                 // Need to resume all executions by calling `CpsThreadGroup.scheduleRun()`.
                 for (FlowExecution exec : FlowExecutionList.get()) {
                     if (exec instanceof CpsFlowExecution) {
-                        CpsFlowExecution cpsExec = (CpsFlowExecution) exec;
-                        cpsExec.runInCpsVmThread(new FutureCallback<CpsThreadGroup>() {
+                        ((CpsFlowExecution) exec).runInCpsVmThread(new FutureCallback<CpsThreadGroup>() {
                             @Override
                             public void onSuccess(CpsThreadGroup g) {
-                                if (!g.isPaused()) {
+                                if (!g.isPaused()) { // If the CpsThreadGroup is paused, scheduleRun will cause it to be persisted again unnecessarily.
                                     g.scheduleRun();
                                 }
                             }
                             @Override
                             public void onFailure(Throwable x) {
-                                LOGGER.log(Level.WARNING, "cannot resume from quiet down " + exec, x);
+                                LOGGER.log(Level.WARNING, "cannot resume " + exec + " after cancelling quiet mode", x);
                             }
                         });
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -110,11 +110,9 @@ import groovy.lang.GroovyCodeSource;
 import hudson.AbortException;
 import hudson.BulkChange;
 import hudson.Extension;
-import hudson.Main;
 import hudson.init.Terminator;
 import hudson.model.Item;
 import hudson.model.Job;
-import hudson.model.PeriodicWork;
 import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.model.Saveable;
@@ -2080,46 +2078,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     @Override
     protected void notifyShutdown() {
         // No-op, handled in the suspendAll terminator
-    }
-
-    // TODO: Core could use a QuietDownListener class with `onQuietDown` and `onCancelQuietDown` methods.
-    @Restricted(NoExternalUse.class)
-    @Extension
-    public static class QuietDownListener extends PeriodicWork {
-        private boolean wasQuietDown = Jenkins.get().isQuietingDown();
-
-        @Override
-        public long getRecurrencePeriod() {
-            return Main.isUnitTest
-                    ? TimeUnit.SECONDS.toMillis(1)
-                    : TimeUnit.MINUTES.toMillis(1);
-        }
-
-        @Override
-        protected void doRun() throws Exception {
-            boolean isQuietDown = Jenkins.get().isQuietingDown();
-            // Quieting down is handled by `CpsThreadGroup.scheduleRun`, so we just need to handle quiet mode being cancelled.
-            if (!isQuietDown && wasQuietDown) {
-                // Need to resume all executions by calling `CpsThreadGroup.scheduleRun()`.
-                for (FlowExecution exec : FlowExecutionList.get()) {
-                    if (exec instanceof CpsFlowExecution) {
-                        ((CpsFlowExecution) exec).runInCpsVmThread(new FutureCallback<CpsThreadGroup>() {
-                            @Override
-                            public void onSuccess(CpsThreadGroup g) {
-                                if (!g.isPaused()) { // If the CpsThreadGroup is paused, scheduleRun will cause it to be persisted again unnecessarily.
-                                    g.scheduleRun();
-                                }
-                            }
-                            @Override
-                            public void onFailure(Throwable x) {
-                                LOGGER.log(Level.WARNING, "cannot resume " + exec + " after canceling quiet mode", x);
-                            }
-                        });
-                    }
-                }
-            }
-            wasQuietDown = isQuietDown;
-        }
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -296,11 +296,14 @@ public final class CpsThreadGroup implements Serializable {
                             } catch (IOException e) {
                                LOGGER.log(Level.WARNING, null, e);
                             }
-                            Timer.get().schedule(() -> {
-                                if (j.isQuietingDown()) {
-                                    Timer.get().schedule(this, Main.isUnitTest ? 1 : 10, TimeUnit.SECONDS);
-                                } else {
-                                    scheduleRun();
+                            Timer.get().schedule(new Runnable() {
+                                @Override
+                                public void run() {
+                                    if (j.isQuietingDown()) {
+                                        Timer.get().schedule(this, Main.isUnitTest ? 1 : 10, TimeUnit.SECONDS);
+                                    } else {
+                                        scheduleRun();
+                                    }
                                 }
                             }, Main.isUnitTest ? 1 : 10, TimeUnit.SECONDS);
                         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -40,9 +40,11 @@ import groovy.lang.GroovyShell;
 import groovy.lang.Script;
 import hudson.ExtensionList;
 import hudson.Functions;
+import hudson.Main;
 import hudson.Util;
 import hudson.model.Result;
 import jenkins.model.Jenkins;
+import jenkins.util.Timer;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -67,6 +69,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -121,6 +124,13 @@ public final class CpsThreadGroup implements Serializable {
 
     /** Set while {@link #runner} is doing something. */
     transient boolean busy;
+
+    /**
+     * True if the build was automatically paused because quiet mode is enabled.
+     * Used to avoid printing more than one pause message or scheduling more than one resumption task per build.
+     * Independent of {@link #paused}.
+     */
+    private transient AtomicBoolean pausedByQuietMode;
 
     /**
      * True if the execution suspension is requested.
@@ -182,6 +192,7 @@ public final class CpsThreadGroup implements Serializable {
 
     private void setupTransients() {
         runner = new CpsVmExecutorService(this);
+        pausedByQuietMode = new AtomicBoolean();
         if (paused == null) { // earlier versions did not have this field.
             paused = new AtomicBoolean();
         }
@@ -271,7 +282,28 @@ public final class CpsThreadGroup implements Serializable {
                 @SuppressFBWarnings(value="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", justification="runner.submit() result")
                 public Void call() throws Exception {
                     Jenkins j = Jenkins.getInstanceOrNull();
+                    if (j != null && !j.isQuietingDown() && execution != null && pausedByQuietMode.compareAndSet(true, false)) {
+                        try {
+                            execution.getOwner().getListener().getLogger().println("Resuming (Prepare for shutdown was canceled)");
+                        } catch (IOException e) {
+                            LOGGER.log(Level.WARNING, null, e);
+                        }
+                    }
                     if (paused.get() || j == null || (execution != null && j.isQuietingDown())) {
+                        if (j != null && j.isQuietingDown() && execution != null && pausedByQuietMode.compareAndSet(false, true)) {
+                            try {
+                                execution.getOwner().getListener().getLogger().println("Pausing (Preparing for shutdown)");
+                            } catch (IOException e) {
+                               LOGGER.log(Level.WARNING, null, e);
+                            }
+                            Timer.get().schedule(() -> {
+                                if (j.isQuietingDown()) {
+                                    Timer.get().schedule(this, Main.isUnitTest ? 1 : 10, TimeUnit.SECONDS);
+                                } else {
+                                    scheduleRun();
+                                }
+                            }, Main.isUnitTest ? 1 : 10, TimeUnit.SECONDS);
+                        }
                         // by doing the pause check inside, we make sure that scheduleRun() returns a
                         // future that waits for any previously scheduled tasks to be completed.
                         saveProgramIfPossible(true);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -284,7 +284,7 @@ public final class CpsThreadGroup implements Serializable {
                     Jenkins j = Jenkins.getInstanceOrNull();
                     if (j != null && !j.isQuietingDown() && execution != null && pausedByQuietMode.compareAndSet(true, false)) {
                         try {
-                            execution.getOwner().getListener().getLogger().println("Resuming (Prepare for shutdown was canceled)");
+                            execution.getOwner().getListener().getLogger().println("Resuming (Shutdown was canceled)");
                         } catch (IOException e) {
                             LOGGER.log(Level.WARNING, null, e);
                         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -258,36 +258,6 @@ public class CpsFlowExecutionTest {
         });
     }
 
-    @Issue("JENKINS-34256")
-    @Test public void pauseAndQuietDown() {
-        story.then(r -> {
-            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-            p.setDefinition(new CpsFlowDefinition("semaphore 'wait'; echo 'I am done'", true));
-            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
-            CpsFlowExecution exec = (CpsFlowExecution) b.getExecutionPromise().get();
-            SemaphoreStep.waitForStart("wait/1", b);
-            // Pause the build and enable quiet mode.
-            exec.pause(true);
-            r.jenkins.doQuietDown(true, 0);
-            exec.waitForSuspension();
-            SemaphoreStep.success("wait/1", null);
-            assertTrue(b.isBuilding());
-            r.assertLogNotContains("I am done", b);
-            // While still paused, cancel quiet mode.
-            r.jenkins.doCancelQuietDown();
-            r.assertLogNotContains("I am done", b);
-            // Enable quiet mode again
-            r.jenkins.doQuietDown(true, 0);
-            r.assertLogNotContains("I am done", b);
-            // Unpause the build
-            exec.pause(false);
-            r.assertLogNotContains("I am done", b);
-            // Cancel quiet mode now that the build is unpaused so the build can finish.
-            r.jenkins.doCancelQuietDown();
-            r.assertLogContains("I am done", r.assertBuildStatusSuccess(r.waitForCompletion(b)));
-        });
-    }
-
     @Test public void timing() {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -255,7 +255,7 @@ public class CpsFlowExecutionTest {
             assertTrue(b.isBuilding());
             r.assertLogNotContains("I am done", b);
             r.jenkins.doCancelQuietDown();
-            r.waitForMessage("Resuming (Prepare for shutdown was canceled)", b);
+            r.waitForMessage("Resuming (Shutdown was canceled)", b);
             r.assertLogContains("I am done", r.assertBuildStatusSuccess(r.waitForCompletion(b)));
         });
     }
@@ -278,7 +278,7 @@ public class CpsFlowExecutionTest {
             r.waitForMessage("Resuming", b);
             r.waitForMessage("Pausing (Preparing for shutdown)", b);
             r.jenkins.doCancelQuietDown();
-            r.waitForMessage("Resuming (Prepare for shutdown was canceled)", b);
+            r.waitForMessage("Resuming (Shutdown was canceled)", b);
             r.assertLogContains("I am done", r.assertBuildStatusSuccess(r.waitForCompletion(b)));
         });
     }
@@ -299,7 +299,7 @@ public class CpsFlowExecutionTest {
             r.assertLogNotContains("Pausing (Preparing for shutdown)", b);
             r.jenkins.doCancelQuietDown();
             Thread.sleep(1000);
-            r.assertLogNotContains("Resuming (Prepare for shutdown was canceled)", b);
+            r.assertLogNotContains("Resuming (Shutdown was canceled)", b);
             ((CpsFlowExecution) b.getExecution()).pause(false);
             r.waitForMessage("Resuming", b);
             r.assertLogContains("I am done", r.assertBuildStatusSuccess(r.waitForCompletion(b)));
@@ -319,7 +319,7 @@ public class CpsFlowExecutionTest {
             ((CpsFlowExecution) b.getExecution()).pause(true);
             r.waitForMessage("Pausing", b);
             r.jenkins.doCancelQuietDown();
-            r.waitForMessage("Resuming (Prepare for shutdown was canceled)", b);
+            r.waitForMessage("Resuming (Shutdown was canceled)", b);
             r.assertLogNotContains("I am done", b);
             ((CpsFlowExecution) b.getExecution()).pause(false);
             r.waitForMessage("Resuming", b);
@@ -343,7 +343,7 @@ public class CpsFlowExecutionTest {
             r.waitForMessage("Resuming", b);
             r.assertLogNotContains("I am done", b);
             r.jenkins.doCancelQuietDown();
-            r.waitForMessage("Resuming (Prepare for shutdown was canceled)", b);
+            r.waitForMessage("Resuming (Shutdown was canceled)", b);
             r.assertLogContains("I am done", r.assertBuildStatusSuccess(r.waitForCompletion(b)));
         });
     }


### PR DESCRIPTION
See [JENKINS-34256](https://issues.jenkins-ci.org/browse/JENKINS-34256).

I am not sure if this is the only problem described in that ticket, since there is some discussion there about specific steps, but as far as I can tell the problem was that once the `CpsThreadGroup` suspended itself because it detected that quiet mode was enabled, nothing will call `CpsThreadGroup.scheduleRun` other than pausing and unpausing the Pipeline or restarting Jenkins, so the build is just permanently suspended.

This PR fixes the issue by adding a listener that tracks `Jenkins.isQuietingDown` to detect when quiet down mode is cancelled so that it can call `CpsThreadGroup.scheduleRun` which will resume the build.

I'm not sure if there is a better way to do this, or if the current behavior is even the behavior we want. Why not just allow the Pipelines to continue executing so that suspension/resumption works as normal when Jenkins is restarted? **EDIT**: Jesse discusses the reasoning behind the current behavior in [JENKINS-32015](https://issues.jenkins-ci.org/browse/JENKINS-32015).

Opening a draft PR for now while I read through the ticket to see if I am misunderstanding the issue.

**EDIT**: I read through all the comments, including the ones on [JENKINS-38316](https://issues.jenkins-ci.org/browse/JENKINS-38316) and found [this comment](https://issues.jenkins-ci.org/browse/JENKINS-38316?focusedCommentId=313473&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-313473) from Jesse, which is essentially what I am doing here for the fix. I think this fix is the root cause of all the issues discussed in the ticket, along with confusion from users on what "Prepare for shutdown" does for Pipeline jobs.