### PR TITLE
update test to work for Jenkins 2.307

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImplTest.java
@@ -501,9 +501,10 @@ public class ArgumentsActionImplTest {
     @Test
     public void testArgumentDescriptions() throws Exception {
         WorkflowJob job = r.createProject(WorkflowJob.class);
+        String builtInNodeLabel = r.jenkins.getSelfLabel().getName(); // compatibility with 2.307+
         job.setDefinition(new CpsFlowDefinition(
                 "echo 'test' \n " +
-                " node('master') { \n" +
+                " node('" + builtInNodeLabel + "') { \n" +
                 "   retry(3) {\n"+
                 "     if (isUnix()) { \n" +
                 "       sh 'whoami' \n" +
@@ -535,8 +536,8 @@ public class ArgumentsActionImplTest {
 
         FlowNode nodeNode = scan.findFirstMatch(run.getExecution().getCurrentHeads().get(0),
                 Predicates.and(Predicates.instanceOf(StepStartNode.class), new NodeStepTypePredicate("node"), FlowScanningUtils.hasActionPredicate(ArgumentsActionImpl.class)));
-        Assert.assertEquals("master", nodeNode.getPersistentAction(ArgumentsAction.class).getArguments().values().iterator().next());
-        Assert.assertEquals("master", ArgumentsAction.getStepArgumentsAsString(nodeNode));
+        Assert.assertEquals(builtInNodeLabel, nodeNode.getPersistentAction(ArgumentsAction.class).getArguments().values().iterator().next());
+        Assert.assertEquals(builtInNodeLabel, ArgumentsAction.getStepArgumentsAsString(nodeNode));
 
         testDeserialize(run.getExecution());
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Terminology changes introduced in Jenkins 2.307 will break tests that hardcode the term `master` in the node label
See https://github.com/jenkinsci/jenkins/pull/5425

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
