### PR TITLE
[JENKINS-68092] Serialization of `java.util.concurrent` data structure in Pipeline: Groovy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -104,7 +104,7 @@ public final class CpsThreadGroup implements Serializable {
     /**
      * Persistent version of {@link #runtimeThreads}.
      */
-    private Map<Integer, CpsThread> threads;
+    private volatile Map<Integer, CpsThread> threads;
 
     /**
      * All the member threads by their {@link CpsThread#id}.
@@ -206,7 +206,7 @@ public final class CpsThreadGroup implements Serializable {
         pausedByQuietMode = new AtomicBoolean();
     }
 
-    private synchronized Object writeReplace() {
+    private Object writeReplace() {
         threads = new HashMap<>(runtimeThreads);
         return this;
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -64,9 +64,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -108,7 +108,7 @@ public final class CpsThreadGroup implements Serializable {
      * and iteration through {@link CpsThreadDump#from(CpsThreadGroup)} may occur on other threads
      * (e.g. non-blocking steps, thread dumps from the UI).
      */
-    private final NavigableMap<Integer,CpsThread> threads = new ConcurrentSkipListMap<>();
+    private final NavigableMap<Integer,CpsThread> threads = Collections.synchronizedNavigableMap(new TreeMap<>());
 
     /**
      * Unique thread ID generator.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -64,9 +64,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -102,13 +102,24 @@ public final class CpsThreadGroup implements Serializable {
     private /*almost final*/ transient CpsFlowExecution execution;
 
     /**
+     * @deprecated use {@link #runtimeThreads}
+     */
+    @Deprecated
+    private final Map<Integer, CpsThread> threads = new HashMap<>();
+
+    /**
      * All the member threads by their {@link CpsThread#id}.
      *
      * All mutation occurs only on the CPS VM thread. Read access through {@link CpsStepContext#doGet}
      * and iteration through {@link CpsThreadDump#from(CpsThreadGroup)} may occur on other threads
      * (e.g. non-blocking steps, thread dumps from the UI).
      */
-    private final NavigableMap<Integer,CpsThread> threads = Collections.synchronizedNavigableMap(new TreeMap<>());
+    private transient NavigableMap<Integer, CpsThread> runtimeThreads;
+
+    /**
+     * Persistent version of {@link #runtimeThreads}.
+     */
+    private Map<Integer, CpsThread> persistentThreads;
 
     /**
      * Unique thread ID generator.
@@ -159,6 +170,7 @@ public final class CpsThreadGroup implements Serializable {
 
     CpsThreadGroup(CpsFlowExecution execution) {
         this.execution = execution;
+        this.persistentThreads = new HashMap<>();
         setupTransients();
     }
 
@@ -178,6 +190,20 @@ public final class CpsThreadGroup implements Serializable {
         execution = CpsFlowExecution.PROGRAM_STATE_SERIALIZATION.get();
         setupTransients();
         assert execution!=null;
+        if (persistentThreads == null) {
+            persistentThreads = new HashMap<>();
+        }
+        if (!threads.isEmpty() && !persistentThreads.isEmpty()) {
+            throw new AssertionError("should never happen");
+        } else if (!threads.isEmpty()) {
+            // Deserializing persisted state from before upgrade
+            runtimeThreads.putAll(threads);
+            threads.clear();
+        } else if (!persistentThreads.isEmpty()) {
+            // Deserializing persisted state from after upgrade
+            runtimeThreads.putAll(persistentThreads);
+            persistentThreads.clear();
+        }
         if (/* compatibility: the field will be null in old programs */ scripts != null && !scripts.isEmpty()) {
             GroovyShell shell = execution.getShell();
             // Take the canonical bindings from the main script and relink that object with that of the shell and all other loaded scripts which kept the same bindings.
@@ -193,15 +219,22 @@ public final class CpsThreadGroup implements Serializable {
     }
 
     private void setupTransients() {
+        runtimeThreads = new ConcurrentSkipListMap<>();
         runner = new CpsVmExecutorService(this);
         pausedByQuietMode = new AtomicBoolean();
+    }
+
+    private synchronized Object writeReplace() {
+        persistentThreads.clear();
+        persistentThreads.putAll(runtimeThreads);
+        return this;
     }
 
     @CpsVmThreadOnly
     public CpsThread addThread(@NonNull Continuable program, FlowHead head, ContextVariableSet contextVariables) {
         assertVmThread();
         CpsThread t = new CpsThread(this, iota++, program, head, contextVariables);
-        threads.put(t.id, t);
+        runtimeThreads.put(t.id, t);
         return t;
     }
 
@@ -223,9 +256,9 @@ public final class CpsThreadGroup implements Serializable {
      *      null if the thread has finished executing.
      */
     public CpsThread getThread(int id) {
-        CpsThread thread = threads.get(id);
+        CpsThread thread = runtimeThreads.get(id);
         if (thread == null && LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.log(Level.FINE, "no thread " + id + " among " + threads.keySet(), new IllegalStateException());
+            LOGGER.log(Level.FINE, "no thread " + id + " among " + runtimeThreads.keySet(), new IllegalStateException());
         }
         return thread;
     }
@@ -234,7 +267,7 @@ public final class CpsThreadGroup implements Serializable {
      * Returns an unmodifiable snapshot of all threads in the thread group.
      */
     public Iterable<CpsThread> getThreads() {
-        return threads.values();
+        return runtimeThreads.values();
     }
 
     @CpsVmThreadOnly("root")
@@ -327,7 +360,7 @@ public final class CpsThreadGroup implements Serializable {
                             // ensures that everything submitted in front of us has finished.
                             runner.submit(new Runnable() {
                                 public void run() {
-                                    if (threads.isEmpty()) {
+                                    if (runtimeThreads.isEmpty()) {
                                         runner.shutdown();
                                     }
                                     // the original promise of scheduleRun() is now complete
@@ -403,7 +436,7 @@ public final class CpsThreadGroup implements Serializable {
         boolean stillRunnable = false;
 
         // TODO: maybe instead of running all the thread, run just one thread in round robin
-        for (CpsThread t : threads.values().toArray(new CpsThread[threads.size()])) {
+        for (CpsThread t : runtimeThreads.values().toArray(new CpsThread[runtimeThreads.size()])) {
             if (t.isRunnable()) {
                 Outcome o = t.runNextChunk();
                 if (o.isFailure()) {
@@ -426,9 +459,9 @@ public final class CpsThreadGroup implements Serializable {
                     LOGGER.fine("completed " + t);
                     t.fireCompletionHandlers(o); // do this after ErrorAction is set above
 
-                    threads.remove(t.id);
+                    runtimeThreads.remove(t.id);
                     t.cleanUp();
-                    if (threads.isEmpty()) {
+                    if (runtimeThreads.isEmpty()) {
                         execution.onProgramEnd(o);
                         try {
                             this.execution.saveOwner();
@@ -620,7 +653,7 @@ public final class CpsThreadGroup implements Serializable {
         // as that's the ony more likely to have caused the problem.
         // TODO: when we start tracking which thread is just waiting for the body, then
         // that information would help. or maybe we should just remember the thread that has run the last time
-        Map.Entry<Integer,CpsThread> lastEntry = threads.lastEntry();
+        Map.Entry<Integer,CpsThread> lastEntry = runtimeThreads.lastEntry();
         if (lastEntry != null) {
             lastEntry.getValue().resume(new Outcome(null,t));
         } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -105,7 +105,7 @@ public final class CpsThreadGroup implements Serializable {
      * @deprecated use {@link #runtimeThreads}
      */
     @Deprecated
-    private final Map<Integer, CpsThread> threads;
+    private Map<Integer, CpsThread> threads;
 
     /**
      * All the member threads by their {@link CpsThread#id}.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -183,9 +183,7 @@ public final class CpsThreadGroup implements Serializable {
         execution = CpsFlowExecution.PROGRAM_STATE_SERIALIZATION.get();
         setupTransients();
         assert execution!=null;
-        if (threads != null) {
-            runtimeThreads.putAll(threads);
-        }
+        runtimeThreads.putAll(threads);
         if (/* compatibility: the field will be null in old programs */ scripts != null && !scripts.isEmpty()) {
             GroovyShell shell = execution.getShell();
             // Take the canonical bindings from the main script and relink that object with that of the shell and all other loaded scripts which kept the same bindings.

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -102,9 +102,8 @@ public final class CpsThreadGroup implements Serializable {
     private /*almost final*/ transient CpsFlowExecution execution;
 
     /**
-     * @deprecated use {@link #runtimeThreads}
+     * Persistent version of {@link #runtimeThreads}.
      */
-    @Deprecated
     private Map<Integer, CpsThread> threads;
 
     /**
@@ -115,11 +114,6 @@ public final class CpsThreadGroup implements Serializable {
      * (e.g. non-blocking steps, thread dumps from the UI).
      */
     private transient NavigableMap<Integer, CpsThread> runtimeThreads;
-
-    /**
-     * Persistent version of {@link #runtimeThreads}.
-     */
-    private Map<Integer, CpsThread> persistentThreads;
 
     /**
      * Unique thread ID generator.
@@ -190,13 +184,7 @@ public final class CpsThreadGroup implements Serializable {
         setupTransients();
         assert execution!=null;
         if (threads != null) {
-            // Deserializing persisted state from before upgrade
-            assert persistentThreads == null;
             runtimeThreads.putAll(threads);
-            threads = null;
-        } else if (persistentThreads != null) {
-            // Deserializing persisted state from after upgrade
-            runtimeThreads.putAll(persistentThreads);
         }
         if (/* compatibility: the field will be null in old programs */ scripts != null && !scripts.isEmpty()) {
             GroovyShell shell = execution.getShell();
@@ -219,7 +207,7 @@ public final class CpsThreadGroup implements Serializable {
     }
 
     private synchronized Object writeReplace() {
-        persistentThreads = new HashMap<>(runtimeThreads);
+        threads = new HashMap<>(runtimeThreads);
         return this;
     }
 


### PR DESCRIPTION
### Steps to reproduce

On Java 17, run `mvn clean verify -Dtest=org.jenkinsci.plugins.workflow.cps.CpsBodyExecutionTest,org.jenkinsci.plugins.workflow.cps.CpsThreadDumpActionTest -Djenkins.version=2.339 -Denforcer.skip -Djenkins-test-harness.version=1723.vcd938b_e66072 '-DargLine=--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED'`

### Expected results

**Note:** These are the *actual* results when adding `--add-opens java.base/java.util.concurrent=ALL-UNNAMED` to the above arguments:

The test passes.

### Actual results

The test fails with:

```
com.thoughtworks.xstream.converters.ConversionException: 
No converter available
             - Debugging information ----
message             : No converter available
type                : java.util.concurrent.ConcurrentSkipListMap
converter           : com.thoughtworks.xstream.converters.reflection.SerializableConverter
message<1>          : Unable to make private void java.util.concurrent.ConcurrentSkipListMap.readObject(java.io.ObjectInputStream) throws java.io.IOException,java.lang.ClassNotFoundException accessible: module java.base does not "opens java.util.concurrent" to unnamed module @210366b4
converter<1>        : com.thoughtworks.xstream.converters.reflection.ReflectionConverter
message[2]          : Unable to make field private static final long java.util.concurrent.ConcurrentSkipListMap.serialVersionUID accessible: module java.base does not "opens java.util.concurrent" to unnamed module @210366b4
-------------------------------
	at com.thoughtworks.xstream.core.DefaultConverterLookup.lookupConverterForType(DefaultConverterLookup.java:88)
	at com.thoughtworks.xstream.XStream$1.lookupConverterForType(XStream.java:478)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:49)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
	at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.marshallField(AbstractReflectionConverter.java:270)
	at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter$2.writeField(AbstractReflectionConverter.java:174)
	at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.doMarshal(AbstractReflectionConverter.java:262)
	at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.marshal(AbstractReflectionConverter.java:90)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:59)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:44)
	at com.thoughtworks.xstream.core.TreeMarshaller.start(TreeMarshaller.java:83)
	at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.marshal(AbstractTreeMarshallingStrategy.java:37)
	at com.thoughtworks.xstream.XStream.marshal(XStream.java:1266)
	at com.thoughtworks.xstream.XStream.marshal(XStream.java:1255)
	at com.thoughtworks.xstream.XStream.toXML(XStream.java:1228)
	at com.thoughtworks.xstream.XStream.toXML(XStream.java:1215)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.asXml(CpsThreadGroup.java:611)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecutionTest.lambda$closureCapturesCpsBodyExecution$4(CpsBodyExecutionTest.java:241)
	at org.jvnet.hudson.test.RestartableJenkinsRule$3.evaluate(RestartableJenkinsRule.java:243)
	at org.jvnet.hudson.test.RestartableJenkinsRule$6.evaluate(RestartableJenkinsRule.java:291)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:606)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

### Evaluation

Of the core test suite and plugin BOM test suite, this is the only test failure I found with a `java.util.concurrent` reflection error. I think it would be desirable to eliminate `java.util.concurrent` from our `Add-Opens` directives if possible, since in most cases it is not necessary to serialize a concurrent data structure.

### Solution

Interestingly enough, I found the tests passed by using a simple `TreeMap` wrapped in `Collections.synchronizedNavigableMap`. If the performance costs are acceptable (and I think they likely are), I think it is worth considering making this change. This would allow me to get rid of the `java.util.concurrent` `Add-Opens` directive in core's `MANIFEST.MF` in jenkinsci/jenkins#6392. Avoiding any `Add-Opens` directives at this early preview stage is much easier than getting rid of them later on.

### Testing done

```
$ mvn clean verify -Djenkins.version=2.339 -Denforcer.skip -Djenkins-test-harness.version=1723.vcd938b_e66072 '-DargLine=--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED'
```

CCC @car-roll @dwnusbaum @jglick