### PR TITLE
[JENKINS-63500] Fix SnippetizerTest.oneOrMoreArgsStepDocs in Jenkins 2.236 and newer

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
@@ -35,10 +35,16 @@ import org.jenkinsci.plugins.workflow.steps.CoreStep;
 import org.jenkinsci.plugins.workflow.steps.EchoStep;
 import org.jenkinsci.plugins.workflow.steps.PwdStep;
 import org.jenkinsci.plugins.workflow.steps.ReadFileStep;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStep;
 import org.jenkinsci.plugins.workflow.support.steps.WorkspaceStep;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStep;
+import org.jenkinsci.plugins.workflow.testMetaStep.Circle;
 import org.jenkinsci.plugins.workflow.testMetaStep.Colorado;
+import org.jenkinsci.plugins.workflow.testMetaStep.CurveMetaStep;
 import org.jenkinsci.plugins.workflow.testMetaStep.EchoResultStep;
 import org.jenkinsci.plugins.workflow.testMetaStep.EchoStringAndDoubleStep;
 import org.jenkinsci.plugins.workflow.testMetaStep.Hawaii;
@@ -50,6 +56,7 @@ import org.jenkinsci.plugins.workflow.testMetaStep.MonomorphicListWithSymbolStep
 import org.jenkinsci.plugins.workflow.testMetaStep.MonomorphicStep;
 import org.jenkinsci.plugins.workflow.testMetaStep.MonomorphicWithSymbolStep;
 import org.jenkinsci.plugins.workflow.testMetaStep.Oregon;
+import org.jenkinsci.plugins.workflow.testMetaStep.Polygon;
 import org.jenkinsci.plugins.workflow.testMetaStep.StateMetaStep;
 import org.jenkinsci.plugins.workflow.testMetaStep.chemical.CarbonMonoxide;
 import org.jenkinsci.plugins.workflow.testMetaStep.chemical.DetectionMetaStep;
@@ -65,19 +72,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 
-import static org.hamcrest.CoreMatchers.*;
-import org.jenkinsci.plugins.workflow.steps.Step;
-import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
-import org.jenkinsci.plugins.workflow.steps.StepExecution;
-import org.jenkinsci.plugins.workflow.testMetaStep.Circle;
-import org.jenkinsci.plugins.workflow.testMetaStep.CurveMetaStep;
-import org.jenkinsci.plugins.workflow.testMetaStep.Polygon;
-import static org.junit.Assert.*;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.NoStaplerConstructorException;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 // TODO these tests would better be moved to the respective plugins
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTest.java
@@ -39,6 +39,7 @@ import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.TimeoutStep;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStep;
 import org.jenkinsci.plugins.workflow.support.steps.WorkspaceStep;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStep;
@@ -302,7 +303,7 @@ public class SnippetizerTest {
 
     @Test
     public void oneOrMoreArgsStepDocs() throws Exception {
-        SnippetizerTester.assertDocGeneration(InputStep.class);
+        SnippetizerTester.assertDocGeneration(TimeoutStep.class);
     }
 
     @Test


### PR DESCRIPTION
See [JENKINS-63500](https://issues.jenkins-ci.org/browse/JENKINS-63500).

Doc generation fails for the `input` step in new versions of Jenkins, so we switch this test over to a different step that doesn't have anything to do with parameters to avoid the issue.

https://github.com/jenkinsci/workflow-cps-plugin/commit/e2b1c95be13c17fc3dbf15cb55a55e16ffa217fc just moves some imports around, and https://github.com/jenkinsci/workflow-cps-plugin/commit/f9f4918b6b5b397c9a2fde53d6d3671a2e87ef62 is the fix.