### PR TITLE
Bump plugin from 4.48 to 4.49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.48</version>
+        <version>4.49</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -69,6 +69,7 @@
         <groovy-cps.version>1.34</groovy-cps.version>
         <node.version>16.17.0</node.version>
         <npm.version>8.18.0</npm.version>
+        <yarn.version>1.22.19</yarn.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Picking up https://github.com/jenkinsci/workflow-cps-plugin/pull/601#issuecomment-1296983973

@jglick 4.49 removed the default the versions set for yarn, node and npm. This repository uses all three tools, but did declare `<node.version>` and `<npm.version>` only.

This PR demonstrates how to upgrade to 4.49 by specifying `<yarn.version>`.

I'll add a few links to the 4.49 changelog where to obtain these versions from. I'd assume that makes it easier for users to upgrade?

Closes https://github.com/jenkinsci/workflow-cps-plugin/pull/601