### PR TITLE
Wrap laodedScripts in optionalBlock

### DIFF
--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction/index.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction/index.jelly
@@ -16,9 +16,11 @@
                                 <wfe:workflow-editor script="${it.originalScript}" checkUrl="${rootURL}/${it.owner.url}${it.urlName}/checkScript" checkDependsOn=""/>
                             </f:entry>
                             <j:forEach var="loadedScript" items="${it.originalLoadedScripts.entrySet()}">
-                                <f:entry field="${loadedScript.key.replace('.', '_')}" title="${loadedScript.key}">
-                                    <wfe:workflow-editor script="${loadedScript.value}" checkUrl="${rootURL}/${it.owner.url}${it.urlName}/checkScript" checkDependsOn=""/>
-                                </f:entry>
+                                <f:optionalBlock name="dynamic" title="${loadedScript.key}">
+                                    <f:entry field="${loadedScript.key.replace('.', '_')}" title="${loadedScript.key}">
+                                        <wfe:workflow-editor script="${loadedScript.value}" checkUrl="${rootURL}/${it.owner.url}${it.urlName}/checkScript" checkDependsOn=""/>
+                                    </f:entry>
+                                </f:optionalBlock>
                             </j:forEach>
                             <f:block>
                                 <a href="${rootURL}/${it.owner.parent.url}/pipeline-syntax" target="_blank">${%Pipeline Syntax}</a>


### PR DESCRIPTION
Wrapping loaded scripts in an `optionalBlock` to make it easier to manage when there are large numbers of loaded scripts.

This is a stab in the dark as I can't get the plugin building locally (and added to the running Jenkins instance).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
