### PR TITLE
Enable Jenkins Security Scan and bypass CodeQL's JavaCompiler to support JDK 17+

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -1,0 +1,20 @@
+name: Jenkins Security Scan
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  security-scan:
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+    with:
+      java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.

--- a/dgm-builder/src/main/java/com/cloudbees/groovy/cps/tool/Driver.java
+++ b/dgm-builder/src/main/java/com/cloudbees/groovy/cps/tool/Driver.java
@@ -9,13 +9,13 @@ import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
-import javax.tools.ToolProvider;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.ServiceLoader;
 import java.util.Set;
 
 public class Driver {
@@ -24,7 +24,7 @@ public class Driver {
     }
 
     public void run(File dir) throws Exception {
-        JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+        JavaCompiler javac = getSystemJavaCompiler();
         DiagnosticListener<JavaFileObject> errorListener = createErrorListener();
 
         try (StandardJavaFileManager fileManager = javac.getStandardFileManager(errorListener, Locale.getDefault(), Charset.defaultCharset())) {
@@ -73,6 +73,20 @@ public class Driver {
 
     private DiagnosticListener<JavaFileObject> createErrorListener() {
         return System.out::println;
+    }
+
+    private static JavaCompiler getSystemJavaCompiler() {
+        for (var compiler : ServiceLoader.load(JavaCompiler.class, ClassLoader.getSystemClassLoader())) {
+            if (compiler.getClass().getName().equals("com.semmle.extractor.java.interceptors.JavacToolInterceptor")) {
+                // CodeQL injects a custom JavaCompiler that does not currently support Java 17+, see https://github.com/jenkinsci/workflow-cps-plugin/pull/901#discussion_r1709926730
+                // We don't actually want to scan the generated CPS-DGM classes anyway, so we ignore it and use the regular implementation.
+                System.out.println("Skipping CodeQL JavaCompiler implementation: " + compiler.getClass().getName());
+            } else {
+                System.out.println("Selected JavaCompiler implementation: " + compiler.getClass().getName());
+                return compiler;
+            }
+        }
+        throw new IllegalStateException("Unable to find a valid JavaCompiler implementation");
     }
 
 }

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -61,6 +61,8 @@
                         <sourceRoot>${project.build.directory}/generated-sources/dgm</sourceRoot>
                         <executable>java</executable>
                         <arguments>
+                            <!-- Workaround for CodeQL support on JDK17+, see https://github.com/jenkinsci/workflow-cps-plugin/pull/901. -->
+                            <argument>--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</argument>
                             <argument>-jar</argument>
                             <argument>${project.build.directory}/groovy-cps-dgm-builder-${project.version}-jar-with-dependencies.jar</argument>
                             <argument>${project.build.directory}/generated-sources/dgm</argument>


### PR DESCRIPTION
Experimental workaround based on the stack trace observed in https://github.com/jenkinsci/workflow-cps-plugin/pull/901. Undoes https://github.com/jenkinsci/workflow-cps-plugin/pull/915.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
