### PR TITLE
Suppress ESLint warning `no-unused-vars`

### DIFF
--- a/plugin/src/main/js/workflow-editor.js
+++ b/plugin/src/main/js/workflow-editor.js
@@ -54,6 +54,7 @@ $(function() {
                         setTheme(editor);
 
                         if (window.isSystemRespectingTheme) {
+                            // eslint-disable-next-line no-unused-vars
                             window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
                                 setTheme(editor)
                             });

--- a/plugin/src/main/js/workflow-editor.js
+++ b/plugin/src/main/js/workflow-editor.js
@@ -54,8 +54,7 @@ $(function() {
                         setTheme(editor);
 
                         if (window.isSystemRespectingTheme) {
-                            // eslint-disable-next-line no-unused-vars
-                            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+                            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
                                 setTheme(editor)
                             });
                         }


### PR DESCRIPTION
This code introduced in #769 is breaking the local build. ~Not sure why it did not at the time; maybe there is some dependency not being pinned properly?~ As per https://github.com/jenkinsci/plugin-pom/issues/874 this is not caught by CI.