### PR TITLE
[JENKINS-50407] Better diagnosis for certain fatal loading errors

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -846,7 +846,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         try {
             Functions.printStackTrace(problem, owner.getListener().getLogger());
         } catch (Exception x) {
-            LOGGER.log(Level.WARNING, "failed to log problem to " + owner, x);
+            LOGGER.log(Level.WARNING, x, () -> "failed to log problem to " + owner);
         }
         promise.setException(problem);
         croak(new AbortException("Failed to load program"));

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -28,8 +28,6 @@ import com.cloudbees.groovy.cps.Continuable;
 import com.cloudbees.groovy.cps.Env;
 import com.cloudbees.groovy.cps.Envs;
 import com.cloudbees.groovy.cps.Outcome;
-import com.cloudbees.groovy.cps.impl.ConstantBlock;
-import com.cloudbees.groovy.cps.impl.ThrowBlock;
 import com.cloudbees.groovy.cps.sandbox.Invoker;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
@@ -841,9 +839,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     }
 
     /**
-     * Used by {@link #loadProgramAsync(File)} to propagate a failure to load the persisted execution state.
-     * <p>
-     * Let the workflow interrupt by throwing an exception that indicates how it failed.
+     * Used to propagate a failure to load the persisted execution state.
      * @param promise same as {@link #programPromise} but more strongly typed
      */
     private void loadProgramFailed(final Throwable problem, SettableFuture<CpsThreadGroup> promise) {
@@ -852,46 +848,8 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         } catch (Exception x) {
             LOGGER.log(Level.WARNING, "failed to log problem to " + owner, x);
         }
-
-        FlowHead head;
-
-        synchronized(this) {
-            if (heads == null || heads.isEmpty()) {
-                head = null;
-            } else {
-                head = getFirstHead();
-            }
-        }
-
-        if (head==null) {
-            // something went catastrophically wrong and there's no live head. fake one
-            head = new FlowHead(this);
-            try {
-                head.newStartNode(new FlowStartNode(this, iotaStr()));
-            } catch (IOException e) {
-                LOGGER.log(Level.FINE, "Failed to persist", e);
-            }
-        }
-
-
-        CpsThreadGroup g = new CpsThreadGroup(this);
-        final FlowHead head_ = head;
-
-        promise.set(g);
-        runInCpsVmThread(new FutureCallback<>() {
-            @Override public void onSuccess(CpsThreadGroup g) {
-                CpsThread t = g.addThread(
-                        new Continuable(new ThrowBlock(new ConstantBlock(
-                            problem instanceof AbortException || problem instanceof FlowInterruptedException ? problem : new IOException("Failed to load build state", problem)))),
-                        head_, null
-                );
-                t.resume(new Outcome(null,null));
-            }
-            @Override public void onFailure(Throwable t) {
-                LOGGER.log(Level.WARNING, "Failed to set program failure on " + owner, t);
-                croak(t);
-            }
-        });
+        promise.setException(problem);
+        croak(new AbortException("Failed to load program"));
     }
 
     /** Report a fatal error in the VM. */

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -107,6 +107,7 @@ import groovy.lang.GroovyCodeSource;
 import hudson.AbortException;
 import hudson.BulkChange;
 import hudson.Extension;
