### PR TITLE
[JENKINS-70564] Replay page broken after the Ace editor update

### DIFF
--- a/plugin/src/main/js/workflow-editor.js
+++ b/plugin/src/main/js/workflow-editor.js
@@ -9,6 +9,7 @@ import { addSamplesWidget } from './samples';
 import ace from "ace-builds/src-noconflict/ace";
 import "ace-builds/src-noconflict/ext-language_tools";
 import "ace-builds/src-noconflict/mode-groovy";
+import "ace-builds/src-noconflict/snippets/javascript";
 import "ace-builds/src-noconflict/theme-tomorrow";
 
 // Import custom snippets
@@ -16,6 +17,7 @@ import "./snippets/workflow";
 
 var editorIdCounter = 0;
 
+document.addEventListener("DOMContentLoaded", function() {
         $('.workflow-editor-wrapper').each(function() {
             initEditor($(this));
         });
@@ -128,3 +130,4 @@ var editorIdCounter = 0;
             wrapper.show();
             textarea.hide();
         }
+});


### PR DESCRIPTION
### Context

See [JENKINS-70564](https://issues.jenkins.io/browse/JENKINS-70564).

### Problems

1. When multiple Ace editors are on a single page (for example, when replaying a Pipeline with a non-trusted shared library), only the first editor loads. This is a regression.
2. Every page with an Ace editor shows log spam of the form "Unable to infer path to `ace` from script `src`, use `ace.config.set('basePath', 'path')` to enable dynamic loading of modes and themes or with `webpack` use `ace/webpack-resolver`"

## Solutions

1. This is a Stapler "adjunct" which is a pair of CSS and JavaScript as in https://github.com/jenkinsci/stapler/blob/70d5f5f9064f527e3fe19671d827857de410d05e/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/Adjunct.java#L204-L207. The way Webpack works, the script is only loaded a single time. In the new logic the script would be loaded before the DOM was completely built (i.e., as soon as the first editor was in the DOM), which would iterate over all editors (there would only be one at this point) and initialize them. The first editor would get initialized and then when loading the second editor, the script portion would be a no-op, so nothing would ever initialize the editors. Looking into how this worked in the old version, the initialization was postponed until after the DOM had been built up. I did a Google search for "how to make javascript execute after page load" which led me to [this page](https://stackoverflow.com/questions/807878/how-to-make-javascript-execute-after-page-load) which showed a few solutions. The first one ("use `defer`") can't be done with Stapler due to https://github.com/jenkinsci/stapler/blob/70d5f5f9064f527e3fe19671d827857de410d05e/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/Adjunct.java#L204-L207 so I followed the second solution (`DOMContentLoaded`) which worked perfectly on the first try.
2. The Ace Groovy mode seems to inherit from the JavaScript mode https://github.com/ajaxorg/ace/blob/4a6ae77940b06240c476fd4c76b3cc5e6983bd56/src/mode/groovy.js#L11 which is why it tries to load some JavaScript mode file and fails because we haven't included it in the list of files to pack. This can be solved by adding the JavaScript mode to the list of files in the Webpack script. I filed for another day any latent curiosity about why this compiler/linker can't seem to correctly compute the transitive closure of its dependency graph.

### Testing done

Reproduced the problems before this PR and verified the problems were resolved after this PR. Also repeated all the original testing from #653.