### PR TITLE
No need to override `reuseForks`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.18</version>
+        <version>4.31</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -269,13 +269,6 @@
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
                     <compatibleSinceVersion>2.18</compatibleSinceVersion>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks> <!-- TODO reuse seems to cause problems in CpsFlowExecutionMemoryTest -->
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
As of https://github.com/jenkinsci/plugin-pom/pull/453. Supersedes #477.
