### PR TITLE
Improve durability of `SURVIVABLE_NONATOMIC` while retaining the skipping of `fsync(2)`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
   ~ THE SOFTWARE.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.18</version>
+        <version>4.19</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -44,9 +44,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${gitHubRepo}.git</developerConnection>
-        <url>https://github.com/jenkinsci/${gitHubRepo}</url>
+        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
     </scm>
     <repositories>
@@ -64,12 +64,12 @@
     <properties>
         <revision>2.93</revision>
         <changelist>-SNAPSHOT</changelist>
-        <gitHubRepo>${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.222.4</jenkins.version>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+        <jenkins.version>2.300-rc31329.23a941f5b44f</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/5599 -->
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <groovy-cps.version>1.32</groovy-cps.version>
-        <workflow-support-plugin.version>3.7</workflow-support-plugin.version>
+        <workflow-support-plugin.version>3.9-rc775.8f378c2fa520</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/120 -->
         <node.version>12.19.0</node.version>
         <npm.version>6.14.8</npm.version>
     </properties>
@@ -77,8 +77,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.222.x</artifactId>
-                <version>23</version>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>887.vae9c8ac09ff7</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -92,6 +92,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
+            <version>2.47-rc1093.d73752dcf969</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/163 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,11 @@
         <revision>2.93</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.300-rc31329.23a941f5b44f</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/5599 -->
+        <jenkins.version>2.302-rc31361.d0e8e1ae1985</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/5599 -->
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <groovy-cps.version>1.32</groovy-cps.version>
-        <workflow-support-plugin.version>3.9-rc775.8f378c2fa520</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/120 -->
+        <workflow-support-plugin.version>3.9-rc777.9c2808547227</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/120 -->
         <node.version>12.19.0</node.version>
         <npm.version>6.14.8</npm.version>
     </properties>


### PR DESCRIPTION
See [JENKINS-66001](https://issues.jenkins.io/browse/JENKINS-66001). Downstream of jenkinsci/jenkins#5599, jenkinsci/workflow-api-plugin#163, and jenkinsci/workflow-support-plugin#120. Part 4 of a 5-part series to make Pipeline's `SURVIVABLE_NONATOMIC` mode behave [as advertised in the documentation](https://www.jenkins.io/doc/book/pipeline/scaling-pipeline/#what-am-i-giving-up-with-this-durability-setting-trade-off) (part 5 is in jenkinsci/workflow-job-plugin#199).

I tested this by running a Pipeline job with 100 steps in `SURVIVABLE_NONATOMIC` mode while simultaneously attaching a remote debugger to `XmlFile` and monitoring `fsync(2)` calls with [`syncsnoop.bt`](https://github.com/iovisor/bpftrace/blob/6cb740241edddc4b88e039bfc9385e6a3bad3abb/tools/syncsnoop.bt). I confirmed that `AtomicFileWriter` was being used in the Java debugger, and I confirmed that `fsync(2)` was not being used with `syncsnoop.bt`.