### PR TITLE
Incorrect use of `gitHubRepo`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${gitHubRepo}.git</developerConnection>
-        <url>https://github.com/jenkinsci/${gitHubRepo}</url>
+        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
     </scm>
     <repositories>
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.95</revision>
         <changelist>-SNAPSHOT</changelist>
-        <gitHubRepo>${project.artifactId}-plugin</gitHubRepo>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>


### PR DESCRIPTION
Mistake in #380. Noticed due to broken SCM URLs in deployed POM in #474.
