### PR TITLE
No need to override default `DescriptorByNameOwner.getDescriptorByName`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
@@ -393,10 +393,6 @@ import org.kohsuke.stapler.StaplerRequest;
         return null;
     }
 
-    @Override public Descriptor getDescriptorByName(String id) {
-        return Jenkins.get().getDescriptorByName(id);
-    }
-
     @Restricted(NoExternalUse.class)
     public Collection<QuasiDescriptor> getQuasiDescriptors(boolean advanced) {
         TreeSet<QuasiDescriptor> t = new TreeSet<>();


### PR DESCRIPTION
As of https://github.com/jenkinsci/jenkins/pull/3009.
