### PR TITLE
[JENKINS-64185] Replace use of NamedArgsAndClosure as return value for invokeDescribable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -289,7 +289,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         ClassLoader originalLoader = Thread.currentThread().getContextClassLoader();
         try {
             TaskListener listener = context.get(TaskListener.class);
-            logInterpolationWarnings(name, argumentsAction, an.getId(), ps.interpolatedStrings, allEnv, sensitiveVariables, listener);
+            logInterpolationWarnings(name, argumentsAction, ps.interpolatedStrings, allEnv, sensitiveVariables, listener);
             if (unreportedAmbiguousFunctions.remove(name)) {
                 reportAmbiguousStepInvocation(context, d, listener);
             }
@@ -360,7 +360,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         }
     }
 
-    private void logInterpolationWarnings(String stepName, @CheckForNull ArgumentsActionImpl argumentsAction, String nodeId, Set<String> interpolatedStrings, @CheckForNull EnvVars envVars, @Nonnull Set<String> sensitiveVariables, TaskListener listener) throws IOException, InterruptedException {
+    private void logInterpolationWarnings(String stepName, @CheckForNull ArgumentsActionImpl argumentsAction, Set<String> interpolatedStrings, @CheckForNull EnvVars envVars, @Nonnull Set<String> sensitiveVariables, TaskListener listener) throws IOException {
         if (UNSAFE_GROOVY_INTERPOLATION.equals("ignore")) {
             return;
         }
@@ -533,12 +533,10 @@ public class DSL extends GroovyObjectSupport implements Serializable {
     /**
      * This class holds the argument map and optional body of the step that is to be invoked.
      *
-     * <p>Some steps have complex argument types (e.g. `checkout` takes {@link hudson.scm.SCM}). When user use symbol-based
-     * syntax with those arguments, an instance of this class is created as the result of {@link DSL#invokeDescribable(String, Object)}.
-     * The instance is returned to the Groovy program so that it can be passed to {@link DSL#invokeStep(StepDescriptor, String, Object)}
-     * later, so it must implement {@link Serializable}.
+     * <p>Groovy strings that are interpolated are collected to be tested against sensitive environment variables in </p>
      */
-    static class NamedArgsAndClosure implements Serializable { final Map<String,Object> namedArgs;
+    static class NamedArgsAndClosure {
+        final Map<String,Object> namedArgs;
         final Closure body;
         final List<String> msgs;
         final Set<String> interpolatedStrings;
@@ -558,9 +556,9 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         }
 
         /**
-         * Recursively search argument values for instances of {@link NamedArgsAndClosure} and convert them to {@link UninstantiatedDescribable}.
+         * Recursively search argument values for instances of {@link UninstantiatedDescribableWithInterpolation}.
          * These instances were created in {@link DSL#invokeDescribable(String, Object)} for symbols with no meta-step.
-         * Gathers all the interpolated strings from each instance of {@link NamedArgsAndClosure}.
+         * Gathers all the interpolated strings from each instance of {@link UninstantiatedDescribableWithInterpolation}.
          */
         private static Object collectInterpolatedStrings(Object argValue, Set<String> interpolatedStrings) {
             if (argValue instanceof UninstantiatedDescribableWithInterpolation) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -447,6 +447,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
             // where this UninstantiatedDescribable is ultimately used, the symbol
             // might be resolved with a specific type.
 
+            // Note: Declarative relies on an instance of UninstantiatedDescribable being returned here in some cases where there is no Pipeline step involved, e.g. for the `triggers` directive.
             return new UninstantiatedDescribableWithInterpolation(symbol, null, args.namedArgs, args.interpolatedStrings);
         } else {
             UninstantiatedDescribable ud = new UninstantiatedDescribable(symbol, null, args.namedArgs);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/UninstantiatedDescribableWithInterpolation.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/UninstantiatedDescribableWithInterpolation.java
@@ -1,0 +1,29 @@
+package org.jenkinsci.plugins.workflow.cps;
+
+import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
+
+import java.util.Map;
+import java.util.Set;
+
+public class UninstantiatedDescribableWithInterpolation extends UninstantiatedDescribable {
+    private final Set<String> interpolatedStrings;
+
+    public UninstantiatedDescribableWithInterpolation(String symbol, String klass, Map<String, ?> arguments, Set<String> interpolatedStrings) {
+        super(symbol, klass, arguments);
+        this.interpolatedStrings = interpolatedStrings;
+    }
+
+    public Set<String> getInterpolatedStrings() {
+        return interpolatedStrings;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/UninstantiatedDescribableWithInterpolation.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/UninstantiatedDescribableWithInterpolation.java
@@ -1,10 +1,20 @@
 package org.jenkinsci.plugins.workflow.cps;
 
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Some steps have complex argument types (e.g. `checkout` takes {@link hudson.scm.SCM}). When user use symbol-based
+ * syntax with those arguments, an instance of this class is created as the result of {@link DSL#invokeDescribable(String, Object)}.
+ *
+ * <p>The difference between this class and its parent, {@link UninstantiatedDescribable}, is that this class stores the Groovy interpolated strings
+ * that were encountered in {@link DSL#flattenGString(Object, Set)} via {@link DSL.NamedArgsAndClosure}</p>
+ */
+@Restricted(NoExternalUse.class)
 public class UninstantiatedDescribableWithInterpolation extends UninstantiatedDescribable {
     private static final long serialVersionUID = 1L;
     private final Set<String> interpolatedStrings;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/UninstantiatedDescribableWithInterpolation.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/UninstantiatedDescribableWithInterpolation.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class UninstantiatedDescribableWithInterpolation extends UninstantiatedDescribable {
+    private static final long serialVersionUID = 1L;
     private final Set<String> interpolatedStrings;
 
     public UninstantiatedDescribableWithInterpolation(String symbol, String klass, Map<String, ?> arguments, Set<String> interpolatedStrings) {


### PR DESCRIPTION
There are some conditions in which the NamedArgsAndClosure class is passed to other packages where it is not recognized. This fix here goes back to an earlier implementation in #370  where we create a subclass of `UninstantiatedDescribable` that stores interpolated strings. This should ensure that existing code that used to look for `UninstantiatedDescribable` can continue to work as expected.


Note: not sure what tests to add to reflect this problem. Did manual testing with the Gerrit plugin