### PR TITLE
[JENKINS-63164] Clear CpsBodyExecution.thread when the body completes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -325,8 +325,16 @@ class CpsBodyExecution extends BodyExecution {
 
     private void setOutcome(Outcome o) {
         synchronized (this) {
-            if (bodyToUnexport != null && thread != null) {
-                thread.group.unexport(bodyToUnexport);
+            if (thread != null) {
+                if (bodyToUnexport != null) {
+                    thread.group.unexport(bodyToUnexport);
+                }
+                // onSuccess and onFailure are part of the program and reference the CpsBodyExecution as their outer
+                // class. They are usually unreachable from the program once the body completes, but in some cases they
+                // may still be reachable (e.g. closures that outlive the body). If the CpsBodyExecution is still part
+                // of the program, we need to make sure that we do not reference to a dead CpsThread because that may
+                // cause resumption issues (JENKINS-63164).
+                thread = null;
             }
             if (outcome!=null)
                 throw new IllegalStateException("Outcome is already set");

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
@@ -228,12 +228,12 @@ public class CpsBodyExecutionTest {
             DumbSlave s = r.createOnlineSlave();
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "demo");
             p.setDefinition(new CpsFlowDefinition(
-                    "def global = null\n" +
+                    "def closure = null\n" +
                     "node('" + s.getNodeName() + "') {\n" +
-                    "  global = { -> 'this closure captures CpsBodyExecution' }\n" +
+                    "  closure = { -> 'this closure captures CpsBodyExecution' }\n" +
                     "}\n" +
                     "semaphore 'wait'\n" +
-                    "echo(global())", true));
+                    "echo(closure())", true));
             WorkflowRun b = p.scheduleBuild2(0).waitForStart();
             SemaphoreStep.waitForStart("wait/1", b);
             String xml = ((CpsFlowExecution) b.getExecution()).programPromise.get().asXml();


### PR DESCRIPTION
See [JENKINS-63164](https://issues.jenkins-ci.org/browse/JENKINS-63164). Kind of reimplements #245 after #279 replaced it with a different approach that works better than #245 but only affects the `parallel` and `load` steps.

JENKINS-63164 is the root cause of `RestartingLoadStepTest.updatedBindingsOnRestart` being flaky, see #366.

I am really not sure about the best way to fix the issue. See https://github.com/jenkinsci/workflow-cps-plugin/pull/367#discussion_r458869636 for some discussion of other options.