### PR TITLE
Skip test if jenkins version is too new to fix PCT failure

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/ParamsVariableTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/ParamsVariableTest.java
@@ -66,7 +66,7 @@ public class ParamsVariableTest {
 
     @Issue("JENKINS-42367")
     @Test public void nullValue() throws Exception {
-        Assume.assumeTrue(Jenkins.getVersion().isOlderThan(new VersionNumber("2.281")));
+        Assume.assumeTrue(Jenkins.getVersion().isOlderThan(new VersionNumber("2.281"))); // TODO delete test when updating baseline
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("echo(/TEXT=${params.TEXT}/)",true));
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TEXT", "")));

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/ParamsVariableTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/ParamsVariableTest.java
@@ -33,8 +33,11 @@ import hudson.model.PasswordParameterValue;
 import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
+import hudson.util.VersionNumber;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;
@@ -63,6 +66,7 @@ public class ParamsVariableTest {
 
     @Issue("JENKINS-42367")
     @Test public void nullValue() throws Exception {
+        Assume.assumeTrue(Jenkins.getVersion().isOlderThan(new VersionNumber("2.281")));
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("echo(/TEXT=${params.TEXT}/)",true));
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("TEXT", "")));


### PR DESCRIPTION
Due to jenkinsci/jenkins#5275 a test breaks PCT and is blocking jenkinsci/bom#511.

Because now there is no way to produce a null value we skip the test on newer versions of jenkins

Tested manually with `mvn clean install -Djenkins.version=2.289`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
