### PR TITLE
Adapting `SubtypeInjectingStepTest`, `ArgumentsActionImplTest`, and `RestartingLoadStepTest` to jenkinsci/jenkins#5425

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/SubtypeInjectingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/SubtypeInjectingStepTest.java
@@ -39,7 +39,7 @@ public class SubtypeInjectingStepTest {
     public void contextInjectionOfSubParameters() throws Exception {
         // see SubtypeInjectingStep
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("node('master') { injectSubtypesAsContext() }", false));
+        p.setDefinition(new CpsFlowDefinition("node('" + r.jenkins.getSelfLabel().getName() + "') { injectSubtypesAsContext() }", false));
         r.assertBuildStatusSuccess(p.scheduleBuild2(0));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImplTest.java
@@ -503,7 +503,7 @@ public class ArgumentsActionImplTest {
         WorkflowJob job = r.createProject(WorkflowJob.class);
         job.setDefinition(new CpsFlowDefinition(
                 "echo 'test' \n " +
-                " node('master') { \n" +
+                " node('" + r.jenkins.getSelfLabel().getName() + "') { \n" +
                 "   retry(3) {\n"+
                 "     if (isUnix()) { \n" +
                 "       sh 'whoami' \n" +
@@ -535,8 +535,8 @@ public class ArgumentsActionImplTest {
 
         FlowNode nodeNode = scan.findFirstMatch(run.getExecution().getCurrentHeads().get(0),
                 Predicates.and(Predicates.instanceOf(StepStartNode.class), new NodeStepTypePredicate("node"), FlowScanningUtils.hasActionPredicate(ArgumentsActionImpl.class)));
-        Assert.assertEquals("master", nodeNode.getPersistentAction(ArgumentsAction.class).getArguments().values().iterator().next());
-        Assert.assertEquals("master", ArgumentsAction.getStepArgumentsAsString(nodeNode));
+        Assert.assertEquals(r.jenkins.getSelfLabel().getName(), nodeNode.getPersistentAction(ArgumentsAction.class).getArguments().values().iterator().next());
+        Assert.assertEquals(r.jenkins.getSelfLabel().getName(), ArgumentsAction.getStepArgumentsAsString(nodeNode));
 
         testDeserialize(run.getExecution());
     }
@@ -545,7 +545,7 @@ public class ArgumentsActionImplTest {
     public void testUnusualStepInstantiations() throws Exception {
         WorkflowJob job = r.createProject(WorkflowJob.class);
         job.setDefinition(new CpsFlowDefinition(
-                " node('master') { \n" +
+                " node('" + r.jenkins.getSelfLabel().getName() + "') { \n" +
                 "   writeFile text: 'hello world', file: 'msg.out'\n" +
                 "   step([$class: 'ArtifactArchiver', artifacts: 'msg.out', fingerprint: false])\n "+
                 "   withEnv(['CUSTOM=val']) {\n"+  //Symbol-based, because withEnv is a metastep; TODO huh? no it is not

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
@@ -199,14 +199,14 @@ public class RestartingLoadStepTest {
                 p.setDefinition(new CpsFlowDefinition("def util\n" +
                         "def config\n" +
                         "def util2\n" +
-                        "node('master') {\n" +
+                        " node('" + story.j.jenkins.getSelfLabel().getName() + "') { \n" +
                         "    config = load 'src/org/foo/devops/JenkinsEnvironment.groovy'\n" +
                         "    util = load 'src/org/foo/devops/Utility.groovy'\n" +
                         "    config.loadProdConfiguration()\n" +
                         "}\n" +
                         "util.isValueExist(\"\")\n" +
                         "semaphore 'wait'\n" +
-                        "node('master') {\n" +
+                        " node('" + story.j.jenkins.getSelfLabel().getName() + "') { \n" +
                         "    util2 = load 'src/org/foo/devops/Utility.groovy'\n" +
                         "    util = load 'src/org/foo/devops/Utility.groovy'\n" +
                         "    assert util.isValueExist('foo') == true\n" +

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
@@ -199,14 +199,14 @@ public class RestartingLoadStepTest {
                 p.setDefinition(new CpsFlowDefinition("def util\n" +
                         "def config\n" +
                         "def util2\n" +
-                        " node('" + story.j.jenkins.getSelfLabel().getName() + "') { \n" +
+                        "node('" + story.j.jenkins.getSelfLabel().getName() + "') {\n" +
                         "    config = load 'src/org/foo/devops/JenkinsEnvironment.groovy'\n" +
                         "    util = load 'src/org/foo/devops/Utility.groovy'\n" +
                         "    config.loadProdConfiguration()\n" +
                         "}\n" +
                         "util.isValueExist(\"\")\n" +
                         "semaphore 'wait'\n" +
-                        " node('" + story.j.jenkins.getSelfLabel().getName() + "') { \n" +
+                        "node('" + story.j.jenkins.getSelfLabel().getName() + "') {\n" +
                         "    util2 = load 'src/org/foo/devops/Utility.groovy'\n" +
                         "    util = load 'src/org/foo/devops/Utility.groovy'\n" +
                         "    assert util.isValueExist('foo') == true\n" +


### PR DESCRIPTION
More breakage from jenkinsci/jenkins#5425, discovered when running PCT against a recent core incremental. This gets these tests to pass against both old and new cores.