### PR TITLE
Update pause icon to use symbol api

### DIFF
--- a/src/main/resources/images/symbols/pause.svg
+++ b/src/main/resources/images/symbols/pause.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512"><title>Pause</title><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="M176 96h16v320h-16zM320 96h16v320h-16z"/></svg>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/PauseUnpauseAction/action.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/PauseUnpauseAction/action.jelly
@@ -25,5 +25,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-    <l:task icon="plugin/workflow-cps/images/pause.svg" title="${%Pause/resume}" href="${h.getActionUrl(it.url, action)}/toggle" post="true" contextMenu="true"/>
+    <l:task icon="symbol-pause plugin-workflow-cps" title="${%Pause/resume}" href="${h.getActionUrl(it.url, action)}/toggle" post="true" contextMenu="true"/>
 </j:jelly>

--- a/src/main/webapp/images/pause.svg
+++ b/src/main/webapp/images/pause.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#b4b4b4">
-    <path d="M0 0h24v24H0V0z" fill="none" />
-    <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
-</svg>


### PR DESCRIPTION
This PR add new svg icon from icons used across whole Jenkins -> https://ionic.io/ionicons
It means pause icon now support theming etc.

PS. I wasn't able to build it locally due to failure of mvn build (gitpod env).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Before:
![FireShot Capture 005 - qmk #179 Console  Jenkins  - 192 168 0 31](https://user-images.githubusercontent.com/9051964/176546150-6cc91860-243f-4af5-b827-f3f66b09b017.png)


After:
![FireShot Capture 007 - qmk #180  Jenkins  - 192 168 0 31](https://user-images.githubusercontent.com/9051964/176546158-ea136d9d-779f-4b33-9470-ccad30ae7edb.png)
