### PR TITLE
Allow `SnippetizerTester` to compile against new cores

### DIFF
--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTester.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTester.java
@@ -85,7 +85,7 @@ public class SnippetizerTester {
         List<NameValuePair> params = new ArrayList<>();
         params.add(new NameValuePair("json", json));
         // WebClient.addCrumb *replaces* rather than *adds*:
-        params.add(new NameValuePair(r.jenkins.getCrumbIssuer().getDescriptor().getCrumbRequestField(), r.jenkins.getCrumbIssuer().getCrumb(null)));
+        params.add(new NameValuePair(r.jenkins.getCrumbIssuer().getDescriptor().getCrumbRequestField(), r.jenkins.getCrumbIssuer().getCrumb()));
         wrs.setRequestParameters(params);
         WebResponse response = wc.getPage(wrs).getWebResponse();
         assertEquals("text/plain", response.getContentType());


### PR DESCRIPTION
The one source code change needed to allow use of a 5.x parent and 2.479.x baseline.