### PR TITLE
[JENKINS-64729] use EnvVars get() instead of TreeMap get()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -376,7 +376,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         }
 
         List<String> scanResults = sensitiveVariables.stream()
-                .filter(e -> !(envVars.get(e, "").isEmpty()) && interpolatedStrings.stream().anyMatch(g -> g.contains(envVars.get(e))))
+                .filter(e -> !envVars.get(e, "").isEmpty() && interpolatedStrings.stream().anyMatch(g -> g.contains(envVars.get(e))))
                 .collect(Collectors.toList());
 
         if (scanResults != null && !scanResults.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -376,7 +376,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         }
 
         List<String> scanResults = sensitiveVariables.stream()
-                .filter(e -> !(envVars.get(e).isEmpty()) && interpolatedStrings.stream().anyMatch(g -> g.contains(envVars.get(e))))
+                .filter(e -> !(envVars.get(e, "").isEmpty()) && interpolatedStrings.stream().anyMatch(g -> g.contains(envVars.get(e))))
                 .collect(Collectors.toList());
 
         if (scanResults != null && !scanResults.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
@@ -95,7 +95,7 @@ public class ArgumentsActionImpl extends ArgumentsAction {
         }
         String modded = input;
         for (String sensitive : sensitiveVariables) {
-            String sensitiveValue = variables.get(sensitive);
+            String sensitiveValue = variables.get(sensitive, "");
             if (sensitiveValue.isEmpty()) {
                 continue;
             }


### PR DESCRIPTION
Fix bug where `TreeMap.get()` was  used  instead of `EnvVars.get()`.
The difference being that `EnvVars.get()` provides a default value if the key  does not exists as opposed to just `null` with `TreeMap.get()`.