### PR TITLE
Replacing `Arrays.asList` with `List.of` can introduce `NullPointerException`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImpl.java
@@ -175,7 +175,7 @@ public class ArgumentsActionImpl extends ArgumentsAction {
             this.isUnmodifiedBySanitization = false;
             return NotStoredReason.OVERSIZE_VALUE;
         }
-        List inputList = List.of(objects);
+        List<Object> inputList = Arrays.asList(objects);
         Object sanitized = sanitizeListAndRecordMutation(inputList, variables);
         if (sanitized == inputList) { // Works because if not mutated, we return original input instance
             return objects;

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/persistence/IteratorHack.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/persistence/IteratorHack.java
@@ -102,7 +102,7 @@ public class IteratorHack {
 
     public static <E> Iterator<E> iterator(E[] array) {
         // TODO as above
-        return new Itr<>(List.of(array));
+        return new Itr<>(Arrays.asList(array));
     }
 
     public static <E> Iterator<E> iterator(Deque deque) {

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/persistence/IteratorHackTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/persistence/IteratorHackTest.java
@@ -256,4 +256,18 @@ public class IteratorHackTest {
             r.assertBuildStatusSuccess(r.waitForCompletion(b));
         });
     }
+
+    @Issue("https://github.com/jenkinsci/workflow-cps-plugin/pull/627#issuecomment-1352869571")
+    @Test public void arrayIterator() throws Exception {
+        rr.then(r -> {
+            WorkflowJob p = r.createProject(WorkflowJob.class);
+            p.setDefinition(new CpsFlowDefinition(
+                    "Object[] arr = [1, null, 2]\n" +
+                    "for (def elt : arr) {\n" +
+                    "  echo(/iterating on $elt/)\n" +
+                    "}\n", false));
+            rr.j.assertLogContains("iterating on null", rr.j.buildAndAssertSuccess(p));
+        });
+    }
+
 }


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-cps-plugin/pull/635#discussion_r1049599451 https://github.com/jenkinsci/workflow-cps-plugin/pull/627#issuecomment-1352869571 @jimklimov