### PR TITLE
[JENKINS-71818] `CpsTransformerTest` fails on Java 21

### DIFF
--- a/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformerTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformerTest.java
@@ -188,7 +188,8 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
             "}\n");
         assertThat(message, anyOf(
                 equalTo("String index out of range: -2"), // Before Java 14
-                equalTo("begin 5, end 3, length 3"))); // Later versions
+                equalTo("begin 5, end 3, length 3"), // Before Java 18
+                equalTo("Range [5, 3) out of bounds for length 3"))); // Later versions
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-71818](https://issues.jenkins.io/browse/JENKINS-71818). Forward compatibility with [JDK-8268698](https://bugs.openjdk.org/browse/JDK-8268698) / https://github.com/openjdk/jdk/pull/4507.

### Testing done

Ran `mvn clean verify` on Java 11, 17, and 21. Before this PR, it failed on Java 21. After this PR, it passes on all three Java versions.