### PR TITLE
Switch from `RUN_SCRIPTS` to `ADMINISTER`

### DIFF
--- a/doc/classloader.md
+++ b/doc/classloader.md
@@ -23,7 +23,7 @@ which is not trusted.
 Scripts loaded in TCL, OTOH, does not live in the security sandbox. This
 classloader is meant to be used to load Groovy code packaged inside
 plugins and global libraries. Write access to these sources should be
-restricted to `RUN_SCRIPTS` permission.
+restricted to `ADMINISTER` permission.
 
 ## Persisting code & surviving restarts
 When a Groovy script is loaded via one of `GroovyShell.parse*()` and

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
@@ -65,7 +65,7 @@ public final class CpsThreadDumpAction implements Action {
     }
 
     @WebMethod(name = "program.xml") public void doProgramDotXml(StaplerRequest req, StaplerResponse rsp) throws Exception {
-        Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         CompletableFuture<String> f = new CompletableFuture<>();
         execution.runInCpsVmThread(new FutureCallback<>() {
             @Override public void onSuccess(CpsThreadGroup g) {

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
@@ -156,7 +156,7 @@ public class ReplayAction implements Action {
 
         CpsFlowExecution exec = getExecutionLazy();
         if (exec != null) {
-            return exec.isSandbox() || Jenkins.get().hasPermission(Jenkins.RUN_SCRIPTS); // We have to check for ADMIN because un-sandboxed code can execute arbitrary on-controller code
+            return exec.isSandbox() || Jenkins.get().hasPermission(Jenkins.ADMINISTER); // We have to check for ADMINISTER because un-sandboxed code can execute arbitrary on-controller code
         } else {
             // If the execution hasn't been lazy-loaded then we will wait to do deeper checks until someone tries to lazy load
             // OR until isReplayableSandboxTest is invoked b/c they actually try to replay the build
@@ -169,8 +169,8 @@ public class ReplayAction implements Action {
         CpsFlowExecution exec = getExecutionBlocking();
         if (exec != null) {
             if (!exec.isSandbox()) {
-                // We have to check for ADMIN because un-sandboxed code can execute arbitrary on-controller code
-                return Jenkins.get().hasPermission(Jenkins.RUN_SCRIPTS);
+                // We have to check for ADMINISTER because un-sandboxed code can execute arbitrary on-controller code
+                return Jenkins.get().hasPermission(Jenkins.ADMINISTER);
             }
             return true;
         }

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction/index.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction/index.jelly
@@ -40,7 +40,7 @@
       </pre>
 
       <j:if test="${td.valid}">
-        <l:hasPermission permission="${app.RUN_SCRIPTS}">
+        <l:hasPermission permission="${app.ADMINISTER}">
           <a href="program.xml">Serialized program state</a>
         </l:hasPermission>
       </j:if>

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
@@ -228,7 +228,7 @@ public class ReplayActionTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("", /* whole-script approval */ false));
                 WorkflowRun b1 = p.scheduleBuild2(0).get();
-                // Jenkins admins can of course do as they please. But developers without RUN_SCRIPTS are out of luck.
+                // Jenkins admins can of course do as they please. But developers without ADMINISTER are out of luck.
                 assertTrue(canReplay(b1, "admin"));
                 assertFalse("not sandboxed, so only safe for admins", canReplay(b1, "dev1"));
                 assertFalse(canReplay(b1, "dev2"));


### PR DESCRIPTION
A user reported not seeing the option for **Serialized program state** in a virtual thread dump. They are running `3713.vd671d4321509` (prior to #755). I suspect that they may have had `ADMINISTER` without `RUN_SCRIPTS`. Since this permission is deprecated, I think we just need to check the new permission.