### PR TITLE
[JENKINS-71692] Attempt to stop step executions if the CPS VM thread dies with a fatal error

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -350,7 +350,12 @@ class CpsBodyExecution extends BodyExecution {
             setOutcome(new Outcome(null,t));
             StepContext sc = new CpsBodySubContext(context, en);
             for (BodyExecutionCallback c : callbacks) {
-                c.onFailure(sc, t);
+                try {
+                    c.onFailure(sc, t);
+                } catch (Exception e) {
+                    t.addSuppressed(e);
+                    sc.onFailure(t);
+                }
             }
             return Next.terminate(null);
         }
@@ -366,7 +371,11 @@ class CpsBodyExecution extends BodyExecution {
             setOutcome(new Outcome(o,null));
             StepContext sc = new CpsBodySubContext(context, en);
             for (BodyExecutionCallback c : callbacks) {
-                c.onSuccess(sc, o);
+                try {
+                    c.onSuccess(sc, o);
+                } catch (Exception e) {
+                    sc.onFailure(e);
+                }
             }
             return Next.terminate(null);
         }

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorService.java
@@ -81,7 +81,7 @@ class CpsVmExecutorService extends InterceptingExecutorService {
             }
         }
         cpsThreadGroup.getExecution().croak(t);
-        // cpsThreadGroup.run() must not execute again. We shut it down after stopping steps and completing the build
+        // cpsThreadGroup.run() must not execute again. We shut this executor service down after stopping steps and completing the build rather than before
         // to avoid RejectedExecutionExceptions inside of StepExecution.stop above as the steps try to call
         // StepContext.onFailure which eventually submits a task to this executor service to trigger CpsThreadGroup.run.
         shutdown();


### PR DESCRIPTION
See [JENKINS-71692](https://issues.jenkins.io/browse/JENKINS-71692).

If there is a fatal error in the CPS VM thread, currently running steps should be given a chance to stop before we kill the build, otherwise async steps will just keep running in the background. Things can get very messy since the execution and run associated with the `StepExecution` will already be dead, and some steps like `node` and `stage` will just run forever if we do not stop them.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
