### PR TITLE
Refine interface of Pipeline Syntax

### DIFF
--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
         <st:include page="sidepanel"/>
         <l:main-panel>
             <f:form name="config">
-                <f:section title="${%Overview}"/>
+                <h1>${%Overview}</h1>
                 <f:block>
                     This <b>Snippet Generator</b> will help you learn the Pipeline Script code which can be used to
                     define various steps. Pick a step you are interested in from the list, configure it,
@@ -68,9 +68,11 @@ THE SOFTWARE.
                     <local:listSteps quasiDescriptors="${it.getQuasiDescriptors(true)}"/>
                 </f:dropdownList>
                 <f:block>
-                    <input type="button" id="generatePipelineScript" value="${%Generate Pipeline Script}"
-                           class="submit-button primary"
-                           data-url="${rootURL}/${it.GENERATE_URL}"/>
+                    <button type="button" id="generatePipelineScript"
+                           class="jenkins-button jenkins-button--primary"
+                           data-url="${rootURL}/${it.GENERATE_URL}">
+                        ${%Generate Pipeline Script}
+                    </button>
                     <f:textarea id="prototypeText" readonly="true" style="margin-top: 10px"/>
                     <l:copyButton text="" clazz="jenkins-hidden jenkins-!-margin-top-1"/>
                     <st:adjunct includes="org.jenkinsci.plugins.workflow.cps.Snippetizer.handle-prototype"/>

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/sidepanel.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/sidepanel.jelly
@@ -37,7 +37,6 @@ THE SOFTWARE.
                     </div>
                 </d:tag>
             </d:taglib>
-            <l:task href=".." icon="icon-up icon-md" title="${%Back}"/>
             <j:forEach var="link" items="${it.snippetizerLinks}">
                 <j:choose>
                     <j:when test="${link.inNewWindow}">


### PR DESCRIPTION
Small one to make a few adjustments to the interface of Pipeline Syntax:

* Up link removed from sidebar
* 'Overview' now shows as a `h1` - same as other pages
* Using `jenkins-button` class rather than YUI button

**Before**

<img width="1024" alt="image" src="https://github.com/jenkinsci/workflow-cps-plugin/assets/43062514/950ca3fc-1f15-44c4-b96e-ebb46be3deab">

**After**

<img width="1038" alt="image" src="https://github.com/jenkinsci/workflow-cps-plugin/assets/43062514/c8258f2b-e17c-481d-955a-ff8cd35bda62">

### Testing done

* Generating code works as before

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
