### PR TITLE
More robust `CpsFlowExecution.croak`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -912,7 +912,15 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     /** Report a fatal error in the VM. */
     void croak(Throwable t) {
         setResult(Result.FAILURE);
-        onProgramEnd(new Outcome(null, t));
+        if (startNodes == null || startNodes.isEmpty()) {
+            try {
+                createPlaceholderNodes(t);
+            } catch (Exception x) {
+                LOGGER.log(Level.WARNING, "Failed to create placeholder nodes in " + owner, x);
+            }
+        } else {
+            onProgramEnd(new Outcome(null, t));
+        }
         cleanUpHeap();
         try {
             saveOwner();

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -912,7 +912,11 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     /** Report a fatal error in the VM. */
     void croak(Throwable t) {
         setResult(Result.FAILURE);
-        if (startNodes == null || startNodes.isEmpty()) {
+        boolean noStartNodes;
+        synchronized (this) {
+            noStartNodes = startNodes == null || startNodes.isEmpty();
+        }
+        if (noStartNodes) {
             try {
                 createPlaceholderNodes(t);
             } catch (Exception x) {


### PR DESCRIPTION
The handling for a broken build in #809 seems to have been broken in the situation which #812 failed to reproduce:

```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
Script3: 8: unable to resolve class XXX 
 @ line 8, column 5.
       XXX xxx = null
       ^

Script3: 10: unable to resolve class XXX 
 @ line 10, column 20.
       void xxx(XXX xxx) {
                ^

2 errors

	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:309)
	at org.codehaus.groovy.control.CompilationUnit.applyToSourceUnits(CompilationUnit.java:981)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:626)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:575)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:323)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:293)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox$Scope.parse(GroovySandbox.java:163)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:190)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:175)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:638)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.loadProgramAsync(CpsFlowExecution.java:855)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:825)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:719)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:577)
	at …
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed: …
	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:309)
	at org.codehaus.groovy.control.CompilationUnit.applyToSourceUnits(CompilationUnit.java:981)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:626)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:575)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:323)
	at …
java.util.EmptyStackException
	at java.base/java.util.Stack.peek(Stack.java:102)
	at java.base/java.util.Stack.pop(Stack.java:84)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onProgramEnd(CpsFlowExecution.java:1325)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.croak(CpsFlowExecution.java:914)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.loadProgramFailed(CpsFlowExecution.java:908)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.loadProgramAsync(CpsFlowExecution.java:893)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:825)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:719)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:577)
	at …
ERROR: Failed to load program
Finished: FAILURE
```
