### PR TITLE
Override 'getIconFileName' rather than setting 'getIconClassName'

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/Snippetizer.java
@@ -574,10 +574,9 @@ import org.kohsuke.stapler.StaplerRequest;
             return Messages.Pipeline_Syntax();
         }
 
-        public String getIconClassName() {
-            return "icon-help";
+        @Override public String getIconFileName() {
+            return "symbol-help-circle";
         }
-
     }
 
     private static final Logger LOGGER = Logger.getLogger(Snippetizer.class.getName());


### PR DESCRIPTION
I'm currently doing some work in core relating to the `Action` class and the way we present them. When doing so I was doing a basic check on `getIconFileName` to see if it was null, if null don't show the action. However the `Pipeline Syntax` action was always invisible as it has `getIconFileName` set to null and is not overridden, instead setting a custom method `getIconClassName`.

<img width="334" alt="image" src="https://github.com/jenkinsci/workflow-cps-plugin/assets/43062514/cf4abcec-826d-4333-8b0d-6cf202f8ebf3">

This PR instead overrides the `getIconFileName` method and it appears as expected.

### Testing done

* Icon/action shows as expected

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
