### PR TITLE
Lockless `Timing.close`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -417,7 +417,11 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         }
 
         @Override public void close() {
-            timings.merge(kind.name(), System.nanoTime() - start, Long::sum);
+            // Not using ConcurrentHashMap::merge since it can acquire a lock:
+            long delta = System.nanoTime() - start;
+            Long prev = timings.get(kind.name());
+            long nue = prev == null ? delta : prev + delta;
+            timings.put(kind.name(), nue);
         }
     }
 


### PR DESCRIPTION
Backport of #659.