### PR TITLE
`CpsFlowExecution.suspendAll` could log ISE

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1642,15 +1642,17 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                             }
                         }
                         cpsExec.checkpoint(true);
-                        cpsExec.runInCpsVmThread(new FutureCallback<>() {
-                            @Override public void onSuccess(CpsThreadGroup g) {
-                                LOGGER.fine(() -> "shutting down CPS VM threadin for " + cpsExec);
-                                g.shutdown();
-                            }
-                            @Override public void onFailure(Throwable t) {
-                                LOGGER.log(Level.WARNING, null, t);
-                            }
-                        });
+                        if (cpsExec.programPromise != null) {
+                            cpsExec.runInCpsVmThread(new FutureCallback<>() {
+                                @Override public void onSuccess(CpsThreadGroup g) {
+                                    LOGGER.fine(() -> "shutting down CPS VM threadin for " + cpsExec);
+                                    g.shutdown();
+                                }
+                                @Override public void onFailure(Throwable t) {
+                                    LOGGER.log(Level.WARNING, null, t);
+                                }
+                            });
+                        }
                         cpsExec.getOwner().getListener().getLogger().close();
                     }
                 } catch (Exception ex) {


### PR DESCRIPTION
Observed during shutdown:

```
WARNING	o.j.p.w.cps.CpsFlowExecution#suspendAll: Error persisting Pipeline execution at shutdown: null
java.lang.IllegalStateException: build storage unloadable, or build already finished
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.runInCpsVmThread(CpsFlowExecution.java:928)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.suspendAll(CpsFlowExecution.java:1719)
```

Not sure what the exact conditions were here, but if we know `programPromise == null` there is no point in even trying to call `CpsThreadGroup.shutdown`. Amending #540.
