### PR TITLE
[JENKINS-63766] Work around JDK-8231454

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1370,7 +1370,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                 Field cacheF = classInfoC.getDeclaredField("CACHE");
                 try {
                     cacheF.setAccessible(true);
-                } catch (RuntimeException e) { // TOOD Java 9+ InaccessibleObjectException
+                } catch (RuntimeException e) { // TODO Java 9+ InaccessibleObjectException
                     /*
                      * Not running with "--add-opens java.desktop/com.sun.beans.introspect=ALL-UNNAMED".
                      * Until core adds this to its --add-opens configuration, and until that core

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1363,7 +1363,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     private static void cleanUpClassInfoCache(Class<?> clazz) {
         JavaSpecificationVersion current = JavaSpecificationVersion.forCurrentJVM();
         if (current.isNewerThan(new JavaSpecificationVersion("1.8"))
-                && current.isOlderThan(new JavaSpecificationVersion("17"))) {
+                && current.isOlderThan(new JavaSpecificationVersion("16"))) {
             try {
                 // TODO Work around JDK-8231454.
                 Class<?> classInfoC = Class.forName("com.sun.beans.introspect.ClassInfo");


### PR DESCRIPTION
### Background

See [JENKINS-63766](https://issues.jenkins.io/browse/JENKINS-63766) and upstream bug [JDK-8231454](https://bugs.openjdk.java.net/browse/JDK-8231454). Users have reported gradual exhaustion of the metaspace when running on Java 11 with Pipeline jobs that define custom classes.

### Steps to reproduce

Create a new Pipeline job with

```java
class asdf {
  void run () {}
}

new asdf().run()
```

and run it under Java 11 with `-verbose:class`. After the job finishes, run `jcmd ${PID} GC.run`

### Expected results

**Note:** These are the _actual_ results when running under Java 8 or Java 17.

The `WorkflowScript` and `asdf` classes get unloaded.

### Actual results

The `WorkflowScript` and `asdf` classes never get unloaded on Java 11.

### Evaluation

As described in the upstream bug, a memory memory leak can occur when `java.beans.Introspector#getBeanInfo` is invoked against a class, even if `java.beans.Introspector#flushFromCaches` is later called on that class. In our case, `java.beans.Introspector#getBeanInfo` is invoked from the following stack trace:

```
getBeanInfo:196, Introspector (java.beans)
run:3328, MetaClassImpl$15 (groovy.lang)
doPrivileged:-1, AccessController (java.security)
addProperties:3326, MetaClassImpl (groovy.lang)
initialize:3303, MetaClassImpl (groovy.lang)
getMetaClassUnderLock:289, ClassInfo (org.codehaus.groovy.reflection)
getMetaClass:331, ClassInfo (org.codehaus.groovy.reflection)
getMetaClass:277, MetaClassRegistryImpl (org.codehaus.groovy.runtime.metaclass)
getMetaClass:905, InvokerHelper (org.codehaus.groovy.runtime)
createCallConstructorSite:86, CallSiteArray (org.codehaus.groovy.runtime.callsite)
defaultCallConstructor:59, CallSiteArray (org.codehaus.groovy.runtime.callsite)
callConstructor:238, AbstractCallSite (org.codehaus.groovy.runtime.callsite)
call:208, Checker$3 (org.kohsuke.groovy.sandbox.impl)
onNewInstance:42, GroovyInterceptor (org.kohsuke.groovy.sandbox)
onNewInstance:173, SandboxInterceptor (org.jenkinsci.plugins.scriptsecurity.sandbox.groovy)
call:205, Checker$3 (org.kohsuke.groovy.sandbox.impl)
checkedConstructor:210, Checker (org.kohsuke.groovy.sandbox.impl)
constructorCall:21, SandboxInvoker (com.cloudbees.groovy.cps.sandbox)
dispatchOrArg:97, FunctionCallBlock$ContinuationImpl (com.cloudbees.groovy.cps.impl)
fixName:78, FunctionCallBlock$ContinuationImpl (com.cloudbees.groovy.cps.impl)
invoke0:-1, NativeMethodAccessorImpl (jdk.internal.reflect)
invoke:62, NativeMethodAccessorImpl (jdk.internal.reflect)
invoke:43, DelegatingMethodAccessorImpl (jdk.internal.reflect)
invoke:566, Method (java.lang.reflect)
receive:72, ContinuationPtr$ContinuationImpl (com.cloudbees.groovy.cps.impl)
eval:21, ConstantBlock (com.cloudbees.groovy.cps.impl)
step:83, Next (com.cloudbees.groovy.cps)
call:174, Continuable$1 (com.cloudbees.groovy.cps)
call:163, Continuable$1 (com.cloudbees.groovy.cps)
use:136, GroovyCategorySupport$ThreadCategoryInfo (org.codehaus.groovy.runtime)
use:275, GroovyCategorySupport (org.codehaus.groovy.runtime)
run0:163, Continuable (com.cloudbees.groovy.cps)
access$001:18, SandboxContinuable (org.jenkinsci.plugins.workflow.cps)
run0:51, SandboxContinuable (org.jenkinsci.plugins.workflow.cps)
runNextChunk:187, CpsThread (org.jenkinsci.plugins.workflow.cps)
run:420, CpsThreadGroup (org.jenkinsci.plugins.workflow.cps)
access$400:95, CpsThreadGroup (org.jenkinsci.plugins.workflow.cps)
call:330, CpsThreadGroup$2 (org.jenkinsci.plugins.workflow.cps)
call:294, CpsThreadGroup$2 (org.jenkinsci.plugins.workflow.cps)
call:67, CpsVmExecutorService$2 (org.jenkinsci.plugins.workflow.cps)
run:264, FutureTask (java.util.concurrent)
run:139, SingleLaneExecutorService$1 (hudson.remoting)
run:28, ContextResettingExecutorService$1 (jenkins.util)
run:68, ImpersonatingExecutorService$1 (jenkins.security)
call:515, Executors$RunnableAdapter (java.util.concurrent)
run:264, FutureTask (java.util.concurrent)
runWorker:1128, ThreadPoolExecutor (java.util.concurrent)
run:628, ThreadPoolExecutor$Worker (java.util.concurrent)
run:829, Thread (java.lang)
```

`java.beans.Introspector#flushFromCaches` is later called on that class, but to no avail:

```
cleanUpLoader:1300, CpsFlowExecution (org.jenkinsci.plugins.workflow.cps)
cleanUpHeap:1269, CpsFlowExecution (org.jenkinsci.plugins.workflow.cps)
run:464, CpsThreadGroup (org.jenkinsci.plugins.workflow.cps)
access$400:95, CpsThreadGroup (org.jenkinsci.plugins.workflow.cps)
call:330, CpsThreadGroup$2 (org.jenkinsci.plugins.workflow.cps)
call:294, CpsThreadGroup$2 (org.jenkinsci.plugins.workflow.cps)
call:67, CpsVmExecutorService$2 (org.jenkinsci.plugins.workflow.cps)
run:264, FutureTask (java.util.concurrent)
run:139, SingleLaneExecutorService$1 (hudson.remoting)
run:28, ContextResettingExecutorService$1 (jenkins.util)
run:68, ImpersonatingExecutorService$1 (jenkins.security)
call:515, Executors$RunnableAdapter (java.util.concurrent)
run:264, FutureTask (java.util.concurrent)
runWorker:1128, ThreadPoolExecutor (java.util.concurrent)
run:628, ThreadPoolExecutor$Worker (java.util.concurrent)
run:829, Thread (java.lang)
```

### Solution

JDK-8231454 solves the problem by removing the class from the `ClassInfo` cache in `Introspector#flushFromCaches`. I plan to backport JDK-8231454 to `jdk11u-dev` upstream. In the meantime, this PR works around the problem for Jenkins users by doing the same thing via reflection. This, in turn, requires `--add-opens java.desktop/com.sun.beans.introspect=ALL-UNNAMED`, which is not in core's `--add-opens` configuration right now. I plan to advise affected users to add this to their configuration manually, and I plan to follow up with a core PR (and backport) to add this to the `--add-opens` configuration in core for current weeklies and LTS releases.

### Testing done

#### Java 8 and Java 17

Ran the scenario without any `--add-opens` directives. Verified in a debugger that the new code did not get executed. Verified via verbose class logging that the `asdf` class was unloaded.

#### Java 11

Ran the scenario with `--add-opens java.desktop/com.sun.beans.introspect=ALL-UNNAMED`. Verified in a debugger that the new code was executed and removed the `asdf` class from the cache. Verified via verbose class logging that the `asdf` class was unloaded.

Ran the scenario without any `--add-opens` directives and no extra logging. Verified that no log spam occurred and that the `asdf` class was not unloaded.

Ran the scenario without any `--add-opens` directives and a custom log recorder. Verified that a `FINER` level log was created and that the `asdf` class was not unloaded.

#### Java 11 with https://github.com/openjdk/jdk11u-dev/pull/1103

Ran the scenario with and without `--add-opens`. Verified that no log spam occurred and that the `asdf` class was unloaded in both cases.