### PR TITLE
Support PCT for multi-module Maven projects

### DIFF
--- a/dgm-builder/pom.xml
+++ b/dgm-builder/pom.xml
@@ -21,10 +21,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -74,19 +70,4 @@
             <version>${groovy.version}</version>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>skip-installation</id>
-            <activation>
-                <property>
-                    <name>set.changelist</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <properties>
-                <maven.install.skip>true</maven.install.skip>
-            </properties>
-        </profile>
-    </profiles>
 </project>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -29,8 +29,21 @@
             <executions>
                 <execution>
                     <goals>
-                        <goal>properties</goal>
+                        <goal>copy</goal>
                     </goals>
+                    <phase>generate-sources</phase>
+                    <configuration>
+                        <artifactItems>
+                            <artifactItem>
+                                <groupId>com.cloudbees</groupId>
+                                <artifactId>groovy-cps-dgm-builder</artifactId>
+                                <version>${project.version}</version>
+                                <classifier>jar-with-dependencies</classifier>
+                            </artifactItem>
+                        </artifactItems>
+                        <outputDirectory>${project.build.directory}</outputDirectory>
+                        <overWriteIfNewer>true</overWriteIfNewer>
+                    </configuration>
                 </execution>
             </executions>
         </plugin>
@@ -49,7 +62,7 @@
                         <executable>java</executable>
                         <arguments>
                             <argument>-jar</argument>
-                            <argument>${com.cloudbees:groovy-cps-dgm-builder:jar:jar-with-dependencies}</argument>
+                            <argument>${project.build.directory}/groovy-cps-dgm-builder-${project.version}-jar-with-dependencies.jar</argument>
                             <argument>${project.build.directory}/generated-sources/dgm</argument>
                         </arguments>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.56</version>
+        <version>4.57</version>
         <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
For the forthcoming support for multi-module Maven projects in PCT, we are planning on running at the root of each Maven multi-module project:

```
$ mvn […] clean process-test-classes  # compile test classes against original production classes
$ mvn -Djenkins.version=${LATEST_WEEKLY} -DoverrideWar=${MEGAWAR} […] hpi:resolve-test-dependencies hpi:test-hpl surefire:test  # run tests against new versions
```

The idea is to use the original production classes for the compatibility test, compiling the test classes against them for the most realistic compatibility test. This is how PCT already works today for flat Maven projects, so we are extending this to multi-module Maven projects. When run in the root of `workflow-cps`, this fails in `lib/` because compiling the test classes depends on having the main sources available, and that in turn fails with:

```
[INFO] --- exec:3.1.0:exec (default) @ groovy-cps ---
Error: Invalid or corrupt jarfile /home/basil/src/jenkinsci/workflow-cps-plugin/dgm-builder/target/classes
[ERROR] Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
    at org.apache.commons.exec.DefaultExecutor.executeInternal (DefaultExecutor.java:404)
    at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:166)
    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:1000)
    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:947)
    at org.codehaus.mojo.exec.ExecMojo.execute (ExecMojo.java:471)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:342)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:330)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:213)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:175)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:76)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:163)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:160)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:260)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:172)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:100)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:821)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:270)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
```

This is because the implementation of `lib/pom.xml` fishes out the `groovy-cps-dgm-builder` JAR from the previous module's build directory rather than fetching the dependency through Maven. So the main sources cannot be generated and therefore the tests cannot be compiled.

This PR solves the problem by fetching the dependency with `maven-dependency-plugin`. To test this PR I ran:

```
$ mvn clean install -Pquick-build (to simulate a deployment)
$ git clean -fxd
$ mvn clean process-test-classes  # failed before, passes now
$ mvn -Djth.jenkins-war.path=/home/basil/src/jenkinsci/bom/target/local-test/megawar.war -DoverrideWarAdditions=true -DoverrideWar=/home/basil/src/jenkinsci/bom/target/local-test/megawar.war -Djenkins.version=2.396 -DuseUpperBounds=true hpi:resolve-test-dependencies hpi:test-hpl surefire:test  # passes
```

The deployment of the new component requires https://github.com/jenkins-infra/repository-permissions-updater/pull/3210.

CC @dwnusbaum 