### PR TITLE
Assert `@Exported` form of `EnvActionImpl`

### DIFF
--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowTest.java
@@ -25,6 +25,8 @@
 package org.jenkinsci.plugins.workflow;
 
 import com.google.common.base.Function;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Functions;
 import hudson.model.Computer;
@@ -40,14 +42,12 @@ import hudson.slaves.SlaveComputer;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.model.Jenkins;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
+import org.hamcrest.MatcherAssert;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
@@ -71,6 +71,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockQueueItemAuthenticator;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
+import static org.hamcrest.Matchers.containsString;
 
 /**
  * Tests of workflows that involve restarting Jenkins in the middle.
@@ -330,6 +331,8 @@ public class WorkflowTest extends SingleJobTestBase {
                 assertEquals("custom2", a.getEnvironment().get("BUILD_TAG"));
                 assertEquals("more", a.getEnvironment().get("STUFF"));
                 assertNotNull(a.getEnvironment().get("PATH"));
+                // TODO use https://www.javadoc.io/doc/com.jayway.jsonpath/json-path-assert/2.4.0/com/jayway/jsonpath/matchers/JsonPathMatchers.html#hasJsonPath-java.lang.String-org.hamcrest.Matcher- to clarify that /actions/[_class="org.jenkinsci.plugins.workflow.cps.EnvActionImpl"].environment.STUFF ⇒ "more"
+                MatcherAssert.assertThat(story.j.createWebClient().getJSON(b.getUrl() + "api/json?tree=actions[environment]").getJSONObject().toString(), containsString("\"STUFF\":\"more\""));
                 // Show that EnvActionImpl binding is a fallback only for things which would otherwise have been undefined:
                 p.setDefinition(new CpsFlowDefinition(
                     "env.env = 'env.env'\n" +


### PR DESCRIPTION
Long implemented as https://github.com/jenkinsci/pipeline-plugin/commit/a2524aee0821acd8af138190fb27724ef1b0500e but apparently never before explicitly demonstrated in a test. Not likely to regress, but people sometimes ask how to extract `EnvAction.overriddenEnvironment` from an HTTP request.