### PR TITLE
Defer being “ready to run” until `StepExecution.onResume`s complete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
+            <version>1154.v8fb_a_08707266</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/221 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.332.x</artifactId>
-                <version>1289.v5c4b_1c43511b_</version>
+                <version>1382.v7d694476f340</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>1154.v8fb_a_08707266</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/221 -->
+            <version>1159.va_643c5f893e9</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/221 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>1159.va_643c5f893e9</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/221 -->
+            <version>1162.va_1e49062a_00e</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -415,12 +415,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             start = System.nanoTime();
         }
 
-        @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
         @Override public void close() {
-            // it is possible for timings to be null if an old build (< v2686.v7c37e0578401) is being loaded from a saved state
-            if (timings == null) {
-                timings = new ConcurrentHashMap<>();
-            }
             timings.merge(kind.name(), System.nanoTime() - start, Long::sum);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -878,6 +878,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                         owner.getListener().getLogger().println("Ready to run at " + new Date());
                         // In case we last paused execution due to Jenkins.isQuietingDown, make sure we do something after we restart.
                         g.unpause();
+                        g.saveProgramIfPossible(false); // ensure pausedWhenLoaded=false is persisted
                     }
                 } catch (IOException x) {
                     LOGGER.log(Level.WARNING, null, x);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -276,6 +276,13 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
 
     boolean resumeBlocked = false;
 
+    /**
+     * Whether {@link CpsThreadGroup#isPaused} when loaded from disk.
+     * @see #loadProgramAsync
+     * @see #afterStepExecutionsResumed
+     */
+    private boolean pausedWhenLoaded;
+
     /** Subdirectory string where we store {@link FlowNode}s */
     private String storageDir = null;
 
@@ -774,17 +781,8 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                             try {
                                 CpsThreadGroup g = (CpsThreadGroup) u.readObject();
                                 result.set(g);
-                                try {
-                                    if (g.isPaused()) {
-                                        owner.getListener().getLogger().println("Still paused");
-                                    } else {
-                                        owner.getListener().getLogger().println("Ready to run at " + new Date());
-                                        // In case we last paused execution due to Jenkins.isQuietingDown, make sure we do something after we restart.
-                                        g.scheduleRun();
-                                    }
-                                } catch (IOException x) {
-                                    LOGGER.log(Level.WARNING, null, x);
-                                }
+                                pausedWhenLoaded = g.isPaused();
+                                g.pause();
                             } catch (Throwable t) {
                                 onFailure(t);
                             } finally {
@@ -868,6 +866,27 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         } catch (Exception ex) {
             LOGGER.log(Level.WARNING, "Failed to persist WorkflowRun after noting a serious failure for run: " + owner, ex);
         }
+    }
+
+    @Override protected void afterStepExecutionsResumed() {
+        runInCpsVmThread(new FutureCallback<CpsThreadGroup>() {
+            @Override public void onSuccess(CpsThreadGroup g) {
+                try {
+                    if (pausedWhenLoaded) {
+                        owner.getListener().getLogger().println("Still paused");
+                    } else {
+                        owner.getListener().getLogger().println("Ready to run at " + new Date());
+                        // In case we last paused execution due to Jenkins.isQuietingDown, make sure we do something after we restart.
+                        g.unpause();
+                    }
+                } catch (IOException x) {
+                    LOGGER.log(Level.WARNING, null, x);
+                }
+            }
+            @Override public void onFailure(Throwable t) {
+                LOGGER.log(Level.WARNING, "could not resume " + this, t);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/workflow-api-plugin/pull/221 and required to avoid regressions in some corner cases.