### PR TITLE
Add 2.82 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 2.82
+
+Release date: 2020-07-30
+
+* Fix: In some cases, block-scoped steps that had already completed could be persisted in serialized Pipelines, causing the already-completed steps to resume when the Pipeline resumed. ([JENKINS-63164](https://issues.jenkins-ci.org/browse/JENKINS-63164))
+
 ### 2.81
 
 Release date: 2020-06-30


### PR DESCRIPTION
I am planning on releasing the plugin today. Only change is #368, so in case something goes wrong with that change we can just block the release from the update center without needing to worry about other changes that users might care about. 