### PR TITLE
Reparse `CpsFlowExecution.loadedScripts` in original order

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -82,7 +82,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -254,7 +253,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
      * Any additional scripts {@linkplain CpsGroovyShell#parse(GroovyCodeSource) parsed} afterward, keyed by
      * their FQCN.
      */
-    /*package*/ /*final*/ Map<String,String> loadedScripts = new HashMap<>();
+    /*package*/ /*final*/ Map<String,String> loadedScripts = new LinkedHashMap<>();
 
     private final boolean sandbox;
     private transient /*almost final*/ FlowExecutionOwner owner;
@@ -644,12 +643,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         }
 
         s.execution = this;
-        if (false) {
-            System.out.println("scriptName="+s.getClass().getName());
-            System.out.println(List.of(s.getClass().getInterfaces()));
-            System.out.println(List.of(s.getClass().getDeclaredFields()));
-            System.out.println(List.of(s.getClass().getDeclaredMethods()));
-        }
         return s;
     }
 
@@ -1877,7 +1870,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                     }
 
                     if (result.loadedScripts == null) {
-                        result.loadedScripts = new HashMap<>();   // field added later
+                        result.loadedScripts = new LinkedHashMap<>(); // field added later
                     }
                     result.liveTimings = result.timings == null ?
                         new ConcurrentHashMap<>() :

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -709,6 +709,7 @@ public class CpsFlowExecutionTest {
         sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
+                "evaluate('true')\n" + // just force this to be Script1
                 "def x = evaluate('class X {X() {}; def m1() {/OK/}}; new X()')\n" +
                 "def y = evaluate('class Y {X x; def m2() {/really ${x.m1()}/}}; new Y()')\n" +
                 "semaphore('wait')\n" +

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -720,6 +720,7 @@ public class CpsFlowExecutionTest {
         sessions.then(r -> {
             WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
             WorkflowRun b = p.getLastBuild();
+            FileUtils.copyFile(new File(b.getRootDir(), "build.xml"), System.out);
             SemaphoreStep.success("wait/1", null);
             r.assertLogContains("received really OK", r.assertBuildStatus(Result.SUCCESS, r.waitForCompletion(b)));
         });


### PR DESCRIPTION
Finally tracked down the error noted in #812. Could reproduce by

<details>
<summary>Test patch</summary>

```diff
diff --git plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
index 69c2399d..00d050b4 100644
--- plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -150,6 +150,7 @@ import org.codehaus.groovy.GroovyBugError;
 import org.jboss.marshalling.reflect.SerializableClassRegistry;
 
 import static com.thoughtworks.xstream.io.ExtendedHierarchicalStreamWriterHelper.startNode;
+import java.util.Comparator;
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.RUN;
 
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
@@ -635,7 +636,10 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
 
             s = (CpsScript) shell.reparse("WorkflowScript",script);
 
-            for (Entry<String, String> e : loadedScripts.entrySet()) {
+            Map<String, String> ls = new TreeMap<>(Comparator.reverseOrder());
+            ls.putAll(loadedScripts);
+            System.err.println("TODO reparsing " + ls);
+            for (Entry<String, String> e : ls.entrySet()) {
                 shell.reparse(e.getKey(), e.getValue());
             }
         } catch (RuntimeException | Error x) {
```

</details>

`loadedScripts` was being stored as a `HashMap` with (semi-)random order, so if code in a later script referred to a static type name defined in an earlier script, it may or may not succeed in resolving the name.
