### PR TITLE
Add `CpsFlowExecution.approximateNodeCount` to `PipelineTimings`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -2065,6 +2065,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                                         Map<String, LongAdder> sortedTimings = new TreeMap<>(((CpsFlowExecution) exec).liveTimings);
                                         pw.println("Timings for " + run + ":");
                                         sortedTimings.forEach((k, v) -> pw.println("  " + k + "\t" + v.longValue() / 1000 / 1000 + "ms"));
+                                        pw.println("Approximate graph size: " + ((CpsFlowExecution) exec).approximateNodeCount());
                                         pw.println();
                                     }
                                 }


### PR DESCRIPTION
Already in `PipelineThreadDump` for running builds, but seems also useful to know for completed builds, especially when you are wondering if there is a reason why some pathologically large timings are being displayed.