### PR TITLE
Fix snippet generator when a custom crumb header is configured

### DIFF
--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/handle-prototype.js
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/handle-prototype.js
@@ -1,4 +1,4 @@
-function handlePrototype(url, crumb) {
+function handlePrototype(url) {
     buildFormTree(document.forms.config);
     // TODO JSON.stringify fails in some circumstances: https://gist.github.com/jglick/70ec4b15c1f628fdf2e9 due to Array.prototype.toJSON
     // TODO simplify when Prototype.js is removed
@@ -7,13 +7,11 @@ function handlePrototype(url, crumb) {
         return; // just a separator
     }
 
-    const headers = new Headers();
-    headers.append("Content-Type", "application/x-www-form-urlencoded");
-    headers.append("Jenkins-Crumb", crumb);
-
     fetch(url, {
         method: "POST",
-        headers: headers,
+        headers: crumb.wrap({
+            "Content-Type": "application/x-www-form-urlencoded"
+        }),
         body: "json=" + encodeURIComponent(json),
 
     })
@@ -37,9 +35,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const generatePipelineScript = document.getElementById("generatePipelineScript");
     const url = generatePipelineScript.getAttribute("data-url");
-    const crumb = generatePipelineScript.getAttribute("data-crumb");
     generatePipelineScript.onclick = (_) => {
-        handlePrototype(url, crumb);
+        handlePrototype(url);
         return false;
     };
 

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -70,8 +70,7 @@ THE SOFTWARE.
                 <f:block>
                     <input type="button" id="generatePipelineScript" value="${%Generate Pipeline Script}"
                            class="submit-button primary"
-                           data-url="${rootURL}/${it.GENERATE_URL}"
-                           data-crumb="${h.getCrumb(request)}"/>
+                           data-url="${rootURL}/${it.GENERATE_URL}"/>
                     <f:textarea id="prototypeText" readonly="true" style="margin-top: 10px"/>
                     <l:copyButton text="" clazz="jenkins-hidden jenkins-!-margin-top-1"/>
                     <st:adjunct includes="org.jenkinsci.plugins.workflow.cps.Snippetizer.handle-prototype"/>


### PR DESCRIPTION
The CSRF crumb header can be configured on Jenkins via the java property `hudson.security.csrf.requestfield`.

When an instance overrides the header value with something different than `Jenkins-crumb`, the snippet generator would still use the hard-coded value, causing a 403 to be returned and no snippet to be displayed

### Testing done
On a Jenkins version 2.440.1 on a Debian 12 machine, Jenkins was started with `-Dhudson.security.csrf.requestfield=X-Jenkins-crumb`. 

Then on the https://jenkins.exemple.com/job/example/pipeline-syntax/ page, the `Generate Pipeline Script` button is clicked. 

Without this patch, the AJAX calls gets a 503, as the sent header is `Jenkins-crumb`. With the patch applied (I built a custom version of the plugin locally with Maven), the header is sent as configured by the Java option and the request is successful. 

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
