### PR TITLE
Move copy button and update generate button

### DIFF
--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -68,11 +68,11 @@ THE SOFTWARE.
                     <local:listSteps quasiDescriptors="${it.getQuasiDescriptors(true)}"/>
                 </f:dropdownList>
                 <f:block>
-                    <input type="button" id="generatePipelineScript" value="${%Generate Pipeline Script}"
-                           class="submit-button primary"
-                           data-url="${rootURL}/${it.GENERATE_URL}"/>
+                    <button class="jenkins-button jenkins-button--primary" id="generatePipelineScript"
+                            data-url="${rootURL}/${it.GENERATE_URL}">${%Generate Pipeline Script}</button>
+                    <nbsp/>
+                    <l:copyButton text="" tooltip="${%Click to copy}" clazz="jenkins-!-margin-left-2"/>
                     <f:textarea id="prototypeText" readonly="true" style="margin-top: 10px"/>
-                    <l:copyButton text="" clazz="jenkins-hidden jenkins-!-margin-top-1"/>
                     <st:adjunct includes="org.jenkinsci.plugins.workflow.cps.Snippetizer.handle-prototype"/>
                 </f:block>
                 <f:section title="${%Global Variables}"/>


### PR DESCRIPTION
The change proposed moves the "copy to clipboard" button above the output box, matching with other buttons' locations.
Additionally, I've changed the generation button from YUI to make use the Jenkins button layout:

Before:
![Screenshot 2024-03-10 at 09 51 54](https://github.com/jenkinsci/workflow-cps-plugin/assets/13383509/c06159ab-606c-442c-8ecd-a9a26c4d3292)

After:
![Screenshot 2024-03-10 at 09 51 09](https://github.com/jenkinsci/workflow-cps-plugin/assets/13383509/e1a18721-9ed1-47ef-99e4-da2fdeffd87f)