### PR TITLE
Avoid `javax` imports in Groovy views

### DIFF
--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/globals.groovy
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/globals.groovy
@@ -4,8 +4,6 @@ package org.jenkinsci.plugins.workflow.cps.Snippetizer
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable
 import org.jenkinsci.plugins.workflow.cps.Snippetizer
 
-import javax.servlet.RequestDispatcher
-
 Snippetizer snippetizer = my;
 
 def l = namespace(lib.LayoutTagLib)
@@ -32,7 +30,7 @@ l.layout(title:_("Pipeline Syntax: Global Variable Reference"), norefresh: true)
                 }
               }
               dd{
-                RequestDispatcher rd = request.getView(v, "help");
+                def rd = request.getView(v, "help");
                 div(class:"help", style:"display: block") {
                   if (rd != null) {
                     st.include(page: "help", it: v)

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/html.groovy
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/html.groovy
@@ -14,8 +14,6 @@ import org.jenkinsci.plugins.workflow.cps.GlobalVariable
 import org.jenkinsci.plugins.workflow.cps.Snippetizer
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor
 
-import javax.servlet.RequestDispatcher
-
 // keeps track of recursion inside generateHelp
 stack = new Stack();
 


### PR DESCRIPTION
Forward compatibility, as these won't work when we switch from `javax` to `jakarta` imports anyway. One of these imports was unused, and the other was used for a variable for which we only checked nullness, so `def` suffices here.