### PR TITLE
`CpsFlowExecutionTest.iterateAfterSuspend` flaky

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -240,6 +240,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1676,7 +1676,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                         if (cpsExec.programPromise != null) {
                             cpsExec.runInCpsVmThread(new FutureCallback<>() {
                                 @Override public void onSuccess(CpsThreadGroup g) {
-                                    LOGGER.fine(() -> "shutting down CPS VM threadin for " + cpsExec);
+                                    LOGGER.fine(() -> "shutting down CPS VM for " + cpsExec);
                                     g.shutdown();
                                 }
                                 @Override public void onFailure(Throwable t) {

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -73,6 +73,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
@@ -207,6 +208,7 @@ public class CpsFlowExecutionTest {
 
     @Test public void iterateAfterSuspend() throws Throwable {
         sessions.then(r -> {
+            logger.record(CpsFlowExecution.class, Level.FINE);
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "iterateAfterSuspend");
             p.setDefinition(new CpsFlowDefinition("semaphore 'wait'", true));
             SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
@@ -226,7 +228,7 @@ public class CpsFlowExecutionTest {
             return; // different test
         }
         try {
-            assertThat(p.getLastBuild().getExecution().getCurrentExecutions(false).get(), empty());
+            await().until(() -> p.getLastBuild().getExecution().getCurrentExecutions(false).get(), empty());
         } catch (Throwable t) {
             iterateAfterSuspendError.set(t);
         }


### PR DESCRIPTION
Introduced in #797, and seems to flake a lot, e.g.: https://github.com/jenkinsci/workflow-cps-plugin/runs/31557729869

Reproducible using

```diff
diff --git plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
index 51518e6f..519e1f14 100644
--- plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -652,6 +652,11 @@ public final class CpsThreadGroup implements Serializable {
     }
 
     void shutdown() {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException x) {
+            x.printStackTrace();
+        }
         runner.shutdown();
     }
 
```