### PR TITLE
Migrate from readResolve to unmarshal

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1604,6 +1604,8 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     // the execution in Groovy CPS should hold that lock (or worse, hold that lock in the runNextChunk method)
     // so that the execution gets suspended while we are getting serialized
 
+    // Note: XStream ignores readResolve and writeReplace methods on types with custom Converter implementations, so use marshal and unmarshal instead.
+
     public static final class ConverterImpl implements Converter {
         private final ReflectionProvider ref;
         private final Mapper mapper;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -428,7 +428,13 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             this.kind = kind;
             start = System.nanoTime();
         }
+
+        @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
         @Override public void close() {
+            // it is possible for timings to be null if an old build (< v2686.v7c37e0578401) is being loaded from a saved state
+            if (timings == null) {
+                timings = new ConcurrentHashMap<>();
+            }
             timings.merge(kind.name(), System.nanoTime() - start, Long::sum);
         }
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
If a build is loaded from a saved state, and the build existed before #519 (i.e. v2686.v7c37e0578401), It is possible for the `timings` field to be `NULL`. This causes an NPE when the Timing is closed: https://github.com/jenkinsci/workflow-cps-plugin/blob/3f09155513c1c8ed3727ec16220701bee0c31a9c/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java#L432

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
