### PR TITLE
Exclude `javax.servlet:servlet-api`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,12 @@
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
             <artifactId>ace-editor</artifactId>
+            <exclusions>
+                <exclusion> <!-- TODO remove when ace-editor is refreshed -->
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.cloudbees</groupId>


### PR DESCRIPTION
With recent versions of Maven Enforcer, any plugin depending on `workflow-cps` starts getting errors like this:

```
Require upper bound dependencies error for javax.servlet:servlet-api:0 [provided] paths to dependency are:
+-org.jenkins-ci.plugins:gitlab-plugin:1.5.25-SNAPSHOT
  +-org.jenkins-ci.plugins.workflow:workflow-cps:2.94 [test]
    +-org.jenkins-ci.ui:ace-editor:1.1 [test] (managed) <-- org.jenkins-ci.ui:ace-editor:1.1 [test]
      +-javax.servlet:servlet-api:0 [provided] (managed) <-- javax.servlet:servlet-api:2.4 [provided]
```

While the root cause of the problem is that `ace-editor` needs refreshing, excluding the problematic `provided` version of `javax.servlet:servlet-api` in `workflow-cps` at the point that `ace-editor` is consumed is easily a fraction of the work and chases away the problem, so I think it is a good temporary measure.