### PR TITLE
[JENKINS-60434] Allow pipelines to continue running when preparing for shutdown

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -44,6 +44,7 @@ import hudson.Util;
 import hudson.model.Result;
 import hudson.util.XStream2;
 import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 import jenkins.util.Timer;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
@@ -94,6 +95,11 @@ import org.jenkinsci.plugins.workflow.support.storage.FlowNodeStorage;
 @PersistIn(PersistenceContext.PROGRAM)
 @SuppressFBWarnings("SE_BAD_FIELD") // bogus warning about closures
 public final class CpsThreadGroup implements Serializable {
+    /**
+     * Whether to keep pipelines running when preparing for shutdown. Defaults to false (pipelines are paused).
+     */
+    private static boolean keepPipelinesRunningWhenQuietingDown = SystemProperties.getBoolean(CpsThreadGroup.class.getName() + ".keepPipelinesRunningWhenQuietingDown");
+
     /**
      * {@link CpsThreadGroup} always belong to the same {@link CpsFlowExecution}.
      *
@@ -303,8 +309,8 @@ public final class CpsThreadGroup implements Serializable {
                             LOGGER.log(Level.WARNING, null, e);
                         }
                     }
-                    if (paused.get() || j == null || (execution != null && j.isQuietingDown())) {
-                        if (j != null && j.isQuietingDown() && execution != null && pausedByQuietMode.compareAndSet(false, true)) {
+                    if (paused.get() || j == null || (execution != null && j.isQuietingDown() && !keepPipelinesRunningWhenQuietingDown)) {
+                        if (j != null && j.isQuietingDown() && execution != null && !keepPipelinesRunningWhenQuietingDown && pausedByQuietMode.compareAndSet(false, true)) {
                             try {
                                 execution.getOwner().getListener().getLogger().println("Pausing (Preparing for shutdown)");
                             } catch (IOException e) {


### PR DESCRIPTION
Prevents pipelines from being paused when preparing for shutdown. No new parts of pipelines are scheduled to executors but parts already running can run to completion, allowing Jenkins to be restarted without any running jobs.

This is disabled by default and enabled by setting `-Dorg.jenkinsci.plugins.workflow.cps.CpsThreadGroup.keepPipelinesRunningWhenQuietingDown=true`.

This provides a solution for https://issues.jenkins.io/browse/JENKINS-60434.

### Testing done

The default case is covered by existing tests in `CpsFlowExecutionTest.java`.

For the case with `-Dorg.jenkinsci.plugins.workflow.cps.CpsThreadGroup.keepPipelinesRunningWhenQuietingDown=true`:
 - tested that pipelines are not automatically pause when preparing for shutdown
 - tested manually pausing and resuming a pipeline
 - tested manually pausing and resuming a pipeline while preparing for shutdown
 - tested preparing for shutdown, allowing a pipeline to run to the end of it's current node section, and restarting Jenkins. The pipeline resumed at the next node section as expected.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
