### PR TITLE
Make Dependabot ignore Groovy and do not specify explicit remoting version in groovy-cps-dgm-builder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+    - dependency-name: org.codehaus.groovy:groovy
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/dgm-builder/pom.xml
+++ b/dgm-builder/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>remoting</artifactId>
-            <version>4.13.3</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <jenkins.version>2.346.3</jenkins.version>
-        <groovy.version>2.4.21</groovy.version>
+        <groovy.version>2.4.21</groovy.version> <!-- TODO: Add org.codehaus.groovy:groovy and org.codehaus.groovy:groovy:sources to Jenkins core BOM so this can be deleted? (currently it only specifies groovy-all) -->
     </properties>
     <modules>
         <module>dgm-builder</module>


### PR DESCRIPTION
Replaces #618 and #619.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
