### PR TITLE
Remove usages of Prototype from Steps Reference

### DIFF
--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/workflow.js
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/workflow.js
@@ -1,23 +1,23 @@
 var refDslHlp = {	
   parseDom:function(){
-    $$('dl.root > dt').each(function(elem){
-      elem.observe('click',refDslHlp.minimizeClick); 
+    document.querySelectorAll('dl.root > dt').forEach(function(elem){
+      elem.addEventListener('click',refDslHlp.minimizeClick); 
     });
   },
   
   minimizeClick:function(){
     var elem = this;
-    var nextElem = elem.next();
-    var height = nextElem.getHeight();
-    if(elem.hasClassName('show-minimize')){
-      elem.removeClassName('show-minimize');
-      nextElem.removeClassName('minimize');
+    var nextElem = elem.nextElementSibling;
+    var height = nextElem.offsetHeight;
+    if(elem.classList.contains('show-minimize')){
+      elem.classList.remove('show-minimize');
+      nextElem.classList.remove('minimize');
     }
     else{
-      nextElem.setStyle({height:height+'px'});
+      nextElem.style.height = height+'px';
       setTimeout(function(){
-        elem.addClassName('show-minimize');
-        nextElem.addClassName('minimize');
+        elem.classList.add('show-minimize');
+        nextElem.classList.add('minimize');
       },10);
     }    
   }


### PR DESCRIPTION
Forgotten in #702. Attempting to view the Steps Reference in the UI with Prototype disabled results in

```
Uncaught ReferenceError: $$ is not defined
    parseDom http://127.0.0.1/adjuncts/0ce4ef4c/org/jenkinsci/plugins/workflow/cps/Snippetizer/workflow.js:3
    <anonymous> http://127.0.0.1/adjuncts/0ce4ef4c/org/jenkinsci/plugins/workflow/cps/Snippetizer/workflow.js:26
```

Fixed by converting this file to native JavaScript. I also verified there were no other usages of Prototype that I missed. To test this, I reproduced the problem in the Steps Reference view and verified that it could no longer be reproduced after this PR by expanding and contracting steps in the UI.