### PR TITLE
Add new step LoadString

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyInvoker.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyInvoker.java
@@ -40,6 +40,7 @@ import javax.annotation.Nonnull;
 
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.*;
 import org.jenkinsci.plugins.workflow.cps.steps.LoadStep;
+import org.jenkinsci.plugins.workflow.cps.steps.LoadStringStep;
 import org.jenkinsci.plugins.workflow.cps.steps.ParallelStep;
 
 /**
@@ -78,6 +79,7 @@ public final class CpsBodyInvoker extends BodyInvoker {
      * @see CpsBodyExecution#bodyToUnexport
      * @see ParallelStep
      * @see LoadStep
+     * @see LoadStringStep
      */
     private final boolean unexport;
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -77,6 +77,7 @@ import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.*;
 import org.jenkinsci.plugins.workflow.cps.steps.LoadStep;
+import org.jenkinsci.plugins.workflow.cps.steps.LoadStringStep;
 import org.jenkinsci.plugins.workflow.cps.steps.ParallelStep;
 import org.jenkinsci.plugins.workflow.cps.view.InterpolatedSecretsAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
@@ -238,7 +239,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         FlowNode an;
 
         // TODO: generalize the notion of Step taking over the FlowNode creation.
-        boolean hack = d instanceof ParallelStep.DescriptorImpl || d instanceof LoadStep.DescriptorImpl;
+        boolean hack = d instanceof ParallelStep.DescriptorImpl || d instanceof LoadStep.DescriptorImpl || d instanceof LoadStringStep.DescriptorImpl; 
 
         if (ps.body == null && !hack) {
             if (!(d.getClass().getName().equals("org.jenkinsci.plugins.workflow.support.steps.StageStep$DescriptorImpl"))

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/LoadStringStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/LoadStringStep.java
@@ -1,0 +1,45 @@
+package org.jenkinsci.plugins.workflow.cps.steps;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Evaluate arbitrary string
+ *
+ * @author Kohsuke Kawaguchi
+ */
+public class LoadStringStep extends AbstractStepImpl {
+    /**
+     * Content of the script to be executed
+     */
+    private final String content;
+
+    @DataBoundConstructor
+    public LoadStringStep(String content) {
+        this.content = content;
+    }
+    
+    public String getContent() {
+        return content;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+        public DescriptorImpl() {
+            super(LoadStringStepExecution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "loadString";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Evaluate Groovy content into the Pipeline script";
+        }
+    }
+
+}


### PR DESCRIPTION
We have recently came up against this particular issue that this PR should patch with minimal noise. This is a non-breaking change.

Consider the following scenario.
The `load` instruction loads a `dummy.groovy`. However, this `dummy.groovy` also pulls a new node. And while this `dummy.groovy` is executing in Node Y, the original Node X that launched the `dummy.groovy` still has a tied down executor doing nothing (waiting for execution of `dummy.groovy`).

The `load` function is specifically tied to a path forcing the need of a node for proper execution. This PR introduces a new step `loadString` which offers the same functionality  as `load` by passing the file content instead if the path.

This new method can then be called outside of a node context, and allow regular execution.

