### PR TITLE
Avoid holding locks from `croak` when calling `notifyListeners`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -933,7 +933,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                 LOGGER.log(Level.WARNING, "Failed to create placeholder nodes in " + owner, x);
             }
         } else {
-            onProgramEnd(new Outcome(null, t));
+            onProgramEnd(new Outcome(null, t), true);
         }
         cleanUpHeap();
         try {
@@ -1346,7 +1346,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
      * Record the end of the build.  Note: we should always follow this with a call to {@link #saveOwner()} to persist the result.
      * @param outcome success; or a normal failure (uncaught exception); or a fatal error in VM machinery
      */
-    synchronized void onProgramEnd(Outcome outcome) {
+    synchronized void onProgramEnd(Outcome outcome, boolean asynchNotifications) {
         FlowNode head = new FlowEndNode(this, iotaStr(), (FlowStartNode)startNodes.pop(), result, getCurrentHeads().toArray(new FlowNode[0]));
         if (outcome.isFailure()) {
             head.addAction(new ErrorAction(outcome.getAbnormal()));
@@ -1356,7 +1356,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         try {
             FlowHead first = getFirstHead();
             if (first != null) {
-                first.setNewHead(head);
+                first.setNewHead(head, asynchNotifications);
                 done = true;  // After setting the final head
                 heads.clear();
                 heads.put(first.getId(), first);

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -60,7 +60,6 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -454,7 +453,7 @@ public final class CpsThreadGroup implements Serializable {
                     runtimeThreads.remove(t.id);
                     t.cleanUp();
                     if (runtimeThreads.isEmpty()) {
-                        execution.onProgramEnd(o);
+                        execution.onProgramEnd(o, false);
                         try {
                             this.execution.saveOwner();
                         } catch (Exception ex) {


### PR DESCRIPTION
Trying to fix

```
Found one Java-level deadlock:
=============================
"Handling GET /…/job/main/ from … : Jetty (winstone)-17 Job/index.jelly WorkflowJob/sidepanel.jelly HistoryWidget/index.jelly":
  waiting to lock monitor 0x00007f2714a7b680 (object 0x0000000672800000, a org.jenkinsci.plugins.workflow.cps.CpsFlowExecution),
    which is held by "jenkins.util.Timer [#5]"
    
    "jenkins.util.Timer [#5]":
      waiting to lock monitor 0x00007f26a0200300 (object 0x00000006728000a0, a java.lang.Object),
        which is held by "Handling GET /…/job/main/ from … : Jetty (winstone)-17 Job/index.jelly WorkflowJob/sidepanel.jelly HistoryWidget/index.jelly"
	
	Java stack information for the threads listed above:
	===================================================
	"Handling GET /…/job/main/ from … : Jetty (winstone)-17 Job/index.jelly WorkflowJob/sidepanel.jelly HistoryWidget/index.jelly":
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.isComplete(CpsFlowExecution.java:1323)
	- waiting to lock <0x0000000672800000> (a org.jenkinsci.plugins.workflow.cps.CpsFlowExecution)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.getCurrentExecutions(CpsFlowExecution.java:1057)
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$ResumeStepExecutionListener.onResumed(FlowExecutionList.java:309)
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionListener.fireResumed(FlowExecutionListener.java:85)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:589)
	- locked <0x00000006728000a0> (a java.lang.Object)
	at hudson.model.RunMap.retrieve(RunMap.java:273)
	at hudson.model.RunMap.retrieve(RunMap.java:65)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:703)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:685)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.getByNumber(AbstractLazyLoadRunMap.java:579)
	- locked <0x00000005e55ca3f0> (a hudson.model.RunMap)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.search(AbstractLazyLoadRunMap.java:537)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.newestBuild(AbstractLazyLoadRunMap.java:470)
	at jenkins.model.lazy.LazyBuildMixIn.getLastBuild(LazyBuildMixIn.java:254)
	at org.jenkinsci.plugins.workflow.job.WorkflowJob.getLastBuild(WorkflowJob.java:242)
	at org.jenkinsci.plugins.workflow.job.WorkflowJob.getLastBuild(WorkflowJob.java:105)
	at hudson.model.Job.getBuildHealthReports(Job.java:1215)
	at …
	"jenkins.util.Timer [#5]":
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.finish(WorkflowRun.java:629)
	- waiting to lock <0x00000006728000a0> (a java.lang.Object)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1068)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1565)
	at org.jenkinsci.plugins.workflow.cps.FlowHead.setNewHead(FlowHead.java:164)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onProgramEnd(CpsFlowExecution.java:1342)
	- locked <0x0000000672800000> (a org.jenkinsci.plugins.workflow.cps.CpsFlowExecution)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.croak(CpsFlowExecution.java:919)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.loadProgramFailed(CpsFlowExecution.java:902)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$2.onFailure(CpsFlowExecution.java:879)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$2.onSuccess(CpsFlowExecution.java:867)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$2.onSuccess(CpsFlowExecution.java:855)
	at …
	at org.jenkinsci.plugins.workflow.support.pickles.TryRepeatedly.access$000(TryRepeatedly.java:48)
	at org.jenkinsci.plugins.workflow.support.pickles.TryRepeatedly$1.run(TryRepeatedly.java:114)
	at …
```
