### PR TITLE
Call `CpsVmExecutorService.shutdown` from `CpsFlowExecution.suspendAll`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1584,6 +1584,15 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                             }
                         }
                         cpsExec.checkpoint(true);
+                        cpsExec.runInCpsVmThread(new FutureCallback<CpsThreadGroup>() {
+                            @Override public void onSuccess(CpsThreadGroup g) {
+                                LOGGER.fine(() -> "shutting down CPS VM threadin for " + cpsExec);
+                                g.shutdown();
+                            }
+                            @Override public void onFailure(Throwable t) {
+                                LOGGER.log(Level.WARNING, null, t);
+                            }
+                        });
                     }
                 } catch (Exception ex) {
                     LOGGER.log(Level.WARNING, "Error persisting Pipeline execution at shutdown: "+((CpsFlowExecution) execution).owner, ex);

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
@@ -436,12 +436,9 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
                     }
                     outcome = new Outcome(null, new AlreadyCompleted());
                 }
-
-                /**
-                 * Program state failed to load.
-                 */
                 @Override
                 public void onFailure(Throwable t) {
+                    LOGGER.log(Level.WARNING, "Failed to proceed after " + CpsStepContext.this, t);
                 }
             });
         } catch (IOException x) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -640,6 +640,10 @@ public final class CpsThreadGroup implements Serializable {
         }
     }
 
+    void shutdown() {
+        runner.shutdown();
+    }
+
     private static final Logger LOGGER = Logger.getLogger(CpsThreadGroup.class.getName());
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
@@ -166,7 +166,7 @@ class CpsVmExecutorService extends InterceptingExecutorService {
         cpsThreadGroup.busy = false;
         context.restore();
         CpsFlowExecution execution = cpsThreadGroup.getExecution();
-        if (isShutdown()) {
+        if (isShutdown() && /* build completed, not just after suspendAll */!cpsThreadGroup.getThreads().iterator().hasNext()) {
             execution.logTimings();
         }
         CpsCallableInvocation.registerMismatchHandler(null);


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/195/commits/19c2fdeab67597016b9cb960cda999839421d112 turned up a curious test failure. It turned out that a synchronous nonblocking step completed long after Jenkins had shut down, but since the test uses `JenkinsSessionRule` rather than `RealJenkinsRule`, the JVM continued running and the completion was actually processed by finishing the build (successfully) in the old copy of Jenkins. Needless to say, things got confused when the same build in the new copy of Jenkins tried to continue running, and began doing stuff with the still uncompleted program state despite the build record on disk claiming the build had completed.

There are probably multiple things that could be fixed here (and I will try to make the test behave more realistically to start with), but one problem seems to be that `suspendAll`, which runs during Jenkins shutdown and pauses all running Pipeline builds and makes sure `program.dat` is flushed to disk etc., was neglecting to actually turn off the CPS VM thread, which then continued to accept new tasks. We do not expect or want any tasks to be running in the CPS VM thread after the program has supposedly been serialized and Jenkins is about to exit, as the behavior could be anomalous; consider a `sleep` step which just happens to finish sleeping during this window. Better to reject any further tasks and let `StepExecution.onResume` and other mechanisms do their job.
