### PR TITLE
[JENKINS-71926] Robustness against NULs in `ArgumentsActionImpl`

### DIFF
--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImplTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImplTest.java
@@ -70,6 +70,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -564,6 +565,14 @@ public class ArgumentsActionImplTest {
         SemaphoreStep.success("wait/1", null);
         r.waitForCompletion(run);
         testDeserialize(run.getExecution());
+    }
+
+    @Test
+    public void nul() throws Exception {
+        var job = r.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition("echo 'one\\0two'; echo 'this part is fine'", true));
+        var store = r.buildAndAssertSuccess(job).getRootDir().toPath().resolve("workflow-completed/flowNodeStore.xml");
+        assertThat(store + " was written", Files.readString(store), containsString("this part is fine"));
     }
 
     @Test


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-71926 since I just stumbled across this myself recently when I tried to use a NUL in a script passed to `sh` and accidentally passed that in the `script` instead.