### PR TITLE
`…/threadDump/program.xml` hangs when program still loading pickles

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDump.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDump.java
@@ -24,6 +24,10 @@ import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
  */
 public final class CpsThreadDump {
 
+    /**
+     * Whether this is an actual list of threads, or just some special text such as a list of pickles.
+     */
+    public final boolean valid;
     private final List<ThreadInfo> threads = new ArrayList<>();
 
     public static final class ThreadInfo {
@@ -103,7 +107,8 @@ public final class CpsThreadDump {
     /**
      * Use one of the {@link #from(CpsThreadGroup)} method.
      */
-    private CpsThreadDump() {
+    private CpsThreadDump(boolean valid) {
+        this.valid = valid;
     }
 
     public List<ThreadInfo> getThreads() {
@@ -128,7 +133,7 @@ public final class CpsThreadDump {
     }
 
     public static CpsThreadDump from(Throwable t) {
-        CpsThreadDump td = new CpsThreadDump();
+        CpsThreadDump td = new CpsThreadDump(false);
         td.threads.add(new ThreadInfo(t));
         return td;}
 
@@ -140,7 +145,7 @@ public final class CpsThreadDump {
             l.add(t);
         }
 
-        CpsThreadDump td = new CpsThreadDump();
+        CpsThreadDump td = new CpsThreadDump(true);
         for (List<CpsThread> e : m.values())
             td.threads.add(new ThreadInfo(e));
         return td;
@@ -165,7 +170,7 @@ public final class CpsThreadDump {
     /**
      * Constant that indicates everything is done and no thread is alive.
      */
-    public static final CpsThreadDump EMPTY = new CpsThreadDump();
+    public static final CpsThreadDump EMPTY = new CpsThreadDump(false);
 
     @Deprecated
     public static final CpsThreadDump UNKNOWN = fromText("Program state is not yet known");

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
@@ -60,8 +60,8 @@ public final class CpsThreadDumpAction implements Action {
         return execution.getThreadDump();
     }
 
-    public String getThreadDump() {
-        return execution.getThreadDump().toString();
+    public CpsThreadDump getThreadDump() {
+        return execution.getThreadDump();
     }
 
     @WebMethod(name = "program.xml") public void doProgramDotXml(StaplerRequest req, StaplerResponse rsp) throws Exception {

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction/index.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction/index.jelly
@@ -28,19 +28,22 @@
   <l:layout title="${%Thread Dump}" type="one-column">
     <l:main-panel>
       <j:set var="td" value="${it.threadDump}"/>
+      <j:set var="tds" value="${td.toString()}"/>
 
       <h1>
         ${%Thread Dump}
-        <l:copyButton text="${td}" message="${%Thread dump copied to clipboard}"/>
+        <l:copyButton text="${tds}" message="${%Thread dump copied to clipboard}"/>
       </h1>
 
       <pre class="console">
-        ${td}
+        ${tds}
       </pre>
 
-      <l:hasPermission permission="${app.RUN_SCRIPTS}">
-        <a href="program.xml">Serialized program state</a>
-      </l:hasPermission>
+      <j:if test="${td.valid}">
+        <l:hasPermission permission="${app.RUN_SCRIPTS}">
+          <a href="program.xml">Serialized program state</a>
+        </l:hasPermission>
+      </j:if>
     </l:main-panel>
   </l:layout>
 </j:jelly>


### PR DESCRIPTION
I tried to click on the `program.xml` link for a thread dump from a build which was still stuck loading pickles, hoping to get information about those pickles, but the web request simply timed out:

```
"Handling GET …/threadDump/program.xml from … TIMED_WAITING on java.util.concurrent.CompletableFuture$Signaller@88c1e6d
	at java.base@11.0.20/jdk.internal.misc.Unsafe.park(Native Method)
	-  waiting on java.util.concurrent.CompletableFuture$Signaller@88c1e6d
	at java.base@11.0.20/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:234)
	at java.base@11.0.20/java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1798)
	at java.base@11.0.20/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3128)
	at java.base@11.0.20/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1868)
	at java.base@11.0.20/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2021)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadDumpAction.doProgramDotXml(CpsThreadDumpAction.java:84)
```

In this case, `!programPromise.isDone()`, so there is no way `doProgramDotXml` could work, and there is no sense in offering it.

For debugging this case, I also tried scripting

```groovy
def x = Run.fromExternalizableId('…').execution;
def rr = new org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverReader(x.programDataFile, x.parseScript().getClass().classLoader, x.owner);
def is = rr.openStreamAt(0);
try {
  def din = new DataInputStream(is);
  def offset = rr.parseHeader(din);
  def pickles = rr.readPickles(offset);
  def config = new org.jboss.marshalling.MarshallingConfiguration();
  config.setClassResolver(new org.jboss.marshalling.SimpleClassResolver(rr.classLoader));
  config.setObjectResolver(rr.ownerResolver);
  def eu = new org.jboss.marshalling.river.RiverMarshallerFactory().createUnmarshaller(config);
  eu.start(org.jboss.marshalling.Marshalling.createByteInput(din));
  def u = new org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverReader.SandboxedUnmarshaller(eu);
  def g = u.readObject();
  println(g.asXml());
} finally {
  is.close();
}
```

but it does not work:

```
java.lang.ClassCastException: Cannot cast org.jenkinsci.plugins.workflow.support.pickles.serialization.DryCapsule to org.csanchez.jenkins.plugins.kubernetes.PodTemplate
```

Without actually resolving pickles, we cannot actually deserialize objects. Finally resorted to

```
org.apache.commons.text.StringEscapeUtils.escapeJava(x.programDataFile.getText('ISO-8859-1'))
```

and looking for class names that might contain relevant fields. I suppose it might have worked to create a variant of `PickleResolver` that only rehydrates those `Pickle`s which are immediately available (so like `SecretPickle`) but for any of those based on `TryRepeatedly` either return `null` or throw an exception which the unmarshaller might have noted with the class/field, but I did not venture that far.
