### PR TITLE
`RejectedExecutionException` from `CpsFlowExecution.getCurrentExecutions`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1060,7 +1060,12 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
 
             @Override
             public void onFailure(Throwable t) {
-                r.setException(t);
+                if (t instanceof RejectedExecutionException) {
+                    // Program already suspended, fine
+                    r.set(List.of());
+                } else {
+                    r.setException(t);
+                }
             }
         });
 


### PR DESCRIPTION
Caught and logged as a warning from `FlowExecutionList.StepExecutionIteratorImpl` when trying to call `StepExecution.applyAll` at a certain point during shutdown, for example from `DurableTaskStep$AgentReconnectionListener.check` if an agent is disconnected. In fact that listener does check `Jenkins.get().isTerminating()` to avoid noise, but unfortunately this flag is set by `Jenkins.cleanUp` _after_ running `@Terminator`s (and before all other cleanup steps).