### PR TITLE
[JENKINS-62659] Fix iterator serialization errors for types that implement Deque

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/persistence/IteratorHack.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/persistence/IteratorHack.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -102,6 +103,11 @@ public class IteratorHack {
     public static <E> Iterator<E> iterator(E[] array) {
         // TODO as above
         return new Itr<>(Arrays.asList(array));
+    }
+
+    public static <E> Iterator<E> iterator(Deque deque) {
+        // TODO as above
+        return new Itr<>(new ArrayList<>(deque));
     }
 
     private static final class ListItr<E> extends Itr<E> implements ListIterator<E> {


### PR DESCRIPTION
See [JENKINS-62659](https://issues.jenkins-ci.org/browse/JENKINS-62659). Fixes https://github.com/cloudbees/groovy-cps/issues/105.

Groovy seems to have nondeterministic behavior when checking for category methods on types that implement more than one interface with the same name (e.g. `LinkedList`, which implements both `Deque` and `List`, each of which have an `iterator` method). Groovy picks one of the interfaces (via `MetaMethodIndex.getMethods`), and only checks for a matching category method for the chosen interface, which is problematic if the category method is only implemented for one of the interfaces and Groovy chooses the other one. 

In our case, this means that `new LinkedList(...).iterator()` sometimes calls `IteratorHack.iterator(List)` and so returns a serializable iterator, but sometimes it doesn't, and we end up with an unserializable iterator that throws a `NotSerializableException`.

I was not able to figure out exactly what causes the nondeterminism in Groovy, and I couldn't reproduce the issue in a standalone Groovy script, so maybe it is specific to embedded Groovy or something.

Thankfully, we can easily fix the specific issue raised in https://github.com/cloudbees/groovy-cps/issues/105 by creating `IteratorHack.iterator(Deque)` so that it doesn't matter which interface Groovy picks.