### PR TITLE
Record which `program.dat` is being saved in a thread dump

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -80,6 +80,7 @@ import static org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.*;
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.*;
 import org.jenkinsci.plugins.workflow.pickles.Pickle;
 import org.jenkinsci.plugins.workflow.pickles.PickleFactory;
+import org.jenkinsci.plugins.workflow.support.concurrent.WithThreadName;
 import org.jenkinsci.plugins.workflow.support.pickles.SingleTypedPickleFactory;
 import org.jenkinsci.plugins.workflow.support.storage.FlowNodeStorage;
 
@@ -554,7 +555,8 @@ public final class CpsThreadGroup implements Serializable {
         }
 
         boolean serializedOK = false;
-        try (CpsFlowExecution.Timing t = execution.time(TimingKind.saveProgram)) {
+        try (CpsFlowExecution.Timing t = execution.time(TimingKind.saveProgram);
+                WithThreadName diag = new WithThreadName("saving " + f)) {
             try (RiverWriter w = new RiverWriter(tmpFile, execution.getOwner(), pickleFactories)) {
                 w.writeObject(this);
             }


### PR DESCRIPTION
When you see something like

```
"Computer.threadPoolForRemoting [#…]" Id=… Group=main RUNNABLE
	at java.util.ArrayList.iterator(ArrayList.java:842)
	at hudson.ExtensionList.iterator(ExtensionList.java:170)
	at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverWriter$1.writeReplace(RiverWriter.java:124)
	at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:190)
	at org.jboss.marshalling.river.RiverMarshaller.doWriteFields(RiverMarshaller.java:1143)
	at org.jboss.marshalling.river.RiverMarshaller.doWriteSerializableObject(RiverMarshaller.java:1101)
	at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:268)
	at …
	at org.jboss.marshalling.river.RiverMarshaller.doWriteObject(RiverMarshaller.java:268)
	at org.jboss.marshalling.AbstractObjectOutput.writeObject(AbstractObjectOutput.java:58)
	at org.jboss.marshalling.AbstractMarshaller.writeObject(AbstractMarshaller.java:111)
	at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverWriter.lambda$writeObject$1(RiverWriter.java:144)
	at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverWriter$$Lambda$1167/1214827998.call(Unknown Source)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox.runInSandbox(GroovySandbox.java:237)
	at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverWriter.writeObject(RiverWriter.java:143)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.saveProgram(CpsThreadGroup.java:559)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.saveProgram(CpsThreadGroup.java:536)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext$3.onSuccess(CpsStepContext.java:562)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext$3.onSuccess(CpsStepContext.java:556)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4$1.run(CpsFlowExecution.java:917)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.run(CpsVmExecutorService.java:38)
	…
```

in a thread dump, you may suspect a performance problem caused by some job with an overly complex definition; but it is impossible to tell which one.
