### PR TITLE
[JENKINS-70591] Cannot create inline Pipeline job after Ace editor upgrade

### DIFF
--- a/plugin/src/main/js/workflow-editor.js
+++ b/plugin/src/main/js/workflow-editor.js
@@ -18,7 +18,7 @@ import "./snippets/workflow";
 
 var editorIdCounter = 0;
 
-document.addEventListener("DOMContentLoaded", function() {
+$(function() {
         $('.workflow-editor-wrapper').each(function() {
             initEditor($(this));
         });


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-cps-plugin/pull/653#issuecomment-1424299833 was an assertion without evidence, and also an incorrect one — the cause of [JENKINS-70591](https://issues.jenkins.io/browse/JENKINS-70591) was #656, **not** #653. This was determined after a few minutes of bisection. Using the [JQuery `ready()` API](https://api.jquery.com/ready/) gets rid of this bug and is consistent with the code elsewhere in this file which uses JQuery rather than plain JavaScript. Note that I followed the recommended syntax:

> jQuery offers several ways to attach a function that will run when the DOM is ready. All of the following syntaxes are equivalent:
>
> - `$( handler )`
> - `$( document ).ready( handler )`
> - `$( "document" ).ready( handler )`
> - `$( "img" ).ready( handler )`
> - `$().ready( handler )`
> 
> As of jQuery 3.0, only the first syntax is recommended; the other syntaxes still work but are deprecated.

The `$(function() {` syntax did look odd to me, but it is explicitly recommended in the documentation:

> Which is equivalent to the recommended way of calling:
> ```javascript
> $(function() {
>   // Handler for .ready() called.
> });
> ```

To test this, I reproduced the problem described in JENKINS-70591 and verified the problem no longer occurred after this PR. I also repeated the testing done in #656 and #653.