### PR TITLE
Expose assertGenerateSnippet to pipeline-model-definition

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
@@ -98,7 +98,7 @@ import org.kohsuke.stapler.StaplerRequest;
      *
      * @param o The object to translate.
      * @param nestedExp
-     *      true if this object is written as a nested expression (in which case we always produce parenthesis for readability)
+     *      true if this object is written as a nested expression (in which case we always produce parentheses for readability)
      * @return A string translation of the object.
      */
     public static String object2Groovy(Object o, boolean nestedExp) throws UnsupportedOperationException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
@@ -89,7 +89,20 @@ import org.kohsuke.stapler.StaplerRequest;
      * @return A string translation of the object.
      */
     public static String object2Groovy(Object o) throws UnsupportedOperationException {
-        return object2Groovy(new StringBuilder(), o, false).toString();
+        return object2Groovy(o, false);
+    }
+
+    /**
+     * Publicly accessible version of {@link #object2Groovy(StringBuilder, Object, boolean)} that translates an object into
+     * the equivalent Pipeline Groovy string.
+     *
+     * @param o The object to translate.
+     * @param nestedExp
+     *      true if this object is written as a nested expression (in which case we always produce parenthesis for readability)
+     * @return A string translation of the object.
+     */
+    public static String object2Groovy(Object o, boolean nestedExp) throws UnsupportedOperationException {
+        return object2Groovy(new StringBuilder(), o, nestedExp).toString();
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTester.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTester.java
@@ -60,8 +60,24 @@ public class SnippetizerTester {
      *      needed because of {@link StaplerReferer}
      */
     public void assertGenerateSnippet(@Nonnull String json, @Nonnull String responseText, @CheckForNull String referer) throws Exception {
+        assertGenerateSnippet(Snippetizer.GENERATE_URL, json, responseText, referer);
+    }
+
+    /**
+     * Tests a form submitting part of snippetizer.
+     *
+     * @param url
+     *      Generation URL
+     * @param json
+     *      The form submission value from the configuration page to be tested.
+     * @param responseText
+     *      Expected snippet to be generated
+     * @param referer
+     *      needed because of {@link StaplerReferer}
+     */
+    protected void assertGenerateSnippet(@Nonnull String url, @Nonnull String json, @Nonnull String responseText, @CheckForNull String referer) throws Exception {
         JenkinsRule.WebClient wc = r.createWebClient();
-        WebRequest wrs = new WebRequest(new URL(r.getURL(), Snippetizer.GENERATE_URL), HttpMethod.POST);
+        WebRequest wrs = new WebRequest(new URL(r.getURL(), url), HttpMethod.POST);
         if (referer != null) {
             wrs.setAdditionalHeader("Referer", referer);
         }


### PR DESCRIPTION
Essentially DRY for [DirectiveGeneratorTest](https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/d9f665d27c269f8294e3897f54f1f7d1f3d6a8e5/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGeneratorTest.java#L587-L602). Upstream of https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/396