### PR TITLE
Support Maven reproducible builds

### DIFF
--- a/dgm-builder/src/main/java/com/cloudbees/groovy/cps/tool/Translator.java
+++ b/dgm-builder/src/main/java/com/cloudbees/groovy/cps/tool/Translator.java
@@ -169,7 +169,7 @@ public class Translator {
      */
     public void translate(String fqcn, String outfqcn, String sourceJarName) throws JClassAlreadyExistsException {
         final JDefinedClass $output = codeModel._class(outfqcn);
-        $output.annotate(Generated.class).param("value", Translator.class.getName()).param("date", new Date().toString()).param("comments", "based on " + sourceJarName);
+        $output.annotate(Generated.class).param("value", Translator.class.getName()).param("comments", "based on " + sourceJarName);
         $output.annotate(SuppressWarnings.class).param("value", "rawtypes");
         $output.constructor(JMod.PRIVATE);
 


### PR DESCRIPTION
Without this PR, Maven reproducible build verification fails with e.g.

```
├── com/cloudbees/groovy/cps/CpsDefaultGroovyMethods.java
│ @@ -39,15 +39,15 @@
│  import org.codehaus.groovy.runtime.GroovyCategorySupport;
│  import org.codehaus.groovy.runtime.InvokerHelper;
│  import org.codehaus.groovy.runtime.ReverseListIterator;
│  import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;
│  import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
│  import org.codehaus.groovy.util.ArrayIterator;
│  
│ -@Generated(value = "com.cloudbees.groovy.cps.tool.Translator", date = "Fri Apr 12 13:32:51 PDT 2024", comments = "based on groovy-cps-dgm-builder-3900.ved80eb_b_c18cf-jar-with-dependencies.jar")
│ +@Generated(value = "com.cloudbees.groovy.cps.tool.Translator", date = "Fri Apr 12 13:33:58 PDT 2024", comments = "based on groovy-cps-dgm-builder-3900.ved80eb_b_c18cf-jar-with-dependencies.jar")
│  @SuppressWarnings("rawtypes")
│  public class CpsDefaultGroovyMethods {
│  
│  
│      private CpsDefaultGroovyMethods() {
│      }
```

Since this date doesn't seem too important, maybe we can just omit it to get a deterministic build.

### Testing done

The above error went away and Maven build verification passed after this PR.