### PR TITLE
Support PCT for multi-module Maven projects (II)

### DIFF
--- a/dgm-builder/pom.xml
+++ b/dgm-builder/pom.xml
@@ -21,6 +21,11 @@
         </license>
     </licenses>
 
+    <properties>
+        <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -28,7 +33,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/dgm-builder/pom.xml
+++ b/dgm-builder/pom.xml
@@ -21,10 +21,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -74,19 +70,4 @@
             <version>${groovy.version}</version>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>skip-installation</id>
-            <activation>
-                <property>
-                    <name>set.changelist</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <properties>
-                <maven.install.skip>true</maven.install.skip>
-            </properties>
-        </profile>
-    </profiles>
 </project>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -78,14 +78,6 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.cloudbees</groupId>
-      <artifactId>groovy-cps-dgm-builder</artifactId>
-      <version>${changelist}</version>
-      <classifier>jar-with-dependencies</classifier>
-      <scope>runtime</scope> <!-- somehow provide to dependency:properties without actually adding to CP -->
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <optional>true</optional>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -29,8 +29,21 @@
             <executions>
                 <execution>
                     <goals>
-                        <goal>properties</goal>
+                        <goal>copy</goal>
                     </goals>
+                    <phase>generate-sources</phase>
+                    <configuration>
+                        <artifactItems>
+                            <artifactItem>
+                                <groupId>com.cloudbees</groupId>
+                                <artifactId>groovy-cps-dgm-builder</artifactId>
+                                <version>${project.version}</version>
+                                <classifier>jar-with-dependencies</classifier>
+                            </artifactItem>
+                        </artifactItems>
+                        <outputDirectory>${project.build.directory}</outputDirectory>
+                        <overWriteIfNewer>true</overWriteIfNewer>
+                    </configuration>
                 </execution>
             </executions>
         </plugin>
@@ -49,7 +62,7 @@
                         <executable>java</executable>
                         <arguments>
                             <argument>-jar</argument>
-                            <argument>${com.cloudbees:groovy-cps-dgm-builder:jar:jar-with-dependencies}</argument>
+                            <argument>${project.build.directory}/groovy-cps-dgm-builder-${project.version}-jar-with-dependencies.jar</argument>
                             <argument>${project.build.directory}/generated-sources/dgm</argument>
                         </arguments>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.56</version>
+        <version>4.57</version>
         <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Subsumes #685 but should allow https://github.com/jenkins-infra/repository-permissions-updater/pull/3210 to be reverted, cleaning up technical debt from #612. Local testing seems fine using both a clean working copy and a clean local repo:

```bash
mvn clean test -Dtest=CpsDefaultGroovyMethodsTest
```