### PR TITLE
Added `@Deprecated` where `@deprecated` already in Javadoc

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowFactoryAction.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowFactoryAction.java
@@ -33,6 +33,7 @@ import java.util.List;
 /**
  * @deprecated Use {@link CpsFlowFactoryAction2} instead.
  */
+@Deprecated
 public interface CpsFlowFactoryAction extends Action {
     CpsFlowExecution create(CpsFlowDefinition def, FlowExecutionOwner owner, List<? extends Action> actions) throws IOException;
 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -223,6 +223,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
      * When {@link #invokeMethod(String, Object)} is calling a {@link StepDescriptor}
      * @deprecated Prefer {@link #invokeStep(StepDescriptor, String, Object)}
      */
+    @Deprecated
     protected Object invokeStep(StepDescriptor d, Object args) {
         return invokeStep(d, d.getFunctionName(), args);
     }
@@ -798,6 +799,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
          * @deprecated
          *      Unused as of 1.2. Left here for serialization compatibility.
          */
+        @Deprecated
         private static class HeadCollector extends BodyExecutionCallback {
             private final CpsStepContext context;
             private final FlowHead head;

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/SingleJobTestBase.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/SingleJobTestBase.java
@@ -45,6 +45,7 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
  * @author Kohsuke Kawaguchi
  * @deprecated inline relevant parts
  */
+@Deprecated
 public abstract class SingleJobTestBase extends Assert {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
@@ -72,6 +73,7 @@ public abstract class SingleJobTestBase extends Assert {
     }
 
     /** @deprecated use {@link JenkinsRule#waitForCompletion} instead */
+    @Deprecated
     public void waitForWorkflowToComplete() throws Exception {
         do {
             waitForWorkflowToSuspend(e);
@@ -79,6 +81,7 @@ public abstract class SingleJobTestBase extends Assert {
     }
 
     /** @deprecated Use some other idiom, like {@link SemaphoreStep}. */
+    @Deprecated
     public void waitForWorkflowToSuspend() throws Exception {
         waitForWorkflowToSuspend(e);
     }


### PR DESCRIPTION
Fixes a warning from javac.