### PR TITLE
[JENKINS-69917] - Snippetizer/index.jelly javascript un-inlined.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/handle-prototype.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/handle-prototype.js
@@ -1,0 +1,28 @@
+
+function handlePrototype() {
+    buildFormTree(document.forms.config);
+    // TODO JSON.stringify fails in some circumstances: https://gist.github.com/jglick/70ec4b15c1f628fdf2e9 due to Array.prototype.toJSON
+    var json = Object.toJSON(JSON.parse(document.forms.config.elements.json.value).prototype);
+    if (!json) {
+        return; // just a separator
+    }
+    const url = '/jenkins/pipeline-syntax/generateSnippet' // ${rootURL}/${it.GENERATE_URL}
+    new Ajax.Request(url, {
+        method: 'POST',
+        parameters: {json: json},
+        onSuccess: function(r) {
+            document.getElementById('prototypeText').value = r.responseText;
+        }
+    });
+}
+
+
+document.addEventListener('DOMContentLoaded', (event) => {
+
+    const generatePipelineScript = document.getElementById("generatePipelineScript");
+    generatePipelineScript.onclick = (_) => {
+        handlePrototype();
+        return false;
+    }
+
+});

--- a/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -67,27 +67,10 @@ THE SOFTWARE.
                     <f:dropdownListBlock title="${%— Advanced/Deprecated —}"/>
                     <local:listSteps quasiDescriptors="${it.getQuasiDescriptors(true)}"/>
                 </f:dropdownList>
-                <j:set var="id" value="${h.generateId()}"/>
                 <f:block>
-                    <input type="button" value="${%Generate Pipeline Script}" onclick="handlePrototype_${id}(); return false" class="submit-button primary"/>
-                    <f:textarea id="prototypeText_${id}" readonly="true" style="margin-top: 10px" />
-                    <script>
-                        function handlePrototype_${id}() {
-                            buildFormTree(document.forms.config);
-                            // TODO JSON.stringify fails in some circumstances: https://gist.github.com/jglick/70ec4b15c1f628fdf2e9 due to Array.prototype.toJSON
-                            var json = Object.toJSON(JSON.parse(document.forms.config.elements.json.value).prototype);
-                            if (!json) {
-                                return; // just a separator
-                            }
-                            new Ajax.Request('${rootURL}/${it.GENERATE_URL}', {
-                                method: 'POST',
-                                parameters: {json: json},
-                                onSuccess: function(r) {
-                                    document.getElementById('prototypeText_${id}').value = r.responseText;
-                                }
-                            });
-                        }
-                    </script>
+                    <input type="button" id="generatePipelineScript" value="${%Generate Pipeline Script}" class="submit-button primary"/>
+                    <f:textarea id="prototypeText" readonly="true" style="margin-top: 10px" />
+                    <st:adjunct includes="org.jenkinsci.plugins.workflow.cps.Snippetizer.handle-prototype"/>
                 </f:block>
                 <f:section title="${%Global Variables}"/>
                 <f:block>


### PR DESCRIPTION
**The issue**
You can find all the issue details [here](https://issues.jenkins.io/browse/JENKINS-69917).

**My updates**
I've moved the `onclick` call from the `Snippetizer/index.jelly` file to the `handle-prototype.js` one.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
