### PR TITLE
[JENKINS-63305] Fix bug that ignores durability settings with lightweight checkout

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsScmFlowDefinition.java
@@ -31,7 +31,6 @@ import hudson.FilePath;
 import hudson.Functions;
 import hudson.model.Action;
 import hudson.model.Computer;
-import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
@@ -118,7 +117,7 @@ public class CpsScmFlowDefinition extends FlowDefinition {
                         String script = fs.child(expandedScriptPath).contentAsString();
                         listener.getLogger().println("Obtained " + expandedScriptPath + " from " + scm.getKey());
                         Queue.Executable exec = owner.getExecutable();
-                        FlowDurabilityHint hint = (exec instanceof Item) ? DurabilityHintProvider.suggestedFor((Item) exec) : GlobalDefaultFlowDurabilityLevel.getDefaultDurabilityHint();
+                        FlowDurabilityHint hint = (exec instanceof Run) ? DurabilityHintProvider.suggestedFor(((Run)exec).getParent()) : GlobalDefaultFlowDurabilityLevel.getDefaultDurabilityHint();
                         return new CpsFlowExecution(script, true, owner, hint);
                     } catch (FileNotFoundException e) {
                         throw new AbortException("Unable to find " + expandedScriptPath + " from " + scm.getKey());


### PR DESCRIPTION
[JENKINS-63305](https://issues.jenkins.io/browse/JENKINS-63305)

Pipeline job durability settings are ignored when lightweight checkout is used. This is due to an incorrect instance check of the `Queue.Executable`.