### PR TITLE
Prevent NPEs in `CpsFlowExecution.cleanUpGlobalClassValue` to make Pipeline cleanup more robust

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1437,7 +1437,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             if (encounteredClasses.add(clazz)) {
                 LOGGER.finer(() -> "found " + clazz.getName());
                 Introspector.flushFromCaches(clazz);
-                cleanUpGlobalClassSet(clazz);
                 cleanUpClassHelperCache(clazz);
                 cleanUpLoader(clazz.getClassLoader(), encounteredLoaders, encounteredClasses);
             }
@@ -1464,24 +1463,15 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         Class<?> entryC = Class.forName("org.codehaus.groovy.util.AbstractConcurrentMapBase$Entry");
         Method getValueM = entryC.getMethod("getValue");
         List<Class<?>> toRemove = new ArrayList<>(); // not sure if it is safe against ConcurrentModificationException or not
-        try {
-            Field classRefF = classInfoC.getDeclaredField("classRef"); // 2.4.8+
-            classRefF.setAccessible(true);
-            for (Object entry : entries) {
-                Object classInfo = getValueM.invoke(entry);
-                if (classInfo != null) {
-                    Class<?> clazz = ((WeakReference<Class<?>>) classRefF.get(classInfo)).get();
-                    if (clazz != null) {
-                        toRemove.add(clazz);
-                    }
+        Field classRefF = classInfoC.getDeclaredField("classRef"); // 2.4.8+
+        classRefF.setAccessible(true);
+        for (Object entry : entries) {
+            Object classInfo = getValueM.invoke(entry);
+            if (classInfo != null) {
+                Class<?> clazz = ((WeakReference<Class<?>>) classRefF.get(classInfo)).get();
+                if (clazz != null) {
+                    toRemove.add(clazz);
                 }
-            }
-        } catch (NoSuchFieldException x) {
-            Field klazzF = classInfoC.getDeclaredField("klazz"); // 2.4.7-
-            klazzF.setAccessible(true);
-            for (Object entry : entries) {
-                Object value = getValueM.invoke(entry);
-                toRemove.add((Class) klazzF.get(value));
             }
         }
         Iterator<Class<?>> it = toRemove.iterator();
@@ -1498,38 +1488,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         LOGGER.fine(() -> "cleaning up " + toRemove + " associated with " + loader);
         for (Class<?> klazz : toRemove) {
             removeM.invoke(map, klazz);
-        }
-    }
-
-    private static void cleanUpGlobalClassSet(@NonNull Class<?> clazz) throws Exception {
-        Class<?> classInfoC = Class.forName("org.codehaus.groovy.reflection.ClassInfo"); // or just ClassInfo.class, but unclear whether this will always be there
-        Field globalClassSetF = classInfoC.getDeclaredField("globalClassSet");
-        globalClassSetF.setAccessible(true);
-        Object globalClassSet = globalClassSetF.get(null);
-        try {
-            classInfoC.getDeclaredField("classRef");
-            return; // 2.4.8+, nothing to do here (classRef is weak anyway)
-        } catch (NoSuchFieldException x2) {} // 2.4.7-
-        // Cannot just call .values() since that returns a copy.
-        Field itemsF = globalClassSet.getClass().getDeclaredField("items");
-        itemsF.setAccessible(true);
-        Object items = itemsF.get(globalClassSet);
-        Method iteratorM = items.getClass().getMethod("iterator");
-        Field klazzF = classInfoC.getDeclaredField("klazz");
-        klazzF.setAccessible(true);
-        synchronized (items) {
-            Iterator<?> iterator = (Iterator) iteratorM.invoke(items);
-            while (iterator.hasNext()) {
-                Object classInfo = iterator.next();
-                if (classInfo == null) {
-                    LOGGER.finer("JENKINS-41945: ignoring null ClassInfo from ManagedLinkedList.Iter.next");
-                    continue;
-                }
-                if (klazzF.get(classInfo) == clazz) {
-                    iterator.remove();
-                    LOGGER.log(Level.FINER, "cleaning up {0} from GlobalClassSet", clazz.getName());
-                }
-            }
         }
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1468,8 +1468,13 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             Field classRefF = classInfoC.getDeclaredField("classRef"); // 2.4.8+
             classRefF.setAccessible(true);
             for (Object entry : entries) {
-                Object value = getValueM.invoke(entry);
-                toRemove.add(((WeakReference<Class<?>>) classRefF.get(value)).get());
+                Object classInfo = getValueM.invoke(entry);
+                if (classInfo != null) {
+                    Class<?> clazz = ((WeakReference<Class<?>>) classRefF.get(classInfo)).get();
+                    if (clazz != null) {
+                        toRemove.add(clazz);
+                    }
+                }
             }
         } catch (NoSuchFieldException x) {
             Field klazzF = classInfoC.getDeclaredField("klazz"); // 2.4.7-


### PR DESCRIPTION
I ran into two unexpected NPEs in `CpsFlowExecution.cleanUpGlobalClassValue`. I have never seen them before, and I am not sure exactly what caused them. The user in question had a very complicated Pipeline library and a very active controller, which might be relevant. In both cases, I think we just want to ignore the unexpected `null`s and continue to attempt to clean up all other values. Here are the stack traces:

```
java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "o" is null
	at java.base/jdk.internal.reflect.UnsafeFieldAccessorImpl.ensureObj(UnsafeFieldAccessorImpl.java:57)
	at java.base/jdk.internal.reflect.UnsafeQualifiedObjectFieldAccessorImpl.get(UnsafeQualifiedObjectFieldAccessorImpl.java:38)
	at java.base/java.lang.reflect.Field.get(Field.java:425)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.cleanUpGlobalClassValue(CpsFlowExecution.java:1455)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.cleanUpLoader(CpsFlowExecution.java:1417)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.cleanUpHeap(CpsFlowExecution.java:1391)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:467)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:331)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:295)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:97)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:139)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at jenkins.util.ErrorLoggingExecutorService.lambda$wrap$0(ErrorLoggingExecutorService.java:51)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

```
java.lang.NullPointerException: Cannot invoke "java.lang.Class.getClassLoader()" because "klazz" is null
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.cleanUpGlobalClassValue(CpsFlowExecution.java:1468)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.cleanUpLoader(CpsFlowExecution.java:1417)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.cleanUpHeap(CpsFlowExecution.java:1391)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:467)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:331)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:295)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:97)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:139)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at jenkins.util.ErrorLoggingExecutorService.lambda$wrap$0(ErrorLoggingExecutorService.java:51)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

In this PR I am also cleaning up old obsolete code paths related to Groovy 2.4.7 and older for clarity. You can review each commit independently if desired.

I was unable to reproduce these issues in tests, and after further review of the upstream Groovy code I have no hypothesis as to how they occurred in the first place. It still seems worth making the minor changes here to avoid NPEs though.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
