### PR TITLE
Set the constructor of ReplayAction as public

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
@@ -91,7 +91,7 @@ public class ReplayAction implements Action {
 
     private final Run run;
 
-    private ReplayAction(Run run) {
+    public ReplayAction(Run run) {
         this.run = run;
     }
 


### PR DESCRIPTION
It's no harm to set the constructor as public. And I hope I can reuse ReplayAction in my plugin directly.