### PR TITLE
Use controller-wide default XStream driver where possible

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -42,6 +42,7 @@ import hudson.Functions;
 import hudson.Main;
 import hudson.Util;
 import hudson.model.Result;
+import hudson.util.XStream2;
 import jenkins.model.Jenkins;
 import jenkins.util.Timer;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
@@ -597,7 +598,7 @@ public final class CpsThreadGroup implements Serializable {
 
     @CpsVmThreadOnly
     String asXml() {
-        XStream xs = new XStream();
+        XStream xs = new XStream(XStream2.getDefaultDriver());
         // Could not handle a general PickleFactory without doing something weird with XStream
         // and there is no apparent way to make a high-priority generic Convertor delegate to others.
         // Anyway the only known exceptions are ThrowablePickle, which we are unlikely to need,


### PR DESCRIPTION
I noticed that in this code path we use the upstream XStream default driver rather than the controller-wide default driver defined by `hudson.util.XStream2#getDefaultDriver()`. The latter is commonly used throughout Jenkins, so it seems desirable to increase consistency by using it in this code path as well. Note that `new XStream2()` cannot be used here, because of JEP-200 violations.