### PR TITLE
Update to 2.426.x, simplify JSON parsing

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -49,7 +49,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.414.x</artifactId>
+                <artifactId>bom-2.426.x</artifactId>
                 <version>2982.vdce2153031a_0</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/handle-prototype.js
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/handle-prototype.js
@@ -1,8 +1,6 @@
 function handlePrototype(url) {
     buildFormTree(document.forms.config);
-    // TODO JSON.stringify fails in some circumstances: https://gist.github.com/jglick/70ec4b15c1f628fdf2e9 due to Array.prototype.toJSON
-    // TODO simplify when Prototype.js is removed
-    const json = Object.toJSON ? Object.toJSON(JSON.parse(document.forms.config.elements.json.value).prototype) : JSON.stringify(JSON.parse(document.forms.config.elements.json.value).prototype);
+    const json = JSON.stringify(JSON.parse(document.forms.config.elements.json.value).prototype);
     if (!json) {
         return; // just a separator
     }

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.414.3</jenkins.version>
+        <jenkins.version>2.426.3</jenkins.version>
         <groovy.version>2.4.21</groovy.version> <!-- TODO: Add org.codehaus.groovy:groovy and org.codehaus.groovy:groovy:sources to Jenkins core BOM so this can be deleted? (currently it only specifies groovy-all) -->
     </properties>
     <modules>


### PR DESCRIPTION
Now that Prototype.js has been removed in 2.426.x, we can remove the no-longer needed `Object.toJSON` workaround.

### Testing done

`mvn clean verify -DskipTests`