### PR TITLE
Trim `StepExecution.status` to a sane length in stack traces

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDump.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDump.java
@@ -30,6 +30,8 @@ public final class CpsThreadDump {
         private final String headline;
         private final List<StackTraceElement> stack = new ArrayList<>();
 
+        private static final int MAX_STATUS_LENGTH = 1000;
+
         /**
          * Given a list of {@link CpsThread}s that share the same {@link FlowHead}, in the order
          * from outer to inner, reconstruct the thread stack.
@@ -48,6 +50,11 @@ public final class CpsThreadDump {
                     if (d != null) {
                         String status = s.getStatusBounded(3, TimeUnit.SECONDS);
                         if (status != null) {
+                            int len = status.length();
+                            if (len > MAX_STATUS_LENGTH) {
+                                int half = MAX_STATUS_LENGTH / 2;
+                                status = status.subSequence(0, half) + "…[truncated " + (len - MAX_STATUS_LENGTH) + " chars]…" + status.subSequence(len - half, len);
+                            }
                             stack.add(new StackTraceElement("DSL", d.getFunctionName(), status, -1));
                         } else {
                             stack.add(new StackTraceElement("DSL", d.getFunctionName(), null, -2));


### PR DESCRIPTION
I noticed in a `nodes/master/pipeline-thread-dump.txt` from a controller with lots of active agents (EC2, as it happens) that most of the file was taken up by `ExecutorStepExecution.status` content bloated by https://github.com/jenkinsci/jenkins/pull/2651:

```
Build: myprj #123
Thread #456
	at DSL.node(waiting for part of myprj #123_somebranch to be scheduled; blocked: Waiting for pending items to get a node assigned; ‘agent1’ doesn’t have label ‘mylabel’; ‘agent2’ doesn’t have label ‘mylabel’; …47Kb later…)
	at WorkflowScript.run(WorkflowScript:789)
	at …
```

Adapted code from the [`junit` plugin](https://github.com/jenkinsci/junit-plugin/blob/74f8fdf99237e144b097830c2ddc6ea6d4c96b82/src/main/java/hudson/tasks/junit/CaseResult.java#L198-L212) for this.
