### PR TITLE
Adapt `SerialFormTest` to removal of `commons-compress`

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -49,15 +49,10 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.426.x</artifactId>
-                <version>3023.v02a_987a_b_3ff9</version>
+                <artifactId>bom-2.452.x</artifactId>
+                <version>3696.vb_b_4e2d1a_0542</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>script-security</artifactId>
-                <version>1369.v9b_98a_4e95b_2d</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -235,10 +230,6 @@
             <scope>test</scope>
             <exclusions>
                 <!-- Provided by Jenkins core -->
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-compress</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.426.3</jenkins.version>
+        <jenkins.version>2.452.4</jenkins.version>
         <groovy.version>2.4.21</groovy.version> <!-- TODO: Add org.codehaus.groovy:groovy and org.codehaus.groovy:groovy:sources to Jenkins core BOM so this can be deleted? (currently it only specifies groovy-all) -->
     </properties>
     <modules>


### PR DESCRIPTION
PCT on Docker-enabled hosts failed after https://github.com/jenkinsci/jenkins/pull/9958 due to https://github.com/jenkinsci/workflow-cps-plugin/blob/5198556e9cead606cba728340bb6be96365a10e6/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/SerialFormTest.java#L87 missing a dep. Also bumped baseline/BOM to pick up https://github.com/jenkinsci/support-core-plugin/pull/545 (fixing some warnings in the log) and to clean up after #952.