### PR TITLE
[JENKINS-70108] CastBlock must contextualize invoker to avoid issues in mixed-trust scenarios

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/Builder.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/Builder.java
@@ -588,7 +588,7 @@ public class Builder {
      *      be used in all other cases, such as Java-syntax casts and implicit casts inserted by the Groovy runtime.
      */
     public Block cast(int line, Block block, Class type, boolean coerce) {
-        return new CastBlock(loc(line), block, type, false, coerce, false);
+        return new CastBlock(loc(line), tags, block, type, false, coerce, false);
     }
 
     /**

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CastBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CastBlock.java
@@ -4,12 +4,13 @@ import com.cloudbees.groovy.cps.Block;
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 import com.cloudbees.groovy.cps.Next;
-import java.util.Collections;
+import com.cloudbees.groovy.cps.sandbox.CallSiteTag;
+import java.util.Collection;
 import java.util.List;
 import org.codehaus.groovy.runtime.InvokerInvocationException;
 import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;
 
-public class CastBlock implements Block {
+public class CastBlock extends CallSiteBlockSupport {
     private final SourceLocation loc;
     private final Block valueExp;
     private final Class<?> type;
@@ -17,7 +18,8 @@ public class CastBlock implements Block {
     private final boolean coerce;
     private final boolean strict;
 
-    public CastBlock(SourceLocation loc, Block valueExp, Class<?> type, boolean ignoreAutoboxing, boolean coerce, boolean strict) {
+    public CastBlock(SourceLocation loc, Collection<CallSiteTag> tags, Block valueExp, Class<?> type, boolean ignoreAutoboxing, boolean coerce, boolean strict) {
+        super(tags);
         this.loc = loc;
         this.valueExp = valueExp;
         this.type = type;
@@ -42,7 +44,7 @@ public class CastBlock implements Block {
 
         public Next cast(Object value) {
             try {
-                return k.receive(e.getInvoker().cast(value, type, ignoreAutoboxing, coerce, strict));
+                return k.receive(e.getInvoker().contextualize(CastBlock.this).cast(value, type, ignoreAutoboxing, coerce, strict));
             } catch (CpsCallableInvocation inv) {
                 // Implementations of asType and other methods used by the Groovy stdlib should be @NonCPS, but we
                 // just log a warning and invoke the callable anyway to maintain the existing behavior.

--- a/lib/src/test/java/com/cloudbees/groovy/cps/AbstractGroovyCpsTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/AbstractGroovyCpsTest.java
@@ -124,10 +124,10 @@ public abstract class AbstractGroovyCpsTest {
      */
     public void assertEvaluate(Object expectedReturnValue, String script) {
         evalCps(script, expectedReturnValue, e -> {
-            throw new RuntimeException("Failed to evaluate sandboxed script: " + script, e);
+            throw new RuntimeException("Failed to evaluate CPS-transformed script: " + script, e);
         });
         eval(script, expectedReturnValue, e -> {
-            throw new RuntimeException("Failed to evaluate unsandboxed script: " + script, e);
+            throw new RuntimeException("Failed to evaluate non-CPS-transformed script: " + script, e);
         });
     }
 

--- a/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformerTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformerTest.java
@@ -527,7 +527,7 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
     @Test
     public void arrayPassedToMethod() throws Throwable {
         assertEvaluate(4, "def m(x) {x.size()}; def a = [1, 2]; a.size() + m(a)"); // control case
-        assertEvaluate(4, "def m(x) {x.size()}; def a = [1, 2].toArray(); a.length + m(List.of(a))"); // workaround #1
+        assertEvaluate(4, "def m(x) {x.size()}; def a = [1, 2].toArray(); a.length + m(Arrays.asList(a))"); // workaround #1
         assertEvaluate(4, "@NonCPS def m(x) {x.length}; def a = [1, 2].toArray(); a.length + m(a)"); // workaround #2
         assertEvaluate(4, "def m(x) {x.length}; def a = [1, 2].toArray(); a.length + m(a)"); // formerly: groovy.lang.MissingPropertyException: No such property: length for class: java.lang.Integer
     }

--- a/lib/src/test/java/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.java
@@ -696,4 +696,16 @@ public class SandboxInvokerTest extends AbstractGroovyCpsTest {
                 "Script1.method3()");
     }
 
+    @Test public void castsInTrustedCodeCalledByUntrustedCodeShouldBeTrusted() throws Throwable {
+        TrustedCpsCompiler trusted = new TrustedCpsCompiler();
+        trusted.setUp();
+        getBinding().setVariable("trusted", trusted.getCsh().parse("def foo() { File f = ['secret.key'] }"));
+
+        assertIntercept(
+            "trusted.foo()", // Untrusted script
+            new File("secret.key"),
+            "Script1.super(Script1).setBinding(Binding)",
+            "Script1.trusted",
+            "Script1.foo()");
+    }
 }

--- a/lib/src/test/java/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.java
@@ -696,16 +696,44 @@ public class SandboxInvokerTest extends AbstractGroovyCpsTest {
                 "Script1.method3()");
     }
 
-    @Test public void castsInTrustedCodeCalledByUntrustedCodeShouldBeTrusted() throws Throwable {
+    @Issue("JENKINS-70108")
+    @Test public void castsInTrustedCodeCalledByUntrustedCodeShouldNotBeIntercepted() throws Throwable {
         TrustedCpsCompiler trusted = new TrustedCpsCompiler();
         trusted.setUp();
         getBinding().setVariable("trusted", trusted.getCsh().parse("def foo() { File f = ['secret.key'] }"));
-
         assertIntercept(
             "trusted.foo()", // Untrusted script
             new File("secret.key"),
             "Script1.super(Script1).setBinding(Binding)",
             "Script1.trusted",
             "Script1.foo()");
+    }
+
+    /*
+     * All blocks that perform boolean casts internally using ContinuationGroup.castToBoolean incorrectly intercept
+     * calls performed by the cast when the cast is in trusted code that is called by untrusted code. For boolean
+     * casts, this is not that interesting, since it only causes problems in practice if you cast a type that
+     * implements an asBoolean method that would not be allowed by the sandbox.
+     * I see two obvious ways to fix this:
+     * 1. Add a CallSiteBlock parameter to ContinuationGroup.castToBoolean, and use it to contextualize the invoker
+     *    used in that method. All Blocks that use the method would need to be updated to implement CallSiteBlock.
+     * 2. Delete ContinuationGroup.castToBoolean and replace all uses with basic Java casts to boolean. Modify
+     *    CpsTransformer to insert explicit boolean casts into the CPS-transformed program for all AST nodes whose
+     *    Blocks previously used castToBoolean.
+     */
+    @Ignore("This variant of JENKINS-70108 seems less likely to cause problems in practice and is more complex to fix")
+    @Test public void booleanCastsInTrustedCodeCalledByUntrustedCodeShouldNotBeIntercepted() throws Throwable {
+        TrustedCpsCompiler trusted = new TrustedCpsCompiler();
+        trusted.setUp();
+        getBinding().setVariable("trusted", trusted.getCsh().parse(
+                "class Test { @NonCPS def asBoolean() { false } }\n" +
+                "def foo() { if (new Test()) { 123 } else { 456 } }"));
+        assertIntercept(
+            "trusted.foo()", // Untrusted script
+            456,
+            "Script1.super(Script1).setBinding(Binding)",
+            "Script1.trusted",
+            "Script1.foo()");
+            // Currently the call to Test.asBoolean() is also intercepted, which is incorrect.
     }
 }


### PR DESCRIPTION
See [JENKINS-70108](https://issues.jenkins.io/browse/JENKINS-70108).

https://github.com/jenkinsci/workflow-cps-plugin/commit/819cc9be597121a2bf88b7669323aa6caa502f72 introduced a new `Block` for casts, `CastBlock`, which did not implement `CallSiteBlock` and did not contextualize its `Invoker`. In cases where untrusted code calls trusted code that performs a cast, this could result in trusted code calling `SandboxInvoker.cast` instead of `DefaultInvoker.cast`. In practical terms, this means that casts inside of global Pipeline libraries were sometimes incorrectly blocked by the sandbox.

This PR makes `CastBlock` implement `CallSiteBlock` so that it can contextualize `Invoker` correctly before performing the cast.

TODO:
* [x] Does `ContinuationGroup.castToBoolean` also need changes?
    * I am pretty sure that it technically does, but the current code would only block casts if the type being cast implements an `asBoolean` method that is not allowed by the sandbox, so IDK if it matters in practice.
    * See https://github.com/jenkinsci/workflow-cps-plugin/pull/640#discussion_r1047399933 and surrounding ignored code and comment.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
