### PR TITLE
Flush overall Pipeline log stream when shutting down Jenkins

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -45,6 +45,7 @@
         <node.version>18.13.0</node.version>
         <npm.version>8.19.3</npm.version>
         <yarn.version>1.22.19</yarn.version>
+        <jenkins-test-harness.version>1926.v9b_323a_4da_421</jenkins-test-harness.version> <!-- Temporary, required to diagnose RJR issues due to https://github.com/jenkinsci/jenkins-test-harness/pull/544#issuecomment-1456707299 -->
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -45,7 +45,7 @@
         <node.version>18.13.0</node.version>
         <npm.version>8.19.3</npm.version>
         <yarn.version>1.22.19</yarn.version>
-        <jenkins-test-harness.version>1926.v9b_323a_4da_421</jenkins-test-harness.version> <!-- Temporary, required to diagnose RJR issues due to https://github.com/jenkinsci/jenkins-test-harness/pull/544#issuecomment-1456707299 -->
+        <jenkins.version>2.391</jenkins.version> <!-- TODO: Trying to diagnose errors with RealJenkinsRule in tests -->
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -45,7 +45,6 @@
         <node.version>18.13.0</node.version>
         <npm.version>8.19.3</npm.version>
         <yarn.version>1.22.19</yarn.version>
-        <jenkins.version>2.391</jenkins.version> <!-- TODO: Trying to diagnose errors with RealJenkinsRule in tests -->
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1694,6 +1694,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                                 LOGGER.log(Level.WARNING, null, t);
                             }
                         });
+                        cpsExec.getOwner().getListener().getLogger().close();
                     }
                 } catch (Exception ex) {
                     LOGGER.log(Level.WARNING, "Error persisting Pipeline execution at shutdown: "+((CpsFlowExecution) execution).owner, ex);

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinitionRJRTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinitionRJRTest.java
@@ -1,8 +1,10 @@
 package org.jenkinsci.plugins.workflow.cps;
 
+import hudson.Functions;
 import java.util.logging.Level;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -26,6 +28,7 @@ public class CpsFlowDefinitionRJRTest {
 
     @Test
     public void flushLogsOnShutdown() throws Throwable {
+        Assume.assumeFalse("RealJenkinsRule does not shut down Jenkins cleanly on Windows, see https://github.com/jenkinsci/jenkins-test-harness/pull/559", Functions.isWindows());
         rjr.withLogger(CpsFlowExecution.class, Level.FINER);
         rjr.then(CpsFlowDefinitionRJRTest::flushLogsOnShutdownPreRestart);
         rjr.then(CpsFlowDefinitionRJRTest::flushLogsOnShutdownPostRestart);

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinitionRJRTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinitionRJRTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow.cps;
 
+import java.util.logging.Level;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
@@ -25,6 +26,7 @@ public class CpsFlowDefinitionRJRTest {
 
     @Test
     public void flushLogsOnShutdown() throws Throwable {
+        rjr.withLogger(CpsFlowExecution.class, Level.FINER);
         rjr.then(CpsFlowDefinitionRJRTest::flushLogsOnShutdownPreRestart);
         rjr.then(CpsFlowDefinitionRJRTest::flushLogsOnShutdownPostRestart);
     }


### PR DESCRIPTION
Right now, when Jenkins shuts down gracefully, we attempt to pause Pipeline execution and save all related state information. However, we do not flush the listener for the overall log, which means that for `LogStorage` implementations like `FileLogStorage` that write the log and log metadata to separate files, and write metadata synchronously while buffering log writes, the metadata and log file may be out of sync after a Jenkins restart.

In particular, when performing a safe restart, we write ["Pausing (Preparing for shutdown)"](https://github.com/jenkinsci/workflow-cps-plugin/blob/43ba38b62bb731c7dffccbc6e975732719f708a2/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java#L308) to the build log and pause the Pipeline. For `FileLogStorage`, if the last log line was written by a step, then we will immediately write the current offset in the log to the metadata file and then flush the metadata file. We will also write the pause message to the log file, but that write will be buffered, and may be lost. On restart, subsequent writes will begin at the log offset that we expected to start with "Pausing (Preparing for shutdown)". For `FileLogStorage`, this is fine, because the first lines after the restart are guaranteed to come from the overall log, but for more complex implementations of `LogStorage` that store additional metadata (e.g. line lengths), this desynchronization can cause problems.

TODO:
* [x] Can this be reproduced in a test?
    * I am not entirely sure why, but so far I have been unable to reproduce the issue in a test (e.g. `JenkinsSessionRule` + `doQuietDown`). I can only reproduce the issue while restarting an actual Jenkins instance using `/safeRestart`.
    * It can be reproduced using `RealJenkinsRule`, so I added a new test
 
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
