### PR TITLE
NPE related to `internalCalls`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1776,6 +1776,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
 
                     result.startNodesSerial = new ArrayList<>();
                     result.headsSerial = new TreeMap<>();
+                    result.internalCalls = ConcurrentHashMap.newKeySet();
 
                     while (reader.hasMoreChildren()) {
                         reader.moveDown();
@@ -1795,7 +1796,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                             setField(result, "timings", timings);
                         } else if (nodeName.equals("internalCalls")) {
                             Set internalCalls = readChild(reader, context, Set.class, result);
-                            result.internalCalls = ConcurrentHashMap.newKeySet();
                             for (Object internalCall : internalCalls) {
                                 result.internalCalls.add((String) internalCall);
                             }


### PR DESCRIPTION
PCT caught a regression in #228 `BuildTriggerStepTest.storedForm`

```
java.lang.NullPointerException
	at java.base/java.util.TreeSet.addAll(TreeSet.java:300)
	at java.base/java.util.TreeSet.<init>(TreeSet.java:160)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$ConverterImpl.marshal(CpsFlowExecution.java:1718)
```

If loading a rather old `build.xml`, make sure to initialize `internalCalls` to an empty set.