+import hudson.Functions;
 import hudson.init.Terminator;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -846,6 +847,12 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
      * @param promise same as {@link #programPromise} but more strongly typed
      */
     private void loadProgramFailed(final Throwable problem, SettableFuture<CpsThreadGroup> promise) {
+        try {
+            Functions.printStackTrace(problem, owner.getListener().getLogger());
+        } catch (Exception x) {
+            LOGGER.log(Level.WARNING, "failed to log problem to " + owner, x);
+        }
+
         FlowHead head;
 
         synchronized(this) {

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -608,6 +608,29 @@ public class CpsFlowExecutionTest {
         });
     }
 
+    @Issue("JENKINS-50407")
+    @Test public void shellLoadingError() throws Throwable {
+        sessions.then(r -> {
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("semaphore 'wait'", true));
+            SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
+        });
+        sessions.then(r -> {
+            r.assertLogContains("IllegalStateException: decorator problem here",
+                r.assertBuildStatus(Result.FAILURE,
+                    r.waitForCompletion(r.jenkins.getItemByFullName("p", WorkflowJob.class).getLastBuild())));
+        });
+    }
+    @TestExtension("shellLoadingError") public static final class BrokenDecorator extends GroovyShellDecorator {
+        static int count;
+        @Override
+        public void configureShell(CpsFlowExecution context, GroovyShell shell) {
+            if (count++ == 1) {
+                throw new IllegalStateException("decorator problem here");
+            }
+        }
+    }
+
     /**
      * This field shouldn't be visible to regular script.
      */


### PR DESCRIPTION
Continuing #215.

Without the main patch, you get the reported error in the system log

```
WARNING	o.j.p.w.cps.CpsVmExecutorService#reportProblem: Unexpected exception in CPS VM thread: CpsFlowExecution[Owner[p/1:p #1]]
java.lang.IllegalStateException: JENKINS-50407: no loaded shell in CpsFlowExecution[Owner[p/1:p #1]]
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:35)
	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:187)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:423)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:331)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:295)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:97)
	at …
```

as well as in the build log

```
Resuming build at Mon Oct 23 16:48:23 EDT 2023 after Jenkins restart
[Pipeline] End of Pipeline
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: ce42faee-d9c6-4e53-9448-32499c419cf5
java.lang.IllegalStateException: JENKINS-50407: no loaded shell in CpsFlowExecution[Owner[p/1:p #1]]
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:35)
	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:187)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:423)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:331)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:295)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:97)
	at …
Finished: FAILURE
```

but that is it; the original exception is swallowed.

(What could be causing the actual problems in the field, I have no idea. It is unlikely to be an error from a shell decorator as in this test; that is just a convenient way I found to simulate a load failure and trigger the condition for `CpsFlowExecution.shell` to be null.)

Sprinking in some `Thread.dumpStack`s here and there shows that while a root error might come from

```
java.lang.IllegalStateException: decorator problem here
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecutionTest$BrokenDecorator.configureShell(CpsFlowExecutionTest.java:629)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShellFactory.build(CpsGroovyShellFactory.java:125)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:579)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.loadProgramAsync(CpsFlowExecution.java:801)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:771)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:720)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:578)
	at …
```

the improper use of the CPS VM thread comes a bit later

```
java.lang.Exception: Stack trace
	at java.base/java.lang.Thread.dumpStack(Thread.java:1383)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$5.onSuccess(CpsFlowExecution.java:959)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$5.onSuccess(CpsFlowExecution.java:954)
	at org.jenkinsci.plugins.workflow.support.concurrent.Futures$1.run(Futures.java:147)
	at org.jenkinsci.plugins.workflow.support.concurrent.DirectExecutor.execute(DirectExecutor.java:33)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1270)
	at com.google.common.util.concurrent.AbstractFuture.addListener(AbstractFuture.java:761)
	at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.addListener(AbstractFuture.java:136)
	at org.jenkinsci.plugins.workflow.support.concurrent.Futures.addCallback(Futures.java:157)
	at org.jenkinsci.plugins.workflow.support.concurrent.Futures.addCallback(Futures.java:97)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.runInCpsVmThread(CpsFlowExecution.java:954)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.getCurrentExecutions(CpsFlowExecution.java:1047)
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$ResumeStepExecutionListener.onResumed(FlowExecutionList.java:284)
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionListener.fireResumed(FlowExecutionListener.java:85)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:590)
	at hudson.model.RunMap.retrieve(RunMap.java:233)
```

I am not actually sure what the purpose of the complex logic in `loadProgramFailed` is; if it ever worked as written, it does not seem to now (as seen by its failing attempt to run `SandboxContinuable.run0`). The much simpler implementation in the second commit also passes the test with less noise.
