### PR TITLE
[JENKINS-70808] Third attempt at lockless `Timing.close` (backport)

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -46,7 +46,9 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import java.io.File;
 import jenkins.model.Jenkins;
+import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
@@ -361,13 +363,14 @@ public class CpsFlowExecutionTest {
         sessions.then(r -> {
                 WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
                 WorkflowRun b = p.getLastBuild();
+                FileUtils.copyFile(new File(b.getRootDir(), "build.xml"), System.out);
                 SemaphoreStep.success("wait/1", null);
                 r.assertBuildStatusSuccess(r.waitForCompletion(b));
                 while (logger.getRecords().isEmpty()) {
                     Thread.sleep(100); // apparently a race condition between CpsVmExecutorService.tearDown and WorkflowRun.finish
                 }
                 assertThat(logger.getRecords(), Matchers.hasSize(Matchers.equalTo(1)));
-                assertEquals(CpsFlowExecution.TimingKind.values().length, ((CpsFlowExecution) b.getExecution()).timings.keySet().size());
+                assertEquals(CpsFlowExecution.TimingKind.values().length, ((CpsFlowExecution) b.getExecution()).liveTimings.keySet().size());
         });
     }
 


### PR DESCRIPTION
Backport of #679, superseding #660.