### PR TITLE
[JENKINS-68849] Restore EnvActionImpl.metaClass during deserialization to prevent NPEs in Declarative `when` conditions in Pipelines resumed after a Jenkins restart

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
@@ -155,6 +155,12 @@ public class EnvActionImpl extends GroovyObjectSupport implements EnvironmentAct
         owner = r;
     }
 
+    private Object readResolve() {
+        // We need to restore the transient MetaClass field when this class is deserialized by XStream to prevent NPEs in Groovy code that calls methods on this class.
+        setMetaClass(null);
+        return this;
+    }
+
     /**
      * Gets the singleton instance for a given build, creating it on demand.
      */

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -530,14 +530,15 @@ public class CpsFlowExecutionTest {
         }
     }
 
-    @Issue("JENKINS-45327")
+    @Issue({ "JENKINS-45327", "JENKINS-68849" })
     @Test public void envActionImplPickle() throws Throwable {
         sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                     "def e = env\n" +
                     "semaphore('wait')\n" + // An instance of EnvActionImpl is part of the program's state at this point.
-                    "e.foo = 'bar'\n", true)); // Without EnvActionImplPickle, this throws an NPE in EnvActionImpl.setProperty because owner is null.
+                    "e.foo = 'bar'\n" +  // Without EnvActionImplPickle, this throws an NPE in EnvActionImpl.setProperty because owner is null.
+                    "env.getProperty('foo')\n", true)); // Without EnvActionImpl.readResolve, this throws an NPE in PogoMetaClassSite.call
             WorkflowRun b = p.scheduleBuild2(0).waitForStart();
             SemaphoreStep.waitForStart("wait/1", b);
         });


### PR DESCRIPTION
See [JENKINS-68849](https://issues.jenkins.io/browse/JENKINS-68849).

Some Declarative `when` conditions are evaluated using Groovy scripts that look up `EnvActionImpl` and then call `getProperty` to determine whether an environment variable exists (see [EnvironmentConditionalScript.groovy](https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/9b5cc3a05622d156ed47dadfed4ee8b30636d2b7/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/EnvironmentConditionalScript.groovy#L41)). Groovy dispatches the call to `getProperty` through `PogoMetaClassSite.call`, which uses `GroovyObject.getMetaClass().invokeMethod(...)` to handle the call. However, when `EnvActionImpl` is deserialized by XStream (since it is an `Action` stored on the `Run`), it does not restore the `transient MetaClass` field defined in `GroovyObjectSupport`, so `EnvActionImpl.getMetaClass` returns `null` and an NPE gets thrown.

Perhaps this should be considered a bug in XStream, but I am not sure. Java serialization (and JBoss marshalling) obviously do not allow deserialization of classes that do not implement `Serializable`, but the Java serialization specification says that during deserialization, "For serializable objects, the no-arg constructor for the first non-serializable supertype is run" (see [here](https://docs.oracle.com/en/java/javase/19/docs/specs/serialization/input.html)), and for XStream I would assume that the same logic would apply (even to classes that do not implement `Serializable`). If that were the case, then the `GroovyObjectSupport` constructor would be automatically invoked when deserializing `EnvActionImpl`, which would initialize the `metaClass` field and avoid the NPE. For comparison, we currently rely on JBoss Marshalling doing just that for all subclasses of `SerializableScript`, such as `CpsScript` in Pipelines.

I did check to see if this was caused by https://github.com/jenkinsci/workflow-cps-plugin/pull/539 (my thought was that perhaps removing `Serializable` changed the behavior of XStream), but from some quick testing the bug occurs even before that change (meaning that XStream seems to not follow the serialization spec's behavior in this case).

I looked through XStream's issue tracker and FAQ but did not see anything specifically related to invocation of default constructors in superclasses. Time permitting, I would like to investigate the behavior of XStream when it is used independently from Jenkins to see if this is the expected behavior or should be reported as a bug upstream, but for now it seems best to fix the issue in Jenkins directly. 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
