### PR TITLE
Restore deployment of `dgm-builder`

### DIFF
--- a/dgm-builder/pom.xml
+++ b/dgm-builder/pom.xml
@@ -21,11 +21,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <maven.install.skip>true</maven.install.skip>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -33,7 +28,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -78,6 +78,14 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.cloudbees</groupId>
+      <artifactId>groovy-cps-dgm-builder</artifactId>
+      <version>${changelist}</version>
+      <classifier>jar-with-dependencies</classifier>
+      <scope>runtime</scope> <!-- somehow provide to dependency:properties without actually adding to CP -->
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <optional>true</optional>


### PR DESCRIPTION
Reverting #689 beyond #685. Issue reproducible outside PCT as

```bash
mvn -Pquick-build package -am -pl plugin
```

since 7fc22238d80bd17031c0df7b4b94ec399bac1f20 makes Maven think this need not be built. I think there is a way to build & deploy `dgm-builder` normally without needing an überjar (the plain JAR is tiny), but it would take some more time to prepare those changes and it would be easier to experiment with that once the dust has settled on PCT.

Likely needs https://github.com/jenkins-infra/repository-permissions-updater/pull/3219 to build.
