### PR TITLE
Verifying that a missing `program.dat` causes a comprehensible error

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -319,6 +319,7 @@ public class PersistenceProblemsTest {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
             assertCompletedCleanly(run);
+            j.assertLogContains("FileNotFoundException", run);
         });
     }
 


### PR DESCRIPTION
Trying to diagnose an intermittent error when restoring builds from backup

```
Resuming build at … after Jenkins restart
[Pipeline] End of Pipeline
java.io.IOException: Unsupported protocol version 101
	at org.jboss.marshalling.river.RiverUnmarshaller.start(RiverUnmarshaller.java:1349)
	at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverReader.readPickles(RiverReader.java:175)
	at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverReader.restorePickles(RiverReader.java:142)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.loadProgramAsync(CpsFlowExecution.java:784)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:750)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:691)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:550)
	at …
Caused: java.io.IOException: Failed to load build state
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$3.onSuccess(CpsFlowExecution.java:865)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$3.onSuccess(CpsFlowExecution.java:863)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4$1.run(CpsFlowExecution.java:917)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.run(CpsVmExecutorService.java:38)
	at …
Finished: FAILURE
```

`program.dat` is missing after this, but based on the passing test here, the error suggests that it was in fact present yet corrupt, and got deleted by https://github.com/jenkinsci/workflow-cps-plugin/blob/f18afa1fa06f13893c43c344994a7c6d6390d794/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java#L455

Unclear how it could have been corrupted, given https://github.com/jenkinsci/workflow-cps-plugin/blob/f18afa1fa06f13893c43c344994a7c6d6390d794/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java#L562
