### PR TITLE
Restore missing `<scope>test</scope>` to `git`

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -203,6 +203,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
+            <scope>test</scope>
             <!-- TODO: Remove version declaration when git plugin 5.1.0 or newer is in plugin BOM -->
             <version>5.1.0</version>
         </dependency>


### PR DESCRIPTION
Regression in #723.