### PR TITLE
Deprecating `waitForSuspension`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -962,7 +962,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
 
     /**
      * Waits for the workflow to move into the SUSPENDED state.
-     * @deprecated Use some other idiom, code {@link SemaphoreStep}.
+     * @deprecated Use some other idiom, like {@code SemaphoreStep}.
      */
     @Deprecated
     public void waitForSuspension() throws InterruptedException, ExecutionException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -962,7 +962,9 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
 
     /**
      * Waits for the workflow to move into the SUSPENDED state.
+     * @deprecated Use some other idiom, code {@link SemaphoreStep}.
      */
+    @Deprecated
     public void waitForSuspension() throws InterruptedException, ExecutionException {
         if (programPromise==null)
             return; // the execution has already finished and we are not loading program state anymore

--- a/src/test/java/org/jenkinsci/plugins/workflow/SerializationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/SerializationTest.java
@@ -132,7 +132,6 @@ public class SerializationTest extends SingleJobTestBase {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 rebuildContext(story.j);
-                assertThatWorkflowIsSuspended();
                 SemaphoreStep.success("wait/1", null);
                 story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b));
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/SingleJobTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/SingleJobTestBase.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -70,18 +71,6 @@ public abstract class SingleJobTestBase extends Assert {
         e = (CpsFlowExecution) b.getExecution();
     }
 
-    /**
-     * Asserts that {@link #e} is in the suspended state and has nothing more to execute.
-     */
-    public void assertThatWorkflowIsSuspended() throws Exception {
-        assertThatWorkflowIsSuspended(b, e);
-    }
-
-    public void assertThatWorkflowIsSuspended(WorkflowRun b, CpsFlowExecution e) throws Exception {
-        e.waitForSuspension();  // it should be in the suspended state
-        assert b.isBuilding();
-    }
-
     /** @deprecated use {@link JenkinsRule#waitForCompletion} instead */
     public void waitForWorkflowToComplete() throws Exception {
         do {
@@ -89,6 +78,7 @@ public abstract class SingleJobTestBase extends Assert {
         } while (!e.isComplete());
     }
 
+    /** @deprecated Use some other idiom, like {@link SemaphoreStep}. */
     public void waitForWorkflowToSuspend() throws Exception {
         waitForWorkflowToSuspend(e);
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
@@ -96,7 +96,6 @@ public class WorkflowTest extends SingleJobTestBase {
             @Override
             public void evaluate() throws Throwable {
                 rebuildContext(story.j);
-                assertThatWorkflowIsSuspended();
                 for (int i = 0; i < 600 && !Queue.getInstance().isEmpty(); i++) {
                     Thread.sleep(100);
                 }
@@ -141,7 +140,6 @@ public class WorkflowTest extends SingleJobTestBase {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 rebuildContext(story.j);
-                assertThatWorkflowIsSuspended();
 
                 // resume execution and cause the retry to invoke the body again
                 SemaphoreStep.success("wait/1", null);
@@ -177,7 +175,6 @@ public class WorkflowTest extends SingleJobTestBase {
             @Override public void evaluate() throws Throwable {
                 assertEquals(JenkinsRule.DummySecurityRealm.class, jenkins().getSecurityRealm().getClass());
                 rebuildContext(story.j);
-                assertThatWorkflowIsSuspended();
                 story.j.waitForMessage("again running as someone", b);
                 CheckAuth.finish(true);
                 story.j.assertLogContains("finally running as someone", story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
@@ -319,7 +316,6 @@ public class WorkflowTest extends SingleJobTestBase {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 rebuildContext(story.j);
-                assertThatWorkflowIsSuspended();
                 SemaphoreStep.success("env/1", null);
                 story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b));
                 story.j.assertLogContains("tag=jenkins-demo-1 PERMACHINE=set", b);


### PR DESCRIPTION
Only used in test code, and there is generally a better way. (CC @riliane)

Not trying to clean up all usages (in this and other plugins) at this time.

https://github.com/jenkinsci/workflow-cps-plugin/pull/340#discussion_r353308803 https://github.com/jenkinsci/pipeline-plugin/pull/249 https://github.com/jenkinsci/workflow-cps-plugin/pull/568#discussion_r929157142