### PR TITLE
[JENKINS-55287] Improve error messages for nonresumable Pipelines

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -2001,7 +2001,9 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             // Nothing to persist OR we've already persisted it along the way.
             return;
         }
-        LOGGER.log(Level.INFO, "Attempting to save a checkpoint of {0} before shutdown", this);
+        LOGGER.log(Level.INFO, "Attempting to checkpoint all data for {0}{1}", new Object[] {
+            this, (shuttingDown ? " before shutdown" : "")
+        });
         boolean persistOk = true;
         FlowNodeStorage storage = getStorage();
         if (storage != null) {
@@ -2077,9 +2079,13 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         }
 
         if (persistOk) {
-            LOGGER.log(Level.INFO, "Successfully saved a checkpoint of {0} before shutdown", this);
+            LOGGER.log(Level.INFO, "Successfully checkpointed {0}{1}", new Object[] {
+                this, (shuttingDown ? " before shutdown" : "")
+            });
         } else {
-            LOGGER.log(Level.WARNING, "Unable to save a checkpoint of {0} before shutdown. The build will probably fail when Jenkins restarts.", this);
+            LOGGER.log(Level.WARNING, "Unable to successfully checkpoint {0}{1}", new Object[] {
+                this, (shuttingDown ? " before shutdown, so this build will probably fail when Jenkins restarts" : "")
+            });
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1957,38 +1957,27 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         }
     }
 
-    void saveOwner() {
-        saveOwner(false);
-    }
-
     /** Save the owner that holds this execution.
      *  Key note: to avoid deadlocks we need to ensure that we don't hold a lock on this CpsFlowExecution when running saveOwner
      *   or pre-emptively lock the run before locking the execution and saving. */
-    void saveOwner(boolean shuttingDown) {
+    void saveOwner() {
         try {
             if (this.owner != null && this.owner.getExecutable() instanceof Saveable) {  // Null-check covers some anomalous cases we've seen
                 Saveable saveable = (Saveable)(this.owner.getExecutable());
-                if (shuttingDown) {
-                    persistedClean = true;
-                }
                 if (storage != null && storage.delegate != null) {
                     // Defensively flush FlowNodes to storage
                     try {
                         storage.flush();
                     } catch (Exception ex) {
                         LOGGER.log(Level.WARNING, "Error persisting FlowNodes for execution "+owner, ex);
-                        if (shuttingDown) {
-                            persistedClean = false;
-                        }
+                        persistedClean = false;
                     }
                 }
                 saveable.save();
             }
         } catch (IOException ex) {
             LOGGER.log(Level.WARNING, "Error persisting Run "+owner, ex);
-            if (shuttingDown) {
-                persistedClean = false;
-            }
+            persistedClean = false;
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
@@ -15,7 +15,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import static org.junit.Assert.*;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
@@ -292,7 +291,6 @@ public class RestartingLoadStepTest {
         });
     }
 
-    @Ignore("TODO Flaky. Sometimes the node step's execution is still part of the program after the restart, which causes the Pipeline to fail during resumption because the node step already completed according to the flow graph")
     @Test
     public void updatedBindingsOnRestart() throws Exception {
         story.then(r -> {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
@@ -15,6 +15,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import static org.junit.Assert.*;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
@@ -291,6 +292,7 @@ public class RestartingLoadStepTest {
         });
     }
 
+    @Ignore("TODO Flaky. Sometimes the node step's execution is still part of the program after the restart, which causes the Pipeline to fail during resumption because the node step already completed according to the flow graph")
     @Test
     public void updatedBindingsOnRestart() throws Exception {
         story.then(r -> {


### PR DESCRIPTION
See [JENKINS-55287](https://issues.jenkins-ci.org/browse/JENKINS-55287). Subsumes https://github.com/jenkinsci/workflow-cps-plugin/pull/354 (and will subsume https://github.com/jenkinsci/workflow-cps-plugin/pull/234 eventually).

Based on the cases I've seen, I think the root cause of JENKINS-55287 is that Jenkins is crashing, so it is expected that PERFORMANCE_OPTIMIZED Pipelines are unable to resume. From that perspective, the issue is more that the error message is misleading and causes users to think they have hit a bug in Pipeline, when really this case is expected and the fix is to investigate and understand why Jenkins is crashing.

The field `CpsFlowExecution.persistedClean` was supposed to help detect these cases and print a more relevant error message, but there were two issues:
* It was always set to true right after a build started because of [this call to `CpsFlowExecution.saveOwner`](https://github.com/jenkinsci/workflow-cps-plugin/blob/455249a3b9b65450e4de0739a46668e2f5c1202e/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java#L537) that occurs right after the build starts. In the cases of JENKINS-55287 I have seen, the only persisted flow node is always the `FlowStartNode`, meaning that this is the only time the build was ever saved, and so the build is always considered resumable unless Jenkins shuts down normally and there is an error while saving the build in `CpsFlowExecution.suspendAll`. To fix this we only modify `persistedClean` if Jenkins is shutting down.
* The logic that checks if a Pipeline can be resumed used to only happen _after_ the flow graph was initialized, but in most (all?) cases the flow graph will be incomplete and so that will fail. That means that we also need to check if the Pipeline is resumable either before trying to initializing flow nodes (pessimistic) and fail immediately, or after we receive an error loading flow nodes (optimistic) and then change the reported error as necessary. **EDIT**: Part of the problem here is that the flow graph is persisted after every step for `PERFORMANCE_OPTIMIZED` pipelines, see https://github.com/jenkinsci/workflow-cps-plugin/pull/234. I don't think it makes sense to try to update the logic here without fixing that first, so I will look into fixing that separately.