### PR TITLE
Suppress warnings for spotbugs 4.8.3

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/NotBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/NotBlock.java
@@ -34,7 +34,7 @@ public class NotBlock implements Block {
         return new ContinuationImpl(e, k).then(b, e, cast);
     }
 
-    @SuppressFBWarnings(value = "SIC_INNER_SHOULD_BE_STATIC", justification = "Common Jenkins pattern that inner classses are not static.")
+    @SuppressFBWarnings(value = "SIC_INNER_SHOULD_BE_STATIC", justification = "Too late to fix compatibly.")
     class ContinuationImpl extends ContinuationGroup {
         final Continuation k;
         final Env e;

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/NotBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/NotBlock.java
@@ -34,6 +34,7 @@ public class NotBlock implements Block {
         return new ContinuationImpl(e, k).then(b, e, cast);
     }
 
+    @SuppressFBWarnings(value = "SIC_INNER_SHOULD_BE_STATIC", justification = "Common Jenkins pattern that inner classses are not static.")
     class ContinuationImpl extends ContinuationGroup {
         final Continuation k;
         final Env e;

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -267,7 +267,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
      *
      * @see #runInCpsVmThread(FutureCallback)
      */
-    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO clean up")
     public transient volatile ListenableFuture<CpsThreadGroup> programPromise;
     private transient volatile Collection<ListenableFuture<?>> pickleFutures;
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -267,6 +267,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
      *
      * @see #runInCpsVmThread(FutureCallback)
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public transient volatile ListenableFuture<CpsThreadGroup> programPromise;
     private transient volatile Collection<ListenableFuture<?>> pickleFutures;
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.76</version>
+        <version>4.77</version>
         <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
## Suppress warnings for spotbugs 4.8.3

Will be needed with parent pom 4.77.

### Testing done

Confirmed that the spotbugs warnings are visible when using the 4.77-SNAPSHOT plugin pom before this change.  With this change, the spotbugs warnings are no longer visible.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
