### PR TITLE
Override `CallEnv.toString`

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
@@ -132,4 +132,10 @@ import java.util.Map;
     public int getDepth() {
         return depth;
     }
+
+    @Override
+    public String toString() {
+        return callSiteLoc != null ? super.toString() + " @" + callSiteLoc : super.toString();
+    }
+
 }


### PR DESCRIPTION
Useful in https://github.com/jenkinsci/workflow-support-plugin/pull/305, and possibly elsewhere.