### PR TITLE
[JENKINS-59743] Restarting before `afterStepExecutionsResumed` could leave a build paused

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -796,7 +796,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                                 CpsThreadGroup g = (CpsThreadGroup) u.readObject();
                                 result.set(g);
                                 pausedWhenLoaded = g.isPaused();
-                                g.pause();
+                                g.pause(false);
                             } catch (Throwable t) {
                                 onFailure(t);
                             } finally {
@@ -1596,7 +1596,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         Futures.addCallback(programPromise, new FutureCallback<>() {
             @Override public void onSuccess(CpsThreadGroup g) {
                 if (v) {
-                    g.pause();
+                    g.pause(true);
                     checkAndAbortNonresumableBuild();  // TODO Verify if we can rely on just killing paused builds at shutdown via checkAndAbortNonresumableBuild()
                     checkpoint(false);
                 } else {

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -366,7 +366,7 @@ public final class CpsThreadGroup implements Serializable {
      * @param persist whether this is a user-initiated pause that should be persisted
      * @return
      *      {@link Future} object that represents the actual suspension of the CPS VM.
-     *      When the {@link #pause()} method is called, CPS VM might be still executing.
+     *      When this method is called, the CPS VM might be still executing.
      */
     public Future<?> pause(boolean persist) {
         paused.set(true);

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -363,14 +363,16 @@ public final class CpsThreadGroup implements Serializable {
 
     /**
      * Pauses the execution.
-     *
+     * @param persist whether this is a user-initiated pause that should be persisted
      * @return
      *      {@link Future} object that represents the actual suspension of the CPS VM.
      *      When the {@link #pause()} method is called, CPS VM might be still executing.
      */
-    public Future<?> pause() {
+    public Future<?> pause(boolean persist) {
         paused.set(true);
-        executionPaused = true;
+        if (persist) {
+            executionPaused = true;
+        }
         // CPS VM might have a long queue in its task list, so to properly ensure
         // that the execution has actually suspended, call scheduleRun() excessively
         return scheduleRun();


### PR DESCRIPTION
[JENKINS-59743](https://issues.jenkins.io/browse/JENKINS-59743) (at least new report from @timja): mistake in #534 affecting controllers that were restarted more than once in quick succession, not unusual in Kubernetes for example.