### PR TITLE
Update groovy-cps to ignore some CPS method mismatch warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <git-plugin.version>3.1.0</git-plugin.version>
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
-        <groovy-cps.version>1.31</groovy-cps.version>
+        <groovy-cps.version>1.32-20200120.215052-1</groovy-cps.version> <!-- TODO: https://github.com/cloudbees/groovy-cps/pull/103 -->
         <structs-plugin.version>1.20</structs-plugin.version>
         <workflow-step-api-plugin.version>2.21</workflow-step-api-plugin.version>
     </properties>


### PR DESCRIPTION
See https://github.com/cloudbees/groovy-cps/pull/103. Just testing that PR and picking it up in a plugin so other plugins can test the fix.