### PR TITLE
Use FailFastCause to provide a nicer cause of failure

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java
@@ -8,6 +8,7 @@ import hudson.Extension;
 import hudson.model.Result;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import jenkins.model.CauseOfInterruption;
 
 import org.jenkinsci.plugins.workflow.cps.CpsVmThreadOnly;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
@@ -147,7 +148,7 @@ public class ParallelStep extends Step {
                         if (stepFailed && handler.failFast && ! handler.isStopSent()) {
                             handler.stopSent();
                             try {
-                                handler.stepExecution.stop(new FailFastException());
+                                handler.stepExecution.stop(new FailFastCause(name));
                             }
                             catch (Exception ignored) {
                                 // ignored.
@@ -249,7 +250,25 @@ public class ParallelStep extends Step {
         private static final long serialVersionUID = 1L;
     }
 
-    /** Internal exception that is only used internally to abort a parallel body in the case of a failFast body failing. */
+    /** Used to abort a running branch body in the case of {@code failFast} taking effect. */
+    private static final class FailFastCause extends CauseOfInterruption {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String failingBranch;
+
+        FailFastCause(String failingBranch) {
+            this.failingBranch = failingBranch;
+        }
+
+        @Override public String getShortDescription() {
+            return "Failed in branch "+ failingBranch;
+        }
+
+    }
+
+    /** @deprecated no longer used, just here for serial compatibility */
+    @Deprecated
     private static final class FailFastException extends Exception {
         private static final long serialVersionUID = 1L;
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepExecution.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.workflow.cps.steps;
 
 import groovy.lang.Closure;
 import hudson.model.TaskListener;
+import jenkins.model.CauseOfInterruption;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.cps.CpsStepContext;
@@ -65,6 +66,12 @@ class ParallelStepExecution extends StepExecution {
         // Despite suggestion in JENKINS-26148, super.stop does not work here, even accounting for the direct call from checkAllDone.
         for (BodyExecution body : bodies) {
             body.cancel(cause);
+        }
+    }
+
+    void stop(CauseOfInterruption... causes) {
+        for (BodyExecution body : bodies) {
+            body.cancel(causes);
         }
     }
 


### PR DESCRIPTION
Previously `ParallelStep.ResultHandler.Callback.checkAllDone` made a `FailFastException` with no (`null`) message, then calls `ParallelStepExecution.stop`, which calls `BodyExecution.cancel(Throwable)`, which creates a `FlowInterruptedException` with an `ExceptionCause`, so the message is poor.

Amends https://github.com/jenkinsci/pipeline-plugin/pull/88.