### PR TITLE
[JENKINS-75067] Unexport step bodies when completed in synchronous mode

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
@@ -359,6 +359,12 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
      */
     private void scheduleNextRun() {
         if (syncMode) {
+            // probably rare for a legit sync step to have a body, but it's possible for a (typically) async step
+            // to be *treated* as sync due to having an outcome set prematurely (e.g. from a StepListener)
+            if (threadGroup != null && body != null) {
+                threadGroup.unexport(body);
+                body = null;
+            }
             // if we get the result set before the start method returned, then DSL.invokeMethod() will
             // plan the next action.
             return;

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
@@ -359,8 +359,9 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
      */
     private void scheduleNextRun() {
         if (syncMode) {
-            // probably rare for a legit sync step to have a body, but it's possible for a (typically) async step
-            // to be *treated* as sync due to having an outcome set prematurely (e.g. from a StepListener)
+            // probably rare for a legit sync step to have a body (unless short-circuiting execution of the body, as
+            // running a body in sync mode is not allowed), but it's possible for a (typically) async step to be
+            // *treated* as sync due to having an outcome set prematurely (e.g. from a StepListener)
             if (threadGroup != null && body != null) {
                 threadGroup.unexport(body);
                 body = null;

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/StepListenerTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/StepListenerTest.java
@@ -24,28 +24,48 @@
 
 package org.jenkinsci.plugins.workflow;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.AbortException;
+import hudson.ExtensionList;
+import hudson.model.Result;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+import org.jenkinsci.plugins.workflow.cps.CpsThreadGroup;
+import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.flow.StepListener;
+import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.logging.Level;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 
 public class StepListenerTest {
-    @ClassRule
-    public static JenkinsRule r = new JenkinsRule();
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @Rule
+    public LoggerRule logger = new LoggerRule();
 
     @Issue("JENKINS-58084")
     @Test
@@ -59,7 +79,7 @@ public class StepListenerTest {
         r.assertLogContains("Step listener saw step echo", build);
     }
 
-    @TestExtension
+    @TestExtension("listener")
     public static class TestStepListener implements StepListener {
         @Override
         public void notifyOfNewStep(@NonNull Step s, @NonNull StepContext context) {
@@ -72,6 +92,50 @@ public class StepListenerTest {
             } catch (Exception e) {
                 // Don't care.
             }
+        }
+    }
+
+    @Issue("JENKINS-75067")
+    @Test
+    public void failingListener() throws Exception {
+        // Even before the fix there's only one warning logged.  Asserting zero records is probably over-stepping,
+        // but asserting just one record with our target message risks a false negative (some other unrelated message
+        // being first, and our being later).
+        logger.record(CpsThreadGroup.class, Level.WARNING).capture(10);
+        WorkflowJob job = r.createProject(WorkflowJob.class, "failingListener");
+        job.setDefinition(new CpsFlowDefinition("node {}\n", true));
+
+        WorkflowRun build = r.buildAndAssertStatus(Result.FAILURE, job);
+        r.assertLogContains("oops", build);
+        assertThat(TestFailingStepListener.get().closureCount, equalTo(0));
+        assertThat(logger.getMessages(), not(hasItem(containsString("Stale closure"))));
+    }
+
+    @TestExtension("failingListener")
+    public static class TestFailingStepListener implements StepListener, GraphListener.Synchronous {
+        int closureCount = -1;
+
+        @Override
+        public void notifyOfNewStep(@NonNull Step s, @NonNull StepContext context) {
+            context.onFailure(new AbortException("oops"));
+        }
+
+        @Override
+        public void onNewHead(FlowNode node) {
+            // this only works using a Synchronous listener, otherwise the fall-back closure cleaning
+            // will have already executed prior to receiving this event
+            if (node instanceof FlowEndNode) {
+              try {
+                closureCount = ((CpsFlowExecution) node.getExecution()).programPromise.get().closures.size();
+              }
+              catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            }
+        }
+
+        static TestFailingStepListener get() {
+            return ExtensionList.lookupSingleton(TestFailingStepListener.class);
         }
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/StepListenerTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/StepListenerTest.java
@@ -24,48 +24,28 @@
 
 package org.jenkinsci.plugins.workflow;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.AbortException;
-import hudson.ExtensionList;
-import hudson.model.Result;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
-import org.jenkinsci.plugins.workflow.cps.CpsThreadGroup;
-import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.flow.StepListener;
-import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
-import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
 
-import java.util.logging.Level;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.not;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class StepListenerTest {
-    @Rule
-    public JenkinsRule r = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule();
 
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
-
-    @Rule
-    public LoggerRule logger = new LoggerRule();
 
     @Issue("JENKINS-58084")
     @Test
@@ -79,7 +59,7 @@ public class StepListenerTest {
         r.assertLogContains("Step listener saw step echo", build);
     }
 
-    @TestExtension("listener")
+    @TestExtension
     public static class TestStepListener implements StepListener {
         @Override
         public void notifyOfNewStep(@NonNull Step s, @NonNull StepContext context) {
@@ -92,50 +72,6 @@ public class StepListenerTest {
             } catch (Exception e) {
                 // Don't care.
             }
-        }
-    }
-
-    @Issue("JENKINS-75067")
-    @Test
-    public void failingListener() throws Exception {
-        // Even before the fix there's only one warning logged.  Asserting zero records is probably over-stepping,
-        // but asserting just one record with our target message risks a false negative (some other unrelated message
-        // being first, and our being later).
-        logger.record(CpsThreadGroup.class, Level.WARNING).capture(10);
-        WorkflowJob job = r.createProject(WorkflowJob.class, "failingListener");
-        job.setDefinition(new CpsFlowDefinition("node {}\n", true));
-
-        WorkflowRun build = r.buildAndAssertStatus(Result.FAILURE, job);
-        r.assertLogContains("oops", build);
-        assertThat(TestFailingStepListener.get().closureCount, equalTo(0));
-        assertThat(logger.getMessages(), not(hasItem(containsString("Stale closure"))));
-    }
-
-    @TestExtension("failingListener")
-    public static class TestFailingStepListener implements StepListener, GraphListener.Synchronous {
-        int closureCount = -1;
-
-        @Override
-        public void notifyOfNewStep(@NonNull Step s, @NonNull StepContext context) {
-            context.onFailure(new AbortException("oops"));
-        }
-
-        @Override
-        public void onNewHead(FlowNode node) {
-            // this only works using a Synchronous listener, otherwise the fall-back closure cleaning
-            // will have already executed prior to receiving this event
-            if (node instanceof FlowEndNode) {
-              try {
-                closureCount = ((CpsFlowExecution) node.getExecution()).programPromise.get().closures.size();
-              }
-              catch (Exception e) {
-                throw new RuntimeException(e);
-              }
-            }
-        }
-
-        static TestFailingStepListener get() {
-            return ExtensionList.lookupSingleton(TestFailingStepListener.class);
         }
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
@@ -1,0 +1,203 @@
+package org.jenkinsci.plugins.workflow.cps;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.AbortException;
+import hudson.ExtensionList;
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.flow.GraphListener;
+import org.jenkinsci.plugins.workflow.flow.StepListener;
+import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.Set;
+import java.util.logging.Level;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+public class CpsStepContextTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @Rule
+    public LoggerRule logger = new LoggerRule();
+
+    @Issue("JENKINS-75067")
+    @Test
+    public void failingStepListenerNotLeakClosures() throws Exception {
+        // Even before the fix there's only one warning logged.  Asserting zero records is probably over-stepping,
+        // but asserting just one record with our target message risks a false negative (some other unrelated message
+        // being first, and our being later).
+        logger.record(CpsThreadGroup.class, Level.WARNING).capture(10);
+        WorkflowJob job = r.createProject(WorkflowJob.class, "p");
+        job.setDefinition(new CpsFlowDefinition("node {}\n", true));
+
+        WorkflowRun build = r.buildAndAssertStatus(Result.FAILURE, job);
+        r.assertLogContains("oops", build);
+        assertThat(ClosureCounter.get().closureCount, equalTo(0));
+        assertThat(logger.getMessages(), not(hasItem(containsString("Stale closure"))));
+    }
+
+    @TestExtension("failingStepListenerNotLeakClosures")
+    public static class FailingStepListener implements StepListener {
+
+        @Override
+        public void notifyOfNewStep(@NonNull Step s, @NonNull StepContext context) {
+            context.onFailure(new AbortException("oops"));
+        }
+    }
+
+    @Issue("JENKINS-75067")
+    @Test
+    public void executionStartExceptionNotLeakClosures() throws Exception {
+        logger.record(CpsThreadGroup.class, Level.WARNING).capture(10);
+        WorkflowJob job = r.createProject(WorkflowJob.class, "p");
+        job.setDefinition(new CpsFlowDefinition("badBlock {}\n", true));
+
+        WorkflowRun build = r.buildAndAssertStatus(Result.FAILURE, job);
+        r.assertLogContains("oops", build);
+        assertThat(ClosureCounter.get().closureCount, equalTo(0));
+        assertThat(logger.getMessages(), not(hasItem(containsString("Stale closure"))));
+    }
+
+    @Issue("JENKINS-75067")
+    @Test
+    public void executionWithBodyRunningSyncNotLeakClosures() throws Exception {
+        logger.record(CpsThreadGroup.class, Level.WARNING).capture(10);
+        WorkflowJob job = r.createProject(WorkflowJob.class, "p");
+        job.setDefinition(new CpsFlowDefinition("echo passthrough {}\n", true));
+
+        WorkflowRun build = r.buildAndAssertSuccess(job);
+        r.assertLogContains("hooray", build);
+        assertThat(ClosureCounter.get().closureCount, equalTo(0));
+        assertThat(logger.getMessages(), not(hasItem(containsString("Stale closure"))));
+    }
+
+    public static class BadBlockStep extends Step {
+
+        @DataBoundConstructor
+        public BadBlockStep() {}
+
+        @Override
+        public StepExecution start(StepContext context) throws Exception {
+            return new Execution(context);
+        }
+
+        public static class Execution extends StepExecution {
+
+            public Execution(StepContext context) {
+                super(context);
+            }
+
+            @Override
+            public boolean start() throws Exception {
+                throw new RuntimeException("oops");
+            }
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends StepDescriptor {
+
+            @Override
+            public Set<? extends Class<?>> getRequiredContext() {
+                return Set.of();
+            }
+
+            @Override
+            public String getFunctionName() {
+                return "badBlock";
+            }
+
+            @Override
+            public boolean takesImplicitBlockArgument() {
+                return true;
+            }
+        }
+    }
+
+    public static class PassthroughStep extends Step {
+
+        @DataBoundConstructor
+        public PassthroughStep() {}
+
+        @Override
+        public StepExecution start(StepContext context) throws Exception {
+            return new Execution(context);
+        }
+
+        public static class Execution extends StepExecution {
+            public Execution(StepContext context) {
+                super(context);
+            }
+
+            @Override
+            public boolean start() throws Exception {
+                getContext().onSuccess("hooray");
+                return true;
+            }
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends StepDescriptor {
+
+            @Override
+            public Set<? extends Class<?>> getRequiredContext() {
+                return Set.of();
+            }
+
+            @Override
+            public String getFunctionName() {
+                return "passthrough";
+            }
+
+            @Override
+            public boolean takesImplicitBlockArgument() {
+                return true;
+            }
+        }
+    }
+
+    @TestExtension
+    public static class ClosureCounter implements GraphListener.Synchronous {
+        int closureCount = -1;
+
+        @Override
+        public void onNewHead(FlowNode node) {
+            // this only works using a Synchronous listener, otherwise the fall-back closure cleaning
+            // will have already executed prior to receiving this event
+            if (node instanceof FlowEndNode) {
+                try {
+                    closureCount = ((CpsFlowExecution) node.getExecution()).programPromise.get().closures.size();
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        static ClosureCounter get() {
+            return ExtensionList.lookupSingleton(ClosureCounter.class);
+        }
+    }
+}

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
@@ -133,19 +133,9 @@ public class CpsStepContextTest {
 
         @Override
         public StepExecution start(StepContext context) throws Exception {
-            return new Execution(context);
-        }
-
-        public static class Execution extends StepExecution {
-            public Execution(StepContext context) {
-                super(context);
-            }
-
-            @Override
-            public boolean start() throws Exception {
-                getContext().onSuccess("hooray");
-                return true;
-            }
+            return StepExecutions.synchronous(context, ctx -> {
+                return "hooray";
+            });
         }
 
         @TestExtension

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
@@ -87,7 +87,7 @@ public class CpsStepContextTest {
     public void executionWithBodyRunningSyncNotLeakClosures() throws Exception {
         logger.record(CpsThreadGroup.class, Level.WARNING).capture(10);
         WorkflowJob job = r.createProject(WorkflowJob.class, "p");
-        job.setDefinition(new CpsFlowDefinition("echo passthrough {}\n", true));
+        job.setDefinition(new CpsFlowDefinition("def r = passthrough {}; echo r", true));
 
         WorkflowRun build = r.buildAndAssertSuccess(job);
         r.assertLogContains("hooray", build);

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
@@ -74,7 +74,7 @@ public class CpsStepContextTest {
     public void executionStartExceptionNotLeakClosures() throws Exception {
         logger.record(CpsThreadGroup.class, Level.WARNING).capture(10);
         WorkflowJob job = r.createProject(WorkflowJob.class, "p");
-        job.setDefinition(new CpsFlowDefinition("badBlock {}\n", true));
+        job.setDefinition(new CpsFlowDefinition("badBlock {}", true));
 
         WorkflowRun build = r.buildAndAssertStatus(Result.FAILURE, job);
         r.assertLogContains("oops", build);

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
@@ -14,6 +14,7 @@ import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepExecutions;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
@@ -106,7 +106,7 @@ public class CpsStepContextTest {
         });
         }
 
-        @TestExtension
+        @TestExtension("executionStartExceptionNotLeakClosures")
         public static class DescriptorImpl extends StepDescriptor {
 
             @Override

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
@@ -52,7 +52,7 @@ public class CpsStepContextTest {
         // being first, and our being later).
         logger.record(CpsThreadGroup.class, Level.WARNING).capture(10);
         WorkflowJob job = r.createProject(WorkflowJob.class, "p");
-        job.setDefinition(new CpsFlowDefinition("node {}\n", true));
+        job.setDefinition(new CpsFlowDefinition("node {}", true));
 
         WorkflowRun build = r.buildAndAssertStatus(Result.FAILURE, job);
         r.assertLogContains("oops", build);

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
@@ -138,7 +138,7 @@ public class CpsStepContextTest {
             });
         }
 
-        @TestExtension
+        @TestExtension("executionWithBodyRunningSyncNotLeakClosures")
         public static class DescriptorImpl extends StepDescriptor {
 
             @Override

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsStepContextTest.java
@@ -101,19 +101,9 @@ public class CpsStepContextTest {
 
         @Override
         public StepExecution start(StepContext context) throws Exception {
-            return new Execution(context);
-        }
-
-        public static class Execution extends StepExecution {
-
-            public Execution(StepContext context) {
-                super(context);
-            }
-
-            @Override
-            public boolean start() throws Exception {
-                throw new RuntimeException("oops");
-            }
+        return StepExecutions.synchronous(context, ctx -> {
+            throw new AbortException("oops");
+        });
         }
 
         @TestExtension


### PR DESCRIPTION
Previously, the unexport of a step's body would only happen when scheduling the next execution (async mode).  If the step was not run async (due to having an outcome set prior to the step starting), the body was not removed until the CpsThreadGroup was finishing.  At this point the body's presence was treated as a resource leak and logged a warning.  Doing an explicit unexport for the sync case at the proper time eliminates the warnings from the fall-back cleanup.

<!-- Please describe your pull request here. -->
Potential fix for https://issues.jenkins.io/browse/JENKINS-75067

I'm not sure if this solution is "correct", but it logically makes sense and all existing tests continue to pass.  Even if the proper fix is different (and/or best handled by you folks), I figured this PR could still prove valuable by providing a test case.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
I created a new test representing the scenario that led me to creating the original issue.  There are two relevant assertions; both fail without my change, and pass after the change.  I don't think both are needed, but didn't know which would be preferred.  The assertion for the (lack of) warning log is obviously simpler and asserts what I truly cared about.  The other asserts based on state, which seemed to be the better approach, but feels a bit heavy/hacky (but it's the best I could come up with without touching unrelated code).


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
