### PR TITLE
Honoring termination milestones

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-api</artifactId>
-                <version>999999-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/301 -->
+                <version>1258.vfc6961b_b_02e1</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/301 -->
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-api</artifactId>
-                <version>1258.vfc6961b_b_02e1</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/301 -->
+                <version>1259.vb_47f14fffc8a_</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -55,6 +55,12 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!-- TODO until in BOM -->
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-api</artifactId>
+                <version>999999-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/301 -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1619,7 +1619,8 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     }
 
     @Restricted(DoNotUse.class)
-    @Terminator public static void suspendAll() {
+    @Terminator(attains = FlowExecutionList.EXECUTIONS_SUSPENDED)
+    public static void suspendAll() {
         CpsFlowExecution exec = null;
         try (Timeout t = Timeout.limit(3, TimeUnit.MINUTES)) { // TODO some complicated sequence of calls to Futures could allow all of them to run in parallel
             LOGGER.fine("starting to suspend all executions");
@@ -2162,12 +2163,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         } catch (IOException ioe) {
             LOGGER.log(Level.WARNING, "Error just doing logging", ioe);
         }
-    }
-
-    /** Ensures that even if we're limiting persistence of data for performance, we still write out data for shutdown. */
-    @Override
-    protected void notifyShutdown() {
-        // No-op, handled in the suspendAll terminator
     }
 
 }


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/workflow-api-plugin/pull/301. Should make shutdown processes more predictable, since I found that `Reactor` uses a `HashSet` of tasks and thus runs terminators in a truly random order (though serialized in one thread!) unless you explicitly order them.