### PR TITLE
Backport #877 to 3653.x

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/Continuable.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/Continuable.java
@@ -23,6 +23,9 @@ import org.codehaus.groovy.runtime.GroovyCategorySupport;
  */
 public class Continuable implements Serializable {
 
+    /**
+     * Users of this library must pass (at least) these to {@link GroovyCategorySupport#use(List, Closure)} during all operations.
+     */
     @SuppressWarnings("rawtypes")
     public static final List<Class> categories = List.of(
         CpsDefaultGroovyMethods.class,
@@ -133,31 +136,21 @@ public class Continuable implements Serializable {
         return run0(new Outcome(null,arg)).wrapReplay();
     }
 
-    @Deprecated
-    public Outcome run0(final Outcome cn) {
-        return run0(cn, categories);
-    }
-
     /**
      * Resumes this program by either returning the value from {@link Continuable#suspend(Object)} or
      * throwing an exception
      */
-    public Outcome run0(final Outcome cn, List<Class> categories) {
-        return GroovyCategorySupport.use(categories, new Closure<>(null) {
-            @Override
-            public Outcome call() {
-                Next n = cn.resumeFrom(e,k);
+    public Outcome run0(final Outcome cn) {
+        Next n = cn.resumeFrom(e,k);
 
-                while(n.yield==null) {
-                    n = n.step();
-                }
+        while(n.yield==null) {
+            n = n.step();
+        }
 
-                e = n.e;
-                k = n.k;
+        e = n.e;
+        k = n.k;
 
-                return n.yield;
-            }
-        });
+        return n.yield;
     }
 
     /**

--- a/lib/src/test/java/com/cloudbees/groovy/cps/CpsDefaultGroovyMethodsTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/CpsDefaultGroovyMethodsTest.java
@@ -334,8 +334,6 @@ public class CpsDefaultGroovyMethodsTest extends AbstractGroovyCpsTest {
             asList("uniqueSet", "([1, 2, -2, 3] as HashSet).unique { i -> i * i }.collect { it.abs() } as HashSet", asList(1, 2, 3) as HashSet),
             */
 
-            // TODO: use?
-
             // TODO: with?
 
             // .withDefault

--- a/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformerTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformerTest.java
@@ -768,7 +768,7 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
 
     @Issue("https://github.com/cloudbees/groovy-cps/issues/16")
     @Test
-    @Ignore
+    @Ignore("cannot easily be supported")
     public void category() throws Throwable {
         assertEvaluate("FOO",
             "class BarCategory {\n" +

--- a/lib/src/test/java/com/cloudbees/groovy/cps/impl/NotBlockTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/impl/NotBlockTest.java
@@ -7,7 +7,6 @@ import com.cloudbees.groovy.cps.Outcome;
 import groovy.lang.Script;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
-import java.util.Collections;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -38,6 +37,6 @@ public class NotBlockTest extends AbstractGroovyCpsTest {
             c = (Continuable)ois.readObject();
         }
         assertTrue(c.isResumable());
-        assertThat(c.run0(new Outcome(false, null), Collections.emptyList()).replay(), equalTo(true));
+        assertThat(c.run0(new Outcome(false, null)).replay(), equalTo(true));
     }
 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.workflow.cps;
 
 import com.cloudbees.groovy.cps.Continuable;
 import com.cloudbees.groovy.cps.Outcome;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FutureCallback;
 import java.io.IOException;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
@@ -43,7 +42,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
-import org.jenkinsci.plugins.workflow.cps.persistence.IteratorHack;
 
 import static java.util.logging.Level.FINE;
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.PROGRAM;
@@ -162,11 +160,6 @@ public final class CpsThread implements Serializable {
         this.step = step;
     }
 
-    private static final List<Class> CATEGORIES = ImmutableList.<Class>builder()
-            .addAll(Continuable.categories)
-            .add(IteratorHack.class)
-            .build();
-
     /**
      * Executes CPS code synchronously a little bit more, until it hits
      * the point the workflow needs to be dehydrated.
@@ -184,7 +177,7 @@ public final class CpsThread implements Serializable {
             LOGGER.fine(() -> "runNextChunk on " + resumeValue);
             final Outcome o = resumeValue;
             resumeValue = null;
-            outcome = program.run0(o, CATEGORIES);
+            outcome = program.run0(o);
             if (outcome.getAbnormal() != null) {
                 LOGGER.log(FINE, "ran and produced error", outcome.getAbnormal());
             } else {

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/SandboxContinuable.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/SandboxContinuable.java
@@ -7,7 +7,6 @@ import hudson.MarkupText;
 import hudson.console.ConsoleAnnotator;
 import hudson.console.ConsoleNote;
 import java.io.IOException;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox;
@@ -24,8 +23,7 @@ class SandboxContinuable extends Continuable {
     }
 
     @SuppressWarnings("rawtypes")
-    @Override
-    public Outcome run0(final Outcome cn, final List<Class> categories) {
+    public Outcome run0(final Outcome cn) {
         CpsFlowExecution e = thread.group.getExecution();
         if (e == null) {
             throw new IllegalStateException("JENKINS-50407: no loaded execution");
@@ -48,7 +46,7 @@ class SandboxContinuable extends Continuable {
             trustedShell.getClassLoader(),
             shell.getClassLoader()));
         try (GroovySandbox.Scope scope = sandbox.enter()) {
-            return SandboxContinuable.super.run0(cn, categories);
+            return SandboxContinuable.super.run0(cn);
         }
     }
 

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionMemoryTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionMemoryTest.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.cps;
 
 import groovy.lang.MetaClass;
+import hudson.model.Computer;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -67,6 +68,7 @@ public class CpsFlowExecutionMemoryTest {
     }
 
     @Test public void loaderReleased() throws Exception {
+        Computer.threadPoolForRemoting.submit(() -> {}).get(); // do not let it be initialized inside the CpsVmExecutorService thread group
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         r.jenkins.getWorkspaceFor(p).child("lib.groovy").write(CpsFlowExecutionMemoryTest.class.getName() + ".register(this)", null);
         p.setDefinition(new CpsFlowDefinition(CpsFlowExecutionMemoryTest.class.getName() + ".register(this); node {load 'lib.groovy'; evaluate(readFile('lib.groovy'))}", false));


### PR DESCRIPTION
Backports #877 to 3653.x.

Note that I copied `ErrorLoggingExecutorService` from core (https://github.com/jenkinsci/jenkins/pull/7284) into `CpsVmExecutorService` as an inner class to avoid having to update dependencies here. If preferred, we could instead update dependencies, or just drop the `ErrorLoggingExecutorService` from `threadPool` in the backport.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
