### PR TITLE
Call `GroovyClassLoader.close` when build completes

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1306,8 +1306,18 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
 
     void cleanUpHeap() {
         LOGGER.log(Level.FINE, "cleanUpHeap on {0}", owner);
-        shell = null;
-        trusted = null;
+        try {
+            if (shell != null) {
+                shell.getClassLoader().close();
+                shell = null;
+            }
+            if (trusted != null) {
+                trusted.getClassLoader().close();
+                trusted = null;
+            }
+        } catch (IOException x) {
+            LOGGER.log(Level.WARNING, "failed to close class loaders from " + owner, x);
+        }
         if (scriptClass != null) {
             try {
                 cleanUpLoader(scriptClass.getClassLoader(), new HashSet<>(), new HashSet<>());


### PR DESCRIPTION
When considering loading libraries from JAR files in https://github.com/jenkinsci/pipeline-groovy-lib-plugin/pull/55 it occurred to me that a completed build might leave classpath JAR files open at least until garbage collection, which could be a problem particularly on Windows. Might also affect Grape users. Safest to close these deterministically. Untested beyond the many functional tests in this plugin.