### PR TITLE
Inlining `InterceptingExecutorService`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
@@ -12,7 +12,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import jenkins.model.Jenkins;
-import jenkins.util.InterceptingExecutorService;
 
 /**
  * {@link ExecutorService} for running CPS VM.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/InterceptingExecutorService.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/InterceptingExecutorService.java
@@ -1,0 +1,84 @@
+package org.jenkinsci.plugins.workflow.cps;
+
+import com.google.common.util.concurrent.ForwardingExecutorService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * {@link ExecutorService} that wraps all the tasks that run inside.
+ *
+ * @author Kohsuke Kawaguchi
+ * @since 1.557
+ */
+public abstract class InterceptingExecutorService extends ForwardingExecutorService {
+    private final ExecutorService base;
+
+    public InterceptingExecutorService(ExecutorService base) {
+        this.base = base;
+    }
+
+    protected abstract Runnable wrap(Runnable r);
+
+    protected abstract <V> Callable<V> wrap(Callable<V> r);
+
+    @Override
+    protected ExecutorService delegate() {
+        return base;
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return super.submit(wrap(task));
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return super.submit(wrap(task), result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return super.submit(wrap(task));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return super.invokeAll(wrap(tasks));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return super.invokeAll(wrap(tasks), timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return super.invokeAny(wrap(tasks));
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return super.invokeAny(wrap(tasks), timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        super.execute(wrap(command));
+    }
+
+    private <T> Collection<Callable<T>> wrap(Collection<? extends Callable<T>> callables) {
+        List<Callable<T>> r = new ArrayList<>();
+        for (Callable<T> c : callables) {
+            r.add(wrap(c));
+        }
+        return r;
+    }
+}


### PR DESCRIPTION
Jenkins core defines `jenkins.util.InterceptingExecutorService`, which extends `com.google.common.util.concurrent.ForwardingExecutorService`. This exposes a Guava API in the Jenkins public API, which is a liability. If the Guava API changed, the Jenkins API might also have to change, which could result in incompatibilities. Supporting such an API also implies that Jenkins core must expose Guava to plugins, something we would rather avoid if possible.

Analyzing usages in both open source and CloudBees proprietary plugins with `usage-in-plugins`, I see that the only usage of this class is in `workflow-cps`. It seems better to move this class to `workflow-cps`. That way `workflow-cps` still gets what it needs, while Jenkins core gets out of the business of exposing Guava classes in its public API.

Concomitant with this PR, I am deprecating `jenkins.util.InterceptingExecutorService` in Jenkins core. Once this PR is widely adopted, I plan to delete `jenkins.util.InterceptingExecutorService` from Jenkins core.