### PR TITLE
Accept run not loading at all as a kind of run failure in testDurableAgainstCleanRestartFailsWithDirtyShutdown

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -63,8 +63,6 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.Assume;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Tests implementations designed to verify handling of the flow durability levels and persistence of pipeline state.

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -45,11 +45,15 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.jvnet.hudson.test.*;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -617,6 +617,7 @@ public class FlowDurabilityTest {
             @Override
             public void evaluate() throws Throwable {
                 WorkflowRun run = story.j.jenkins.getItemByFullName("durableAgainstClean", WorkflowJob.class).getLastBuild();
+                if (run == null) { return; } //there is a small chance due to non atomic write that build.xml will be empty and the run won't load at all
                 verifyFailedCleanly(story.j.jenkins, run);
                 story.j.assertLogContains(logStart[0], run);
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -589,10 +589,8 @@ public class FlowDurabilityTest {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                WorkflowRun run = story.j.jenkins.getItemByFullName("durableAgainstClean", WorkflowJob.class).getLastBuild();
-                try {
-                    verifyFailedCleanly(story.j.jenkins, run);
-                } catch (NullPointerException e) {
+                if (logging.getMessages().stream().anyMatch(msg -> msg.contains("could not load") && msg.contains("jobs/durableAgainstClean/builds/1"))){
+                    log.warning("Found a message in LoggerRule - trying to log the build.xml");
                     File buildXml = new File (story.j.jenkins.getRootDir() + "/jobs/durableAgainstClean/builds/1/build.xml");
                     BufferedReader in = new BufferedReader(new FileReader(buildXml));
                     String line = in.readLine();
@@ -602,6 +600,23 @@ public class FlowDurabilityTest {
                         line = in.readLine();
                     }
                     in.close();
+                    log.warning("Done logging the build.xml");
+                }
+                WorkflowRun run = story.j.jenkins.getItemByFullName("durableAgainstClean", WorkflowJob.class).getLastBuild();
+                try {
+                    verifyFailedCleanly(story.j.jenkins, run);
+                } catch (NullPointerException e) {
+                    log.warning("Caught NPE - trying to log the build.xml");
+                    File buildXml = new File (story.j.jenkins.getRootDir() + "/jobs/durableAgainstClean/builds/1/build.xml");
+                    BufferedReader in = new BufferedReader(new FileReader(buildXml));
+                    String line = in.readLine();
+                    while(line != null)
+                    {
+                        log.warning(line);
+                        line = in.readLine();
+                    }
+                    in.close();
+                    log.warning("Done logging the build.xml");
                     throw e;
                 }
                 story.j.assertLogContains(logStart[0], run);

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -255,8 +255,7 @@ public class FlowDurabilityTest {
      * Currently dirty shutdowns have the potential to lose the head node ID if they happen at the moment of writing
      * it to build.xml
      */
-    static void verifyDirtyResumed(JenkinsRule rule, WorkflowRun run, String logStart) throws Exception {
-        assert run.isBuilding();
+    private static void verifyDirtyResumed(JenkinsRule rule, WorkflowRun run, String logStart) throws Exception {
         assertHasTimingAction(run.getExecution());
         rule.waitForCompletion(run);
         Assert.assertEquals(Result.SUCCESS, run.getResult());
@@ -266,8 +265,8 @@ public class FlowDurabilityTest {
     }
 
     /** If it's a {@link SemaphoreStep} we test less rigorously because that blocks async GraphListeners. */
-    static void verifySafelyResumed(JenkinsRule rule, WorkflowRun run, boolean isSemaphore, String logStart) throws Exception {
-        assert run.isBuilding();
+    private static void verifySafelyResumed(JenkinsRule rule, WorkflowRun run, boolean isSemaphore, String logStart) throws Exception {
+        Assert.assertTrue(run.isBuilding());
         FlowExecution exec = run.getExecution();
 
         // Assert that we have the appropriate flow graph entries

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -51,7 +51,6 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.lang.annotation.ElementType;


### PR DESCRIPTION
`testDurableAgainstCleanRestartFailsWithDirtyShutdown` occasionally throws an NPE and flakes, because the build.xml file of the run ends up empty after being interrupted by a dirty restart, as the writes for performance-optimized durability are not atomic. That's still a kind of run failure and a plausible consequence of a dirty restart, so I propose to accept this outcome and skip all the remaining assertions.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue
