### PR TITLE
Handle tables-to-divs conversion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(useAci: false, configurations: [
   [ platform: "linux", jdk: "8", jenkins: null ],
   [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "11", jenkins: "2.222.3", javaLevel: 8 ]
+  [ platform: "linux", jdk: "11", jenkins: "2.276", javaLevel: 8 ]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <revision>2.88</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.176.4</jenkins.version>
+        <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <groovy-cps.version>1.32</groovy-cps.version>
@@ -78,8 +78,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.176.x</artifactId>
-                <version>16</version>
+                <artifactId>bom-2.222.x</artifactId>
+                <version>23</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -42,35 +42,6 @@ THE SOFTWARE.
                 <!-- Similar to f:dropdownDescriptorSelector, but adds fallback content to block, and JENKINS-25130 adds per-selection help: -->
                 <j:set var="item" value="${it.getItem(request)}"/>
                 <d:taglib uri="local">
-                    <!-- this tag wraps the dropdown list in a div but only in div-based forms
-                        using a div in table-based forms will crash the layout generation -->
-                    <d:tag name="snippetizerOptionsWrapper">
-                       <j:choose>
-                           <j:when test="${divBasedFormLayout}">
-                               <style>
-                                   .snippetizer-options-wrapper .setting-input.dropdownList {
-                                       max-width: calc(100% - 2rem);
-                                   }
-
-                                   .snippetizer-help {
-                                       position: relative;
-                                   }
-
-                                   .snippetizer-help a.help-button {
-                                       position: absolute;
-                                       top: -2rem;
-                                   }
-                               </style>
-
-                               <div class="snippetizer-options-wrapper">
-                                   <d:invokeBody />
-                               </div>
-                           </j:when>
-                           <j:otherwise>
-                               <d:invokeBody />
-                           </j:otherwise>
-                       </j:choose>
-                    </d:tag>
 
                     <d:tag name="listSteps">
                         <j:forEach var="quasiDescriptor" items="${quasiDescriptors}">
@@ -80,23 +51,7 @@ THE SOFTWARE.
                                     <j:set var="it" value="${item}"/>
                                     <j:set var="instance" value="${null}"/>
                                     <j:set var="help" value="${descriptor.helpFile}"/>
-                                    
-                                    <j:if test="${help != null}">
-                                        <j:choose>
-                                            <j:when test="${divBasedFormLayout}">
-                                                <div class="snippetizer-help">
-                                                    <f:entry help="${help}" />
-                                                </div>
-                                            </j:when>
-                                            <j:otherwise>
-                                                <tr>
-                                                    <td colspan="3"/>
-                                                    <f:helpLink url="${help}"/>
-                                                </tr>
-                                            </j:otherwise>
-                                        </j:choose>
-                                        <f:helpArea/>
-                                    </j:if>
+                                    <f:entry title="STEP: &lt;code&gt;${quasiDescriptor.symbol}&lt;code&gt;" help="${help}" />
                                     <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true">
                                         <f:block>
                                             ${%This step has not yet defined any visual configuration.}
@@ -108,13 +63,11 @@ THE SOFTWARE.
                     </d:tag>
                 </d:taglib>
 
-                <local:snippetizerOptionsWrapper>
-                    <f:dropdownList name="prototype" title="${%Sample Step}">
-                        <local:listSteps quasiDescriptors="${it.getQuasiDescriptors(false)}"/>
-                        <f:dropdownListBlock title="${%— Advanced/Deprecated —}"/>
-                        <local:listSteps quasiDescriptors="${it.getQuasiDescriptors(true)}"/>
-                    </f:dropdownList>
-                </local:snippetizerOptionsWrapper>
+                <f:dropdownList name="prototype" title="${%Sample Step}">
+                    <local:listSteps quasiDescriptors="${it.getQuasiDescriptors(false)}"/>
+                    <f:dropdownListBlock title="${%— Advanced/Deprecated —}"/>
+                    <local:listSteps quasiDescriptors="${it.getQuasiDescriptors(true)}"/>
+                </f:dropdownList>
 
                 <j:set var="id" value="${h.generateId()}"/>
                 <f:block>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -51,7 +51,7 @@ THE SOFTWARE.
                                     <j:set var="it" value="${item}"/>
                                     <j:set var="instance" value="${null}"/>
                                     <j:set var="help" value="${descriptor.helpFile}"/>
-                                    <f:entry title="&lt;strong&gt;&lt;code&gt;${symbol}&lt;code&gt;&lt;/strong&gt;" help="${help}" />
+                                    <f:entry title="STEP: ${symbol}" help="${help}" />
                                     <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true">
                                         <f:block>
                                             ${%This step has not yet defined any visual configuration.}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -51,7 +51,7 @@ THE SOFTWARE.
                                     <j:set var="it" value="${item}"/>
                                     <j:set var="instance" value="${null}"/>
                                     <j:set var="help" value="${descriptor.helpFile}"/>
-                                    <f:entry title="STEP: ${symbol}" help="${help}" />
+                                    <f:entry title="${symbol}" help="${help}" />
                                     <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true">
                                         <f:block>
                                             ${%This step has not yet defined any visual configuration.}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -42,16 +42,16 @@ THE SOFTWARE.
                 <!-- Similar to f:dropdownDescriptorSelector, but adds fallback content to block, and JENKINS-25130 adds per-selection help: -->
                 <j:set var="item" value="${it.getItem(request)}"/>
                 <d:taglib uri="local">
-
                     <d:tag name="listSteps">
                         <j:forEach var="quasiDescriptor" items="${quasiDescriptors}">
                             <j:set var="descriptor" value="${quasiDescriptor.real}"/>
-                            <f:dropdownListBlock title="${quasiDescriptor.symbol}: ${descriptor.displayName}" staplerClass="${descriptor.clazz.name}" lazy="descriptor,item">
+                            <j:set var="symbol" value="${quasiDescriptor.symbol}"/>
+                            <f:dropdownListBlock title="${symbol}: ${descriptor.displayName}" staplerClass="${descriptor.clazz.name}" lazy="descriptor,item,symbol">
                                 <l:ajax>
                                     <j:set var="it" value="${item}"/>
                                     <j:set var="instance" value="${null}"/>
                                     <j:set var="help" value="${descriptor.helpFile}"/>
-                                    <f:entry title="STEP: &lt;code&gt;${quasiDescriptor.symbol}&lt;code&gt;" help="${help}" />
+                                    <f:entry title="&lt;strong&gt;&lt;code&gt;${symbol}&lt;code&gt;&lt;/strong&gt;" help="${help}" />
                                     <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true">
                                         <f:block>
                                             ${%This step has not yet defined any visual configuration.}
@@ -62,13 +62,11 @@ THE SOFTWARE.
                         </j:forEach>
                     </d:tag>
                 </d:taglib>
-
                 <f:dropdownList name="prototype" title="${%Sample Step}">
                     <local:listSteps quasiDescriptors="${it.getQuasiDescriptors(false)}"/>
                     <f:dropdownListBlock title="${%— Advanced/Deprecated —}"/>
                     <local:listSteps quasiDescriptors="${it.getQuasiDescriptors(true)}"/>
                 </f:dropdownList>
-
                 <j:set var="id" value="${h.generateId()}"/>
                 <f:block>
                     <input type="button" value="${%Generate Pipeline Script}" onclick="handlePrototype_${id}(); return false" class="submit-button primary"/>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -42,34 +42,6 @@ THE SOFTWARE.
                 <!-- Similar to f:dropdownDescriptorSelector, but adds fallback content to block, and JENKINS-25130 adds per-selection help: -->
                 <j:set var="item" value="${it.getItem(request)}"/>
                 <d:taglib uri="local">
-                    <d:tag name="row">
-                        <j:choose>
-                          <j:when test="${divBasedFormLayout}">
-                                <div class="tr">
-                                    <d:invokeBody/>
-                                </div>
-                            </j:when>
-                            <j:otherwise>
-                                <tr>
-                                    <d:invokeBody/>
-                                </tr>
-                            </j:otherwise>
-                        </j:choose>
-                    </d:tag>
-                      <d:tag name="td">
-                        <j:choose>
-                          <j:when test="${divBasedFormLayout}">
-                            <div>
-                              <d:invokeBody/>
-                            </div>
-                          </j:when>
-                          <j:otherwise>
-                            <td colspan="3">
-                              <d:invokeBody/>
-                            </td>
-                          </j:otherwise>
-                        </j:choose> 
-                      </d:tag>
                     <d:tag name="listSteps">
                         <j:forEach var="quasiDescriptor" items="${quasiDescriptors}">
                             <j:set var="descriptor" value="${quasiDescriptor.real}"/>
@@ -80,10 +52,19 @@ THE SOFTWARE.
                                     <j:set var="help" value="${descriptor.helpFile}"/>
                                     
                                     <j:if test="${help != null}">
-                                        <local:row>
-                                            <local:td />
-                                            <f:helpLink url="${help}"/>
-                                        </local:row>
+                                        <j:choose>
+                                            <j:when test="${divBasedFormLayout}">
+                                                <div class="setting-name help-sibling snippetizer-help">
+                                                    <f:helpLink url="${help}"/>
+                                                </div>
+                                            </j:when>
+                                            <j:otherwise>
+                                                <tr>
+                                                    <td colspan="3"/>
+                                                    <f:helpLink url="${help}"/>
+                                                </tr>
+                                            </j:otherwise>
+                                        </j:choose>
                                         <f:helpArea/>
                                     </j:if>
                                     <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true">

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -42,6 +42,34 @@ THE SOFTWARE.
                 <!-- Similar to f:dropdownDescriptorSelector, but adds fallback content to block, and JENKINS-25130 adds per-selection help: -->
                 <j:set var="item" value="${it.getItem(request)}"/>
                 <d:taglib uri="local">
+                    <d:tag name="row">
+                        <j:choose>
+                          <j:when test="${divBasedFormLayout}">
+                                <div class="tr">
+                                    <d:invokeBody/>
+                                </div>
+                            </j:when>
+                            <j:otherwise>
+                                <tr>
+                                    <d:invokeBody/>
+                                </tr>
+                            </j:otherwise>
+                        </j:choose>
+                    </d:tag>
+                      <d:tag name="td">
+                        <j:choose>
+                          <j:when test="${divBasedFormLayout}">
+                            <div>
+                              <d:invokeBody/>
+                            </div>
+                          </j:when>
+                          <j:otherwise>
+                            <td colspan="3">
+                              <d:invokeBody/>
+                            </td>
+                          </j:otherwise>
+                        </j:choose> 
+                      </d:tag>
                     <d:tag name="listSteps">
                         <j:forEach var="quasiDescriptor" items="${quasiDescriptors}">
                             <j:set var="descriptor" value="${quasiDescriptor.real}"/>
@@ -50,11 +78,12 @@ THE SOFTWARE.
                                     <j:set var="it" value="${item}"/>
                                     <j:set var="instance" value="${null}"/>
                                     <j:set var="help" value="${descriptor.helpFile}"/>
+                                    
                                     <j:if test="${help != null}">
-                                        <tr>
-                                            <td colspan="3"/>
+                                        <local:row>
+                                            <local:td />
                                             <f:helpLink url="${help}"/>
-                                        </tr>
+                                        </local:row>
                                         <f:helpArea/>
                                     </j:if>
                                     <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true">

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/workflow.css
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/workflow.css
@@ -99,6 +99,10 @@ z.root>dt {
   padding-bottom: 0
 }
 
+.snippetizer-help {
+  height: 20px;
+}
+
 .array-title {
   border-left: 1px solid #eee;
   padding-left: 10px;

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/workflow.css
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/workflow.css
@@ -99,10 +99,6 @@ z.root>dt {
   padding-bottom: 0
 }
 
-.snippetizer-help {
-  height: 20px;
-}
-
 .array-title {
   border-left: 1px solid #eee;
   padding-left: 10px;


### PR DESCRIPTION
This is a simplistic start at the tables to divs conversion for this plugin based on https://github.com/jenkinsci/scm-api-plugin/commit/0c2723bb5029805565ffe128b98bfca6574d418b . 

This may be all that is needed, but we should run tests against some downstream plugins just to be sure.
