### PR TITLE
Flake in `PersistenceProblemsTest.inProgressButFlowNodesLost`

### DIFF
--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -15,6 +15,7 @@ import org.jenkinsci.plugins.workflow.job.properties.DurabilityHintJobProperty;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
 import org.junit.Assert;
+import org.junit.AssumptionViolatedException;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,6 +24,7 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -293,7 +295,11 @@ public class PersistenceProblemsTest {
         story.thenWithHardShutdown( j -> {
             WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build);
             CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
-            FileUtils.deleteDirectory(((CpsFlowExecution)(run.getExecution())).getStorageDir());
+            try {
+                FileUtils.deleteDirectory(((CpsFlowExecution)(run.getExecution())).getStorageDir());
+            } catch (IOException x) {
+                throw new AssumptionViolatedException("Failed to delete storage directory (race condition?)", x);
+            }
         });
         story.then( j->{
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);


### PR DESCRIPTION
Seen recently in PCT:

```
org.apache.commons.io.IOExceptionList: …/plugin/target/tmp/j h9111237813030279202/jobs/testJob/builds/1/workflow
	at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:331)
	at org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.java:1192)
	at org.jenkinsci.plugins.workflow.cps.PersistenceProblemsTest.lambda$inProgressButFlowNodesLost$16(PersistenceProblemsTest.java:296)
	at …
Caused by: java.io.FileNotFoundException: File does not exist: …/plugin/target/tmp/j h9111237813030279202/jobs/testJob/builds/1/workflow/atomic5190200290324607044tmp
	at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:1349)
	at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:324)
	... 9 more
```

Seems like some sort of background process is running which interferes with the test’s attempt to delete part of the build directory. Cannot reproduce locally, so just treating this as a flake.
