### PR TITLE
Forward compatibility with Guice 7

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -49,16 +49,10 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2378.v3e03930028f2</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2705.vf5c48c31285b_</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <!-- TODO until in BOM: -->
-            <dependency>
-              <groupId>org.jenkins-ci.plugins</groupId>
-              <artifactId>support-core</artifactId>
-              <version>1366.v9d076592655d</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/RestartingLoadStepTest.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.workflow.cps.steps;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import groovy.lang.GroovyShell;
 import hudson.FilePath;
 import hudson.model.Result;

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <groovy.version>2.4.21</groovy.version> <!-- TODO: Add org.codehaus.groovy:groovy and org.codehaus.groovy:groovy:sources to Jenkins core BOM so this can be deleted? (currently it only specifies groovy-all) -->
     </properties>
     <modules>


### PR DESCRIPTION
Without dropping compatibility with Guice 6 (currently delivered by Jenkins core), add support for Guice 7.