### PR TITLE
[JENKINS-55287] Improve shutdown-related logging

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1978,6 +1978,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             // Nothing to persist OR we've already persisted it along the way.
             return;
         }
+        LOGGER.log(Level.INFO, "Attempting to save a checkpoint of {0} before shutdown", this);
         boolean persistOk = true;
         FlowNodeStorage storage = getStorage();
         if (storage != null) {
@@ -1985,59 +1986,72 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                 storage.flush();
             } catch (IOException ioe) {
                 persistOk=false;
-                LOGGER.log(Level.WARNING, "Error persisting FlowNode storage before shutdown", ioe);
+                LOGGER.log(Level.WARNING, "Error persisting FlowNode storage for: " + this, ioe);
             }
 
             // Try to ensure we've saved the appropriate things -- the program is the last stumbling block.
             try {
                 final SettableFuture<Void> myOutcome = SettableFuture.create();
-                LOGGER.log(Level.INFO, "About to try to checkpoint the program for build"+this);
+                LOGGER.log(Level.FINE, "About to try to checkpoint the program for: {0}", this);
                 if (programPromise != null && programPromise.isDone()) {
                     runInCpsVmThread(new FutureCallback<CpsThreadGroup>() {
                         @Override
                         public void onSuccess(CpsThreadGroup result) {
                             try {
-                                LOGGER.log(Level.INFO, "Trying to save program before shutdown "+this);
+                                LOGGER.log(Level.FINE, "Trying to save program for: {0}", CpsFlowExecution.this);
                                 result.saveProgramIfPossible(true);
-                                LOGGER.log(Level.INFO, "Finished saving program before shutdown "+this);
+                                LOGGER.log(Level.FINE, "Finished saving program for: {0}", CpsFlowExecution.this);
                                 myOutcome.set(null);
                             } catch (Exception ex) {
-                                LOGGER.log(Level.WARNING, "Error persisting program: "+ex);
+                                // Logged at Level.WARNING when we call `myOutcome.get` and it throws an exception.
                                 myOutcome.setException(ex);
                             }
                         }
 
                         @Override
                         public void onFailure(Throwable t) {
-                            LOGGER.log(Level.WARNING, "Failed trying to save program before shutdown "+this);
+                            // Logged at Level.WARNING when we call `myOutcome.get` and it throws an exception.
                             myOutcome.setException(t);
                         }
                     });
                     myOutcome.get(30, TimeUnit.SECONDS);
-                    LOGGER.log(Level.FINE, "Successfully saved program for "+this);
+                    LOGGER.log(Level.FINE, "Successfully saved program for: {0}", this);
+                } else {
+                    persistOk = false;
+                    LOGGER.log(Level.WARNING, "Unable to persist program because it was never loaded for: {0}", this);
                 }
 
             } catch (TimeoutException te) {
                 persistOk = false;
-                LOGGER.log(Level.WARNING, "Timeout persisting program at execution checkpoint", te);
+                LOGGER.log(Level.WARNING, "Timeout persisting program for: " + this, te);
             } catch (ExecutionException | InterruptedException ex) {
                 persistOk = false;
-                LOGGER.log(Level.FINE, "Error saving program, that should be handled elsewhere.", ex);
+                LOGGER.log(Level.WARNING, "Error saving program for: " + this, ex);
             }
             try { // Flush node storage just in case the Program mutated it, just to be sure
                 storage.flush();
-                LOGGER.log(Level.FINE, "Successfully did final flush of storage for "+this);
+                LOGGER.log(Level.FINE, "Successfully did final flush of storage for: {0}", this);
             } catch (IOException ioe) {
                 persistOk=false;
-                LOGGER.log(Level.WARNING, "Error persisting FlowNode storage before shutdown", ioe);
+                LOGGER.log(Level.WARNING, "Error persisting FlowNode storage for: " + this, ioe);
             }
             persistedClean = persistOk;
             try {
                 saveOwner();
             } catch (Exception ex) {
-                LOGGER.log(Level.WARNING, "Error saving build for "+this, ex);
+                persistOk = false;
+                LOGGER.log(Level.WARNING, "Error saving build for: " + this, ex);
             }
 
+        } else {
+            persistOk = false;
+            LOGGER.log(Level.WARNING, "No FlowNode storage for: {0}", this);
+        }
+
+        if (persistOk) {
+            LOGGER.log(Level.INFO, "Successfully saved a checkpoint of {0} before shutdown", this);
+        } else {
+            LOGGER.log(Level.WARNING, "Unable to save a checkpoint of {0} before shutdown. The build will probably fail when Jenkins restarts.", this);
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -16,7 +16,6 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -245,7 +244,6 @@ public class PersistenceProblemsTest {
     }
 
     @Test
-    @Ignore
     public void inProgressMaxPerfCleanShutdown() throws Exception {
         final int[] build = new int[1];
         story.then( j -> {
@@ -265,7 +263,6 @@ public class PersistenceProblemsTest {
     }
 
     @Test
-    @Ignore
     public void inProgressMaxPerfDirtyShutdown() throws Exception {
         final int[] build = new int[1];
         final String[] finalNodeId = new String[1];


### PR DESCRIPTION
See [JENKINS-55287](https://issues.jenkins-ci.org/browse/JENKINS-55287).

While looking through some potentially-relevant code for that issue, I noticed that the logging when saving `CpsFlowExecutions` using the `PERFORMANCE_OPTIMIZED` durability level was a bit inconsistent, didn't really have a single clear message of whether everything was successful or not, didn't log anything for a few conditions that should never happen, used a default impl of `toString` (e.g. `MyClass@hash`) in some cases that were intending to print the name of the flow execution, and mentioned shutdown in some cases where Jenkins isn't shutting down.

~Opening as a draft PR for now, because I want to look through the logs of the tests before and after the change to see if anything interesting stands out, and maybe add some assertions on specific log messages to existing tests. I did check the output of some tests in `PersistenceProblemsTest` just as an overall sanity check.~

More detailed analysis of JENKINS-55287 is in https://github.com/jenkinsci/workflow-cps-plugin/pull/363 (which incorporates this PR). I think this PR is still useful, so I am marking it as ready for review so it can be reviewed and merged independently from https://github.com/jenkinsci/workflow-cps-plugin/pull/363