### PR TITLE
Better `CodeSource.location` for Groovy loaded from JARs

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShell.java
@@ -90,6 +90,11 @@ class CpsGroovyShell extends GroovyShell {
         @SuppressWarnings("rawtypes")
         @Deprecated
         @Override public Class parseClass(InputStream in, String fileName) throws CompilationFailedException {
+            try {
+                in.close();
+            } catch (IOException x) {
+                LOGGER.log(Level.WARNING, "failed to close input stream for " + fileName, x);
+            }
             LOGGER.finer(() -> "processing " + fileName);
             if (fileName.startsWith("jar:file:")) {
                 try {


### PR DESCRIPTION
Needs more comprehensive testing.