### PR TITLE
[JENKINS-63164] Clear fields in CpsThread when thread is removed from CpsThreadGroup

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -235,8 +235,8 @@ public final class CpsThread implements Serializable {
     }
 
     /**
-     * When this thread is removed from its CpsThreadGroup, we null out most of its references in case something is
-     * unexpectedly holding a reference directly to the CpsThread (e.g. JENKINS-63164).
+     * When this thread is removed from its {@link CpsThreadGroup}, we null out most of its references in case
+     * something is unexpectedly holding a reference directly to it (see JENKINS-63164 for an example scenario).
      */
     void cleanUp() {
         program = null;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -114,7 +114,7 @@ public final class CpsThread implements Serializable {
      */
     private final List<FutureCallback<Object>> completionHandlers = new ArrayList<>();
 
-    CpsThread(CpsThreadGroup group, int id, Continuable program, FlowHead head, ContextVariableSet contextVariables) {
+    CpsThread(CpsThreadGroup group, int id, @Nonnull Continuable program, FlowHead head, ContextVariableSet contextVariables) {
         this.group = group;
         this.id = id;
         this.program = group.getExecution().isSandbox() ? new SandboxContinuable(program,this) : program;
@@ -231,6 +231,7 @@ public final class CpsThread implements Serializable {
      * (as opposed to have finished running, either normally or abnormally?)
      */
     boolean isAlive() {
+        assert program != null; // Otherwise this CpsThread is not even part of the CpsThreadGroup, so how is it being accessed?
         return program.isResumable();
     }
 
@@ -323,6 +324,7 @@ public final class CpsThread implements Serializable {
     }
 
     public List<StackTraceElement> getStackTrace() {
+        assert program != null; // Otherwise this CpsThread is not even part of the CpsThreadGroup, so how is it being accessed?
         return program.getStackTrace();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -101,7 +101,7 @@ public final class CpsThread implements Serializable {
     final FlowHead head;
 
     @Nullable
-    private final ContextVariableSet contextVariables;
+    private ContextVariableSet contextVariables;
 
     /**
      * If this thread is waiting for a {@link StepExecution} to complete (by invoking our callback),
@@ -232,6 +232,18 @@ public final class CpsThread implements Serializable {
      */
     boolean isAlive() {
         return program.isResumable();
+    }
+
+    /**
+     * When this thread is removed from its CpsThreadGroup, we null out most of its references in case something is
+     * unexpectedly holding a reference directly to the CpsThread (e.g. JENKINS-63164).
+     */
+    void cleanUp() {
+        program = null;
+        resumeValue = null;
+        step = null;
+        contextVariables = null;
+        completionHandlers.clear();
     }
 
     @CpsVmThreadOnly

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -194,7 +194,7 @@ public final class CpsThreadGroup implements Serializable {
     }
 
     @CpsVmThreadOnly
-    public CpsThread addThread(Continuable program, FlowHead head, ContextVariableSet contextVariables) {
+    public CpsThread addThread(@Nonnull Continuable program, FlowHead head, ContextVariableSet contextVariables) {
         assertVmThread();
         CpsThread t = new CpsThread(this, iota++, program, head, contextVariables);
         threads.put(t.id, t);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -419,6 +419,7 @@ public final class CpsThreadGroup implements Serializable {
                     t.fireCompletionHandlers(o); // do this after ErrorAction is set above
 
                     threads.remove(t.id);
+                    t.cleanUp();
                     if (threads.isEmpty()) {
                         execution.onProgramEnd(o);
                         try {

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;
-import static org.hamcrest.Matchers.*;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepNode;
@@ -27,7 +26,6 @@ import org.jenkinsci.plugins.workflow.steps.BodyExecution;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
-import static org.junit.Assert.*;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,6 +34,11 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class CpsBodyExecutionTest {
 
@@ -214,14 +217,36 @@ public class CpsBodyExecutionTest {
         });
         rr.then(r -> {
             WorkflowRun b = r.jenkins.getItemByFullName("demo", WorkflowJob.class).getBuildByNumber(1);
-            SemaphoreStep.waitForStart("wait/1", b);
             SemaphoreStep.success("wait/1", null);
-            while (b.isBuilding()) {
-                // Before the fix for JENKINS-53709, the job hangs forever while attempting to rehydrate the agent.
-                r.assertLogNotContains("Jenkins doesn’t have label", b);
-                Thread.sleep(100);
-            }
-            r.assertBuildStatusSuccess(b);
+            r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        });
+    }
+
+    @Issue("JENKINS-63164")
+    @Test public void closureCapturesCpsBodyExecution() {
+        rr.then(r -> {
+            DumbSlave s = r.createOnlineSlave();
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "demo");
+            p.setDefinition(new CpsFlowDefinition(
+                    "def closure = null\n" +
+                    "node('" + s.getNodeName() + "') {\n" +
+                    "  closure = { -> 'this closure captures CpsBodyExecution' }\n" +
+                    "}\n" +
+                    "semaphore 'wait'\n" +
+                    "echo(closure())", true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            SemaphoreStep.waitForStart("wait/1", b);
+            String xml = ((CpsFlowExecution) b.getExecution()).programPromise.get().asXml();
+            System.out.print(xml);
+            assertThat(xml, not(containsString(s.getWorkspaceFor(p).getRemote())));
+            // TODO: ExecutorStepExecution.PlaceholderTask.Callback is still present in the program, should we do something about CpsBodyExecution.callbacks?
+            r.jenkins.removeNode(s);
+        });
+        rr.then(r -> {
+            WorkflowRun b = r.jenkins.getItemByFullName("demo", WorkflowJob.class).getBuildByNumber(1);
+            SemaphoreStep.success("wait/1", null);
+            r.assertBuildStatusSuccess(r.waitForCompletion(b));
+            r.assertLogContains("this closure captures CpsBodyExecution", b);
         });
     }
 


### PR DESCRIPTION
See #367. This is the first alternative discussed in https://github.com/jenkinsci/workflow-cps-plugin/pull/367#discussion_r458869636.