### PR TITLE
Reduce reflection in `CpsFlowExecution`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1483,6 +1483,13 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     }
 
     private static void cleanUpObjectStreamClassCaches(@NonNull Class<?> clazz) throws Exception {
+      int releaseVersion = JavaSpecificationVersion.forCurrentJVM().toReleaseVersion();
+      VersionNumber javaVersion = new VersionNumber(System.getProperty("java.version"));
+      if ((releaseVersion < 11)
+              || (releaseVersion == 11 && javaVersion.isOlderThan(new VersionNumber("11.0.16")))
+              || (releaseVersion > 11 && releaseVersion < 17)
+              || (releaseVersion == 17 && javaVersion.isOlderThan(new VersionNumber("17.0.4")))
+              || (releaseVersion == 18 && javaVersion.isOlderThan(new VersionNumber("18.0.2")))) {
         Class<?> cachesC = Class.forName("java.io.ObjectStreamClass$Caches");
         for (String cacheFName : new String[] {"localDescs", "reflectors"}) {
             Field cacheF = cachesC.getDeclaredField(cacheFName);
@@ -1500,6 +1507,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                 }
             }
         }
+      }
     }
 
     synchronized @CheckForNull FlowHead getFirstHead() {


### PR DESCRIPTION
Jenkins core currently specifies `--add-opens java.base/java.io=ALL-UNNAMED`, which is technical debt in the sense that it enables deprecated behavior. This is only needed for `workflow-cps`'s `cleanUpObjectStreamClassCaches` method, and that method is in turn only needed for old JVMs that do not have the fix for [JDK-8277072](https://bugs.openjdk.org/browse/JDK-8277072). This PR makes the reflection-based logic conditional on running on these older JVMs, so that when running on a newer JVM the illegal reflective access is not attempted. When this PR is widely adopted, we can remove the `--add-opens java.base/java.io=ALL-UNNAMED` directive from Jenkins core and clean up this technical debt.

To test this change I removed `--add-opens java.base/java.io=ALL-UNNAMED` and verified that this exception was logged even when running on Java 11.0.17:

```
java.lang.reflect.InaccessibleObjectException: Unable to make field static final java.io.ClassCache java.io.ObjectStreamClass$Caches.localDescs accessible: module java.base does not "opens java.io" to unnamed module @2cb2b9bd
        at java.base/java.lang.reflect.AccessibleObject.throwInaccessibleObjectException(AccessibleObject.java:387)
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:363)
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:311)
        at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:180)
        at java.base/java.lang.reflect.Field.setAccessible(Field.java:174)
        at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.cleanUpObjectStreamClassCaches(CpsFlowExecution.java:1489)
        at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.cleanUpLoader(CpsFlowExecution.java:1346)
        at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.cleanUpHeap(CpsFlowExecution.java:1311)
        at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:464)
        at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$400(CpsThreadGroup.java:95)
        at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:330)
        at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:294)
        at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:67)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:139)
        at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:30)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:70)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1589)
```

With this PR the exception is no longer logged. If accepted I will make a similar PR for the copypasta of this code in `script-security`.