### PR TITLE
[JENKINS-60354] Mark thrown FlowInterruptedExceptions as actual interruptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <groovy-cps.version>1.31</groovy-cps.version>
         <structs-plugin.version>1.20</structs-plugin.version>
-        <workflow-step-api-plugin.version>2.21</workflow-step-api-plugin.version>
+        <workflow-step-api-plugin.version>2.22-rc550.2870bd01d2ff</workflow-step-api-plugin.version> <!-- TODO: https://github.com/jenkinsci/workflow-step-api-plugin/pull/51 -->
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -250,7 +250,7 @@ class CpsBodyExecution extends BodyExecution {
         synchronized (this) {
             if (isDone())  return false;   // already complete
             // TODO should perhaps rather override cancel(Throwable) and make this overload just delegate to that one
-            stopped = new FlowInterruptedException(Result.ABORTED, causes);
+            stopped = new FlowInterruptedException(Result.ABORTED, true, causes);
             t = this.thread;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1134,7 +1134,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         setResult(result);
 
         LOGGER.log(Level.FINE, "Interrupting {0} as {1}", new Object[] {owner, result});
-        final FlowInterruptedException ex = new FlowInterruptedException(result,causes);
+        final FlowInterruptedException ex = new FlowInterruptedException(result, true, causes);
 
         // stop all ongoing activities
         runInCpsVmThread(new FutureCallback<CpsThreadGroup>() {
@@ -2048,7 +2048,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         }
         try {
             owner.getListener().getLogger().println("Failing build: shutting down master and build is marked to not resume");
-            final Throwable x = new FlowInterruptedException(Result.ABORTED);
+            final Throwable x = new FlowInterruptedException(Result.ABORTED, true);
             Futures.addCallback(this.getCurrentExecutions(/* cf. JENKINS-26148 */true), new FutureCallback<List<StepExecution>>() {
                 @Override public void onSuccess(List<StepExecution> l) {
                     for (StepExecution e : Iterators.reverse(l)) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
@@ -398,7 +398,7 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
                                 if (s != null) {
                                     // TODO: ideally this needs to work like interrupt, in that
                                     // if s==null the next StepExecution gets interrupted when it happen
-                                    FlowInterruptedException cause = new FlowInterruptedException(Result.FAILURE, new BodyFailed());
+                                    FlowInterruptedException cause = new FlowInterruptedException(Result.FAILURE, true, new BodyFailed());
                                     cause.initCause(getOutcome().getAbnormal());
                                     try {
                                         // TODO JENKINS-26148/JENKINS-34637 this is probably wrong: should interrupt the innermost execution


### PR DESCRIPTION
See [JENKINS-60354](https://issues.jenkins-ci.org/browse/JENKINS-60354) and https://github.com/jenkinsci/workflow-step-api-plugin/pull/51.