### PR TITLE
Adapt 'one-column' design in thread dump

### DIFF
--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction/index.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction/index.jelly
@@ -25,12 +25,7 @@
   -->
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:i="jelly:fmt">
-  <l:layout title="${%Thread Dump}">
-    <l:side-panel>
-      <l:tasks>
-        <l:task icon="icon-up icon-md" href="${rootURL}/${it.parentUrl}" title="${%Up}" contextMenu="false"/>
-      </l:tasks>
-    </l:side-panel>
+  <l:layout title="${%Thread Dump}" type="one-column">
     <l:main-panel>
       <j:set var="td" value="${it.threadDump}"/>
 


### PR DESCRIPTION
The change proposed adapts core changes, such as https://github.com/jenkinsci/jenkins/pull/7634, moving to the `one-column` layout, you can find already in various core pages.

Before:
![Screenshot 2023-07-10 at 23 33 51](https://github.com/jenkinsci/workflow-cps-plugin/assets/13383509/3d4e68b1-eb60-4175-89af-108d8ca4283e)

After:
![Screenshot 2023-07-10 at 23 36 37](https://github.com/jenkinsci/workflow-cps-plugin/assets/13383509/6b6a5619-1182-4c9c-9106-fc1e5c708d04)