### PR TITLE
[JENKINS-64282] Skip if sensitive variable has an empty string

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -376,7 +376,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         }
 
         List<String> scanResults = sensitiveVariables.stream()
-                .filter(e -> interpolatedStrings.stream().anyMatch(g -> g.contains(envVars.get(e))))
+                .filter(e -> !(envVars.get(e).isEmpty()) && interpolatedStrings.stream().anyMatch(g -> g.contains(envVars.get(e))))
                 .collect(Collectors.toList());
 
         if (scanResults != null && !scanResults.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
@@ -95,6 +95,10 @@ public class ArgumentsActionImpl extends ArgumentsAction {
         }
         String modded = input;
         for (String sensitive : sensitiveVariables) {
+            String sensitiveValue = variables.get(sensitive);
+            if (sensitiveValue.isEmpty()) {
+                continue;
+            }
             modded = modded.replace(variables.get(sensitive), "${" + sensitive + "}");
         }
         return modded;

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -609,7 +609,8 @@ public class DSLTest {
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 
-    @Test public void passwordParameter() throws Exception {
+    @Issue("JENKINS-47101")
+    @Test public void passwordParametersSanitized() throws Exception {
         String shellStep = Functions.isWindows()? "bat" : "sh";
         p.setDefinition(new CpsFlowDefinition(""
                 + "node {\n"
@@ -638,7 +639,7 @@ public class DSLTest {
     }
 
     @Issue("JENKINS-64282")
-    @Test public void emptyPasswordParameter() throws Exception {
+    @Test public void emptyPasswordParametersIgnored() throws Exception {
         String shellStep = Functions.isWindows()? "bat" : "sh";
         p.setDefinition(new CpsFlowDefinition(""
                 + "node {\n"

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImplTest.java
@@ -626,22 +626,6 @@ public class ArgumentsActionImplTest {
                 equalTo(NotStoredReason.UNSERIALIZABLE));
     }
 
-    @Issue("JENKINS-47101")
-    @Test public void passwordParametersSanitized() throws Exception {
-        WorkflowJob p = r.createProject(WorkflowJob.class);
-        p.addProperty(new ParametersDefinitionProperty(
-                Arrays.asList(new PasswordParameterDefinition("MYPASSWORD", "mysecret", "description"))));
-        p.setDefinition(new CpsFlowDefinition("echo(\"$MYPASSWORD\")", true));
-        ParametersAction paramsAction = new ParametersAction(Arrays.asList(new PasswordParameterValue("MYPASSWORD", "mysecret")));
-        WorkflowRun b = p.scheduleBuild2(0, paramsAction).waitForStart();
-        r.assertBuildStatusSuccess(r.waitForCompletion(b));
-        LinearScanner scan = new LinearScanner();
-        FlowNode shNode = scan.findFirstMatch(b.getExecution().getCurrentHeads().get(0), new NodeStepTypePredicate("echo"));
-        ArgumentsAction args = shNode.getPersistentAction(ArgumentsAction.class);
-        assertThat(args.isUnmodifiedArguments(), equalTo(false));
-        assertThat(args.getArguments(), hasEntry("message", "${MYPASSWORD}"));
-    }
-
     public static class NopStep extends Step {
         @DataBoundConstructor
         public NopStep(Object value) {}


### PR DESCRIPTION
See [JENKINS-64282](https://issues.jenkins.io/browse/JENKINS-64282).

Empty string password parameters will trigger a false warning of groovy string interpolation