### PR TITLE
Diagnostics for `FlowDurabilityTest`

### DIFF
--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -63,7 +63,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
 import org.junit.Assume;
+import org.jvnet.hudson.test.LoggerRule;
 
 /**
  * Tests implementations designed to verify handling of the flow durability levels and persistence of pipeline state.
@@ -86,6 +88,9 @@ public class FlowDurabilityTest {
 
     @Rule
     public TimedRepeatRule repeater = new TimedRepeatRule();
+
+    @Rule
+    public LoggerRule logging = new LoggerRule().record(WorkflowRun.class, Level.FINE);
 
     // Used in Race-condition/persistence fuzzing where we need to run repeatedly
     static class TimedRepeatRule implements TestRule {


### PR DESCRIPTION
Get occasional flakes in CI in `FlowDurabilityTest.testPauseForcesLowDurabilityToPersist` and some others ([CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-22302)) that I do not understand:

```
org.junit.runners.model.TestTimedOutException: test timed out after 180 seconds
	at java.base@17.0.13/java.lang.Object.wait(Native Method)
	at app//org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.get(WorkflowRun.java:985)
	at app//org.jenkinsci.plugins.workflow.flow.FlowExecutionList.resume(FlowExecutionList.java:226)
	at app//org.jenkinsci.plugins.workflow.flow.FlowExecutionList$ItemListenerImpl.onLoaded(FlowExecutionList.java:217)
	at app//jenkins.model.Jenkins.<init>(Jenkins.java:1070)
	at …
```

After the restart, there are no warnings about the test build, and nothing in the log beyond

```
   0.612 [id=279]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
 180.001 [id=1]	WARNING	o.j.hudson.test.JenkinsRule$2#evaluate: Test timed out (after 180 seconds).
 180.002 [id=263]	WARNING	o.j.p.w.job.WorkflowRun$Owner#get: failed to wait for durableAgainstClean #1 to be loaded
java.lang.InterruptedException
	at java.base/java.lang.Object.wait(Native Method)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.get(WorkflowRun.java:985)
	at …
```

and no other threads active. It is as if `RunMap.retrieve` calls `reload` (via `<init>`) but not `onLoad`? No real hypothesis at this point. The test cases in this class generally are clearly prone to flakiness (see the various `sleep` steps and `Thread.sleep` calls with no guard) but seem potentially important so I am reluctant to just disable them.
