### PR TITLE
[JENKINS-73726] Avoid NPE trying to cancel a block which is already done

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -249,6 +249,9 @@ class CpsBodyExecution extends BodyExecution {
             t.getExecution().runInCpsVmThread(new FutureCallback<>() {
                 @Override
                 public void onSuccess(CpsThreadGroup g) {
+                    if (thread == null) {
+                        return;
+                    }
                     // Similar to getCurrentExecutions but we want the raw CpsThread, not a StepExecution; cf. CpsFlowExecution.interrupt
                     Map<FlowHead, CpsThread> m = new LinkedHashMap<>();
                     for (CpsThread t : thread.group.getThreads()) {


### PR DESCRIPTION
Amending #925. Test case is in https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/738; did not manage to reproduce without Declarative (something weird in `ModelInterpreter.getParallelStages`). https://github.com/jenkinsci/workflow-cps-plugin/blob/3761c26d756586b2c88d3c9bbcf8ea577902129b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStep.java#L151 is immediately responsible:

```
org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
	at org.jenkinsci.plugins.workflow.cps.steps.ParallelStep$ResultHandler$Callback.checkAllDone(ParallelStep.java:151)
	at org.jenkinsci.plugins.workflow.cps.steps.ParallelStep$ResultHandler$Callback.onFailure(ParallelStep.java:138)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution$FailureAdapter.receive(CpsBodyExecution.java:357)
	at com.cloudbees.groovy.cps.impl.ThrowBlock$1.receive(ThrowBlock.java:66)
	at com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21)
	at com.cloudbees.groovy.cps.Next.step(Next.java:83)
	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:147)
	at …
```

```
java.lang.Exception: Stack trace
	at java.base/java.lang.Thread.dumpStack(Thread.java:2209)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution.cancel(CpsBodyExecution.java:251)
	at org.jenkinsci.plugins.workflow.cps.steps.ParallelStepExecution.stop(ParallelStepExecution.java:67)
	at org.jenkinsci.plugins.workflow.cps.steps.ParallelStep$ResultHandler$Callback.checkAllDone(ParallelStep.java:151)
	at org.jenkinsci.plugins.workflow.cps.steps.ParallelStep$ResultHandler$Callback.onFailure(ParallelStep.java:138)
	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution$FailureAdapter.receive(CpsBodyExecution.java:357)
	at com.cloudbees.groovy.cps.impl.ThrowBlock$1.receive(ThrowBlock.java:66)
	at com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21)
	at com.cloudbees.groovy.cps.Next.step(Next.java:83)
	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:147)
	at …
```