### PR TITLE
feat: Switch to ionicons api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
             <version>639.v6eca_cd8c04a_a_</version> <!-- TODO until in BOM -->
         </dependency>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>ionicons-api</artifactId>
+            <version>19.v744f3b_2b_b_e4e</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
@@ -102,7 +102,7 @@ public class ReplayAction implements Action {
     }
 
     @Override public String getIconFileName() {
-        return isEnabled() || isRebuildEnabled() ? "symbol-redo plugin-workflow-cps" : null;
+        return isEnabled() || isRebuildEnabled() ? "symbol-arrow-redo-outline plugin-ionicons-api" : null;
     }
 
     @Override public String getUrlName() {

--- a/src/main/resources/images/symbols/pause.svg
+++ b/src/main/resources/images/symbols/pause.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512"><title>Pause</title><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="M176 96h16v320h-16zM320 96h16v320h-16z"/></svg>

--- a/src/main/resources/images/symbols/redo.svg
+++ b/src/main/resources/images/symbols/redo.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512"><title>Arrow Redo</title><path d="M448 256L272 88v96C103.57 184 64 304.77 64 424c48.61-62.24 91.6-96 208-96v96z" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="32"/></svg>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/PauseUnpauseAction/action.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/PauseUnpauseAction/action.jelly
@@ -25,5 +25,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-    <l:task icon="symbol-pause plugin-workflow-cps" title="${%Pause/resume}" href="${h.getActionUrl(it.url, action)}/toggle" post="true" contextMenu="true"/>
+    <l:task icon="symbol-pause-outline plugin-ionicons-api" title="${%Pause/resume}" href="${h.getActionUrl(it.url, action)}/toggle" post="true" contextMenu="true"/>
 </j:jelly>


### PR DESCRIPTION
The change proposed makes use of the centralized ionicons API to remove the need to ship symbols on a per-plugin basis, that are provided by the library.

cc @jenkinsci/workflow-cps-plugin-developers 