### PR TITLE
Lockless `Timing.close`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -426,7 +426,11 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         }
 
         @Override public void close() {
-            timings.merge(kind.name(), System.nanoTime() - start, Long::sum);
+            // Not using ConcurrentHashMap::merge since it can acquire a lock:
+            long delta = System.nanoTime() - start;
+            Long prev = timings.get(kind.name());
+            long nue = prev == null ? delta : prev + delta;
+            timings.put(kind.name(), nue);
         }
     }
 


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-cps-plugin/pull/519#discussion_r838633990 looked reasonable, yet there have been field reports of lock contention here. (Complements https://github.com/jenkinsci/blueocean-plugin/pull/2406.) Since gathering of timing information is done on a best-effort basis, and is used only for support diagnostics, it is preferable to risk the occasional clobbered update from two threads (effectively losing one delta) than to ever acquire a lock.