### PR TITLE
Add global option to disable pipeline rerun/replay

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/WorkflowConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/WorkflowConfig.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 Motional
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+@Extension
+public class WorkflowConfig extends GlobalConfiguration {
+	private boolean replayDisabled = false;
+
+
+	public WorkflowConfig() {
+		load();
+	}
+
+	public static WorkflowConfig getInstance() {
+		return GlobalConfiguration.all().get(WorkflowConfig.class);
+	}
+
+	@Override
+	public boolean configure(StaplerRequest req, JSONObject o) throws FormException {
+		this.replayDisabled = o.getBoolean("replayDisabled");
+		save();
+		return super.configure(req, o);
+	}
+
+	public boolean getReplayDisabled() {
+		return this.replayDisabled;
+	}
+	@DataBoundSetter
+	public void setReplayDisabled(boolean replayDisabled) {
+		this.replayDisabled = replayDisabled;
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
@@ -69,6 +69,7 @@ import net.sf.json.JSONObject;
 import org.acegisecurity.AccessDeniedException;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+import org.jenkinsci.plugins.workflow.cps.WorkflowConfig;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.kohsuke.accmod.Restricted;
@@ -140,6 +141,10 @@ public class ReplayAction implements Action {
             return false;
         }
 
+        if (WorkflowConfig.getInstance().getReplayDisabled() == true) {
+            return false;
+        }
+
         return true;
     }
 
@@ -149,6 +154,10 @@ public class ReplayAction implements Action {
         }
 
         if (!run.getParent().isBuildable()) {
+            return false;
+        }
+
+        if (WorkflowConfig.getInstance().getReplayDisabled() == true) {
             return false;
         }
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/WorkflowConfig/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/WorkflowConfig/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+    <f:section title="${%title.configtitle}">
+       <f:entry title="Pipeline replay (rerun) disabled (rebuild not affected)" field="replayDisabled">
+         <f:checkbox/>
+       </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/WorkflowConfig/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/WorkflowConfig/config.properties
@@ -1,0 +1,1 @@
+title.configtitle=Pipeline Workflows


### PR DESCRIPTION
Replay does confuse users when used in dynamic worker configuration.
For such, allow to disable feature. Users will still be able to schedule new builds or use rebuild plugin.