### PR TITLE
[JENKINS-74884] Tie RunningFlowActions factory to a specific type of action

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpAction.java
@@ -6,7 +6,6 @@ import com.cloudbees.jenkins.support.api.Content;
 import com.google.common.util.concurrent.FutureCallback;
 import hudson.Extension;
 import hudson.Functions;
-import hudson.model.Action;
 import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.security.Permission;
@@ -38,7 +37,7 @@ import org.kohsuke.stapler.WebMethod;
 /**
  * Shows thread dump for {@link CpsFlowExecution}.
  */
-public final class CpsThreadDumpAction implements Action {
+public final class CpsThreadDumpAction extends RunningFlowAction {
 
     private final CpsFlowExecution execution;
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/PauseUnpauseAction.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/PauseUnpauseAction.java
@@ -24,14 +24,13 @@
 
 package org.jenkinsci.plugins.workflow.cps;
 
-import hudson.model.Action;
 import java.io.IOException;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
  * Allows a running flow to be paused or unpaused.
  */
-public class PauseUnpauseAction implements Action {
+public class PauseUnpauseAction extends RunningFlowAction {
 
     static final String URL = "pause";
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/RunningFlowAction.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/RunningFlowAction.java
@@ -1,0 +1,11 @@
+package org.jenkinsci.plugins.workflow.cps;
+
+import hudson.model.Action;
+
+/**
+ * Parent class for transient {@link hudson.model.Action}s of running pipeline builds.
+ * @see org.jenkinsci.plugins.workflow.cps.RunningFlowActions
+ */
+public abstract class RunningFlowAction implements Action {
+
+}

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/RunningFlowActions.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/RunningFlowActions.java
@@ -40,7 +40,12 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
  * Adds actions to the sidebar of a running Pipeline build.
  */
 @Extension public class RunningFlowActions extends TransientActionFactory<FlowExecutionOwner.Executable> {
-    
+
+    @Override
+    public Class<? extends Action> actionType() {
+        return RunningFlowAction.class;
+    }
+
     @Override public Class<FlowExecutionOwner.Executable> type() {
         return FlowExecutionOwner.Executable.class;
     }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/RunningFlowActionsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/RunningFlowActionsTest.java
@@ -1,0 +1,51 @@
+package org.jenkinsci.plugins.workflow.cps;
+
+import hudson.model.Action;
+import jenkins.model.TransientActionFactory;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+public class RunningFlowActionsTest {
+
+    // JenkinsRule required for initialization of TransientActionFactory cache
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test public void noRunningFlowActionsIfTypeIrrelevant() {
+        assertThat(TransientActionFactory.factoriesFor(WorkflowRun.class, TestNotARunningFlowAction.class),
+            not(hasItem(instanceOf(RunningFlowActions.class))));
+        assertThat(TransientActionFactory.factoriesFor(FlowExecutionOwner.Executable.class, TestNotARunningFlowAction.class),
+            not(hasItem(instanceOf(RunningFlowActions.class))));
+        assertThat(TransientActionFactory.factoriesFor(FlowExecutionOwner.Executable.class, RunningFlowAction.class),
+            hasItems(instanceOf(RunningFlowActions.class)));
+    }
+
+    @TestExtension("testNotARunningFlowAction")
+    public static class TestNotARunningFlowAction implements Action {
+
+        @Override
+        public String getIconFileName() {
+            return "";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "";
+        }
+
+        @Override
+        public String getUrlName() {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
[JENKINS-73984](https://issues.jenkins.io/browse/JENKINS-73984) Add a parent abstract Action and tie the factory to this type of action to avoid un-necessary consultation from `Actionable#getAction[s]`.

### Testing done

* Run a pipeline with Input step
* Verify that the Pause Action is displayed
* Verify that the Thread Dump Action is displayed

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue