### PR TITLE
Fix generated gdsl code display names

### DIFF
--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/gdsl.groovy
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/gdsl.groovy
@@ -57,7 +57,7 @@ steps.each { StepDescriptor step, DescribableModel model ->
 
     boolean requiresNode = step.requiredContext.contains(FilePath)
     boolean takesClosure = step.takesImplicitBlockArgument()
-    def sanitizedDisplayName = StringEscapeUtils.escapeJavaScript(step.displayName)
+    def sanitizedDisplayName = StringEscapeUtils.escapeJava(step.displayName)
     String description = sanitizedDisplayName
     if (step.isAdvanced()) {
         description = "Advanced/Deprecated " + description
@@ -70,7 +70,7 @@ steps.each { StepDescriptor step, DescribableModel model ->
         if (takesClosure) {
             fixedParams = params + ['body': "'Closure'"]
         }
-        String contr = "method(name: '${step.functionName}', type: 'Object', params: ${fixedParams}, doc: '${description}')"
+        String contr = "method(name: '${step.functionName}', type: 'Object', params: ${fixedParams}, doc: '''${description}''')"
         if (requiresNode) {
             nodeContext.add(contr)
         } else {
@@ -91,9 +91,9 @@ steps.each { StepDescriptor step, DescribableModel model ->
         }
         String contr
         if (takesClosure) {
-            contr = "method(name: '${step.functionName}', type: 'Object', params: [body:Closure], namedParams: [${namedParamsS.toString()}], doc: '${sanitizedDisplayName}')"
+            contr = "method(name: '${step.functionName}', type: 'Object', params: [body:Closure], namedParams: [${namedParamsS.toString()}], doc: '''${sanitizedDisplayName}''')"
         } else {
-            contr = "method(name: '${step.functionName}', type: 'Object', namedParams: [${namedParamsS.toString()}], doc: '${sanitizedDisplayName}')"
+            contr = "method(name: '${step.functionName}', type: 'Object', namedParams: [${namedParamsS.toString()}], doc: '''${sanitizedDisplayName}''')"
         }
         if (requiresNode) {
             nodeContext.add(contr)

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/gdsl.groovy
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/gdsl.groovy
@@ -57,7 +57,7 @@ steps.each { StepDescriptor step, DescribableModel model ->
 
     boolean requiresNode = step.requiredContext.contains(FilePath)
     boolean takesClosure = step.takesImplicitBlockArgument()
-    def sanitizedDisplayName = StringEscapeUtils.escapeJava(step.displayName)
+    def sanitizedDisplayName = StringEscapeUtils.escapeJava(step.displayName).replace('\'', '\\\'')
     String description = sanitizedDisplayName
     if (step.isAdvanced()) {
         description = "Advanced/Deprecated " + description
@@ -70,7 +70,7 @@ steps.each { StepDescriptor step, DescribableModel model ->
         if (takesClosure) {
             fixedParams = params + ['body': "'Closure'"]
         }
-        String contr = "method(name: '${step.functionName}', type: 'Object', params: ${fixedParams}, doc: '''${description}''')"
+        String contr = "method(name: '${step.functionName}', type: 'Object', params: ${fixedParams}, doc: '${description}')"
         if (requiresNode) {
             nodeContext.add(contr)
         } else {
@@ -91,9 +91,9 @@ steps.each { StepDescriptor step, DescribableModel model ->
         }
         String contr
         if (takesClosure) {
-            contr = "method(name: '${step.functionName}', type: 'Object', params: [body:Closure], namedParams: [${namedParamsS.toString()}], doc: '''${sanitizedDisplayName}''')"
+            contr = "method(name: '${step.functionName}', type: 'Object', params: [body:Closure], namedParams: [${namedParamsS.toString()}], doc: '${sanitizedDisplayName}')"
         } else {
-            contr = "method(name: '${step.functionName}', type: 'Object', namedParams: [${namedParamsS.toString()}], doc: '''${sanitizedDisplayName}''')"
+            contr = "method(name: '${step.functionName}', type: 'Object', namedParams: [${namedParamsS.toString()}], doc: '${sanitizedDisplayName}')"
         }
         if (requiresNode) {
             nodeContext.add(contr)


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Calling https://localhost/pipeline-syntax/gdsl creates a document that escapes forward slashes. 

The use of `groovy.json.StringEscapeUtils.escapeJavaScript(java.lang.String)`, will break parsing of the resulting content within an IDE (i.e. IntelliJ Idea), if described plugin steps have a forward slash in their `displayName` content.

plugin samples: 
- step `envVarsForTool` of plugin "pipeline-model-definition" (contains single quote) [Link](https://www.jenkins.io/doc/pipeline/steps/pipeline-model-definition/)
- step `sshGet`, `sshPut` of plugin "ssh-steps" (contain forward slash) [Link](https://www.jenkins.io/doc/pipeline/steps/ssh-steps/)

According to Groovy API doc of [escapeJavaScript](https://docs.groovy-lang.org/latest/html/api/groovy/json/StringEscapeUtils.html#escapeJavaScript(java.lang.String)) : 

> The only difference between Java strings and JavaScript strings is that in JavaScript, a single quote must be escaped. 

which is not 100% true to their code, as it also escapes forward slashes, which in turn breaks the parsing. 

So to have the `displayName` properly escaped, it is sufficient to switch to `escapeJava(String)` and also escape single quotes afterwards. 

(Using `escapeJavaStyleString(<String>, true, false)` whould also be sufficient, but that [worker function](https://github.com/groovy/groovy-core/blob/01309f9d4be34ddf93c4a9943b5a97843bff6181/subprojects/groovy-json/src/main/java/groovy/json/StringEscapeUtils.java#L151) is marked `private` in `groovy.json.StringEscapeUtils`)

[JENKINS-70755](https://issues.jenkins.io/browse/JENKINS-70755)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
