### PR TITLE
[JENKINS-45327] Pickle EnvActionImpl to prevent multiple instances from existing after resumption

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
@@ -215,17 +215,18 @@ public class EnvActionImpl extends GroovyObjectSupport implements EnvironmentAct
      * in case {@code env} is serialized into the program.
      */
     private static class EnvActionImplPickle extends Pickle {
+        @Override
         public ListenableFuture<?> rehydrate(FlowExecutionOwner owner) {
-            IOException cause = null;
             try {
                 Queue.Executable executable = owner.getExecutable();
                 if (executable instanceof Run) {
                     return Futures.immediateFuture(EnvActionImpl.forRun((Run)executable));
+                } else {
+                    return Futures.immediateFailedFuture(new IllegalStateException("Invalid executable: " + executable));
                 }
             } catch (IOException e) {
-                cause = e;
+                return Futures.immediateFailedFuture(e);
             }
-            return Futures.immediateFailedFuture(new RuntimeException("Unable to find Run for EnvActionImpl: " + owner, cause));
         }
     }
 }


### PR DESCRIPTION
See [JENKINS-45327](https://issues.jenkins.io/browse/JENKINS-45327).

Right now, if you use `env` in a Pipeline in a way that causes `EnvActionImpl` to be serialized into the program's state, then after resumption you end up with a distinct instance of `EnvActionImpl` that is unrelated to the action attached to the `WorkflowRun`, so the `owner` for the deserialized `EnvActionImpl` is null, and `getProperty` and `setProperty` throw NPEs.

This PR fixes the issue by pickling `EnvActionImpl` so that it can be rehydrated using the action attached to the `WorkflowRun`, which maintains the expected singleton semantics and prevents issues.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
