### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/plugin/src/main/js/samples.js
+++ b/plugin/src/main/js/samples.js
@@ -12,13 +12,17 @@ export function addSamplesWidget(editor, editorId, samplesUrl) {
     var sampleSelect = $('<select></select>');
 
     sampleSelect.append('<option >try sample Pipeline...</option>');
-    // eslint-disable-next-line no-undef
-    new Ajax.Request(samplesUrl, {
-        onSuccess : function(data) {
-            samples = data.responseJSON.samples;
-            for (var i = 0; i < samples.length; i++) {
-                sampleSelect.append('<option value="' + samples[i].name + '">' + samples[i].title + '</option>');
-            }
+    fetch(samplesUrl, {
+        method: "post",
+        headers: crumb.wrap({}),
+    }).then((rsp) => {
+        if (rsp.ok) {
+            rsp.json().then((json) => {
+                samples = json.samples;
+                for (var i = 0; i < samples.length; i++) {
+                    sampleSelect.append('<option value="' + samples[i].name + '">' + samples[i].title + '</option>');
+                }
+            });
         }
     });
 

--- a/plugin/src/main/js/workflow-editor.js
+++ b/plugin/src/main/js/workflow-editor.js
@@ -70,31 +70,35 @@ $(function() {
                         var url = textarea.attr("checkUrl") + 'Compile';
 
 
-                        // eslint-disable-next-line no-undef
-                        new Ajax.Request(url, { // jshint ignore:line
+                        fetch(url, {
                             method: textarea.attr('checkMethod') || 'POST',
-                            parameters: {
-                                value: editor.getValue()
-                            },
-                            onSuccess : function(data) {
-                                var json = data.responseJSON;
-                                var annotations = [];
-                                if (json.status && json.status === 'success') {
-                                    // Fire script approval check - only if the script is syntactically correct
-                                    textarea.trigger('change');
-                                    return;
-                                } else {
-                                    // Syntax errors
-                                    $.each(json, function(i, value) {
-                                        annotations.push({
-                                            row: value.line - 1,
-                                            column: value.column,
-                                            text: value.message,
-                                            type: 'error'
+                            headers: crumb.wrap({
+                                "Content-Type": "application/x-www-form-urlencoded",
+                            }),
+                            body: new URLSearchParams({
+                                value: editor.getValue(),
+                            }),
+                        }).then((rsp) => {
+                            if (rsp.ok) {
+                                rsp.json().then((json) => {
+                                    var annotations = [];
+                                    if (json.status && json.status === 'success') {
+                                        // Fire script approval check - only if the script is syntactically correct
+                                        textarea.trigger('change');
+                                        return;
+                                    } else {
+                                        // Syntax errors
+                                        $.each(json, function(i, value) {
+                                            annotations.push({
+                                                row: value.line - 1,
+                                                column: value.column,
+                                                text: value.message,
+                                                type: 'error'
+                                            });
                                         });
-                                    });
-                                }
-                                editor.getSession().setAnnotations(annotations);
+                                    }
+                                    editor.getSession().setAnnotations(annotations);
+                                });
                             }
                         });
                     });

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -75,15 +75,24 @@ THE SOFTWARE.
                         function handlePrototype_${id}() {
                             buildFormTree(document.forms.config);
                             // TODO JSON.stringify fails in some circumstances: https://gist.github.com/jglick/70ec4b15c1f628fdf2e9 due to Array.prototype.toJSON
-                            var json = Object.toJSON(JSON.parse(document.forms.config.elements.json.value).prototype);
+                            // TODO simplify when Prototype.js is removed
+                            var json = Object.toJSON ? Object.toJSON(JSON.parse(document.forms.config.elements.json.value).prototype) : JSON.stringify(JSON.parse(document.forms.config.elements.json.value).prototype);
                             if (!json) {
                                 return; // just a separator
                             }
-                            new Ajax.Request('${rootURL}/${it.GENERATE_URL}', {
-                                method: 'POST',
-                                parameters: {json: json},
-                                onSuccess: function(r) {
-                                    document.getElementById('prototypeText_${id}').value = r.responseText;
+                            fetch('${rootURL}/${it.GENERATE_URL}', {
+                                method: 'post',
+                                headers: crumb.wrap({
+                                    "Content-Type": "application/x-www-form-urlencoded",
+                                }),
+                                body: new URLSearchParams({
+                                    json: json,
+                                }),
+                            }).then((rsp) => {
+                                if (rsp.ok) {
+                                    rsp.text().then((responseText) => {
+                                        document.getElementById('prototypeText_${id}').value = responseText;
+                                    });
                                 }
                             });
                         }


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I installed this plugin on a custom build of Jenkins that had Prototype ripped out (a local project branch), went to the Pipeline Editor, verified that correct syntax and syntax errors were correctly flagged, tried out each sample, and generated several snippets on the snippets page.