### PR TITLE
Assertion error from `CpsThread.getStackTrace`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -327,8 +327,11 @@ public final class CpsThread implements Serializable {
     }
 
     public List<StackTraceElement> getStackTrace() {
-        assert program != null; // Otherwise this CpsThread is not even part of the CpsThreadGroup, so how is it being accessed?
-        return program.getStackTrace();
+        Continuable p = program;
+        if (p == null) {
+            return List.of(new StackTraceElement("not", "running", null, -1));
+        }
+        return p.getStackTrace();
     }
 
     private static final Logger LOGGER = Logger.getLogger(CpsThread.class.getName());


### PR DESCRIPTION
Have seen a test flake in PCT:

```
java.lang.AssertionError
	at org.jenkinsci.plugins.workflow.cps.CpsThread.getStackTrace(CpsThread.java:330)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadDump$ThreadInfo.<init>(CpsThreadDump.java:68)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadDump.from(CpsThreadDump.java:150)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.getThreadDump(CpsThreadGroup.java:515)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.getThreadDump(CpsFlowExecution.java:1090)
	at org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecutionTest.getStatus(GeneralNonBlockingStepExecutionTest.java:79)
```

https://github.com/jenkinsci/workflow-step-api-plugin/blob/6ecacd8c04aa1326eab48553730541b0abc9c1f9/src/test/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecutionTest.java#L69 looks inherently flaky, but anyway #368 seems to have introduced an unnecessary assertion error: this is a diagnostic method so it should behave conservatively.
