### PR TITLE
Warn user when forgetting `def` on a variable

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
@@ -138,12 +138,17 @@ final class LoggingInvoker implements Invoker {
         Class<?> clazz = classOf(lhs);
         maybeRecord(clazz, () -> clazz.getName() + "." + name);
         delegate.setProperty(lhs, name, value);
-        var g = CpsThreadGroup.current();
-        if (g != null) {
-            var e = g.getExecution();
-            if (e != null) {
-                e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(findOwner(lhs).getClass().getName(), name, value.getClass().getName()));
-                assert false : "TODO look for false positives";
+        if (value != null) {
+            var owner = findOwner(lhs);
+            if (owner instanceof CpsScript) {
+                var g = CpsThreadGroup.current();
+                if (g != null) {
+                    var e = g.getExecution();
+                    if (e != null) {
+                        e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(findOwner(lhs).getClass().getName(), name, value.getClass().getName()));
+                        assert false : "TODO look for false positives";
+                    }
+                }
             }
         }
     }

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
@@ -142,11 +142,16 @@ final class LoggingInvoker implements Invoker {
             if (value != null) {
                 var owner = findOwner(lhs);
                 if (owner instanceof CpsScript) {
-                    var g = CpsThreadGroup.current();
-                    if (g != null) {
-                        var e = g.getExecution();
-                        if (e != null) {
-                            e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(owner.getClass().getSimpleName(), name, value.getClass().getSimpleName()));
+                    try {
+                        owner.getClass().getDeclaredField(name);
+                        // OK, @Field, ignore
+                    } catch (NoSuchFieldException x) {
+                        var g = CpsThreadGroup.current();
+                        if (g != null) {
+                            var e = g.getExecution();
+                            if (e != null) {
+                                e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(owner.getClass().getSimpleName(), name, value.getClass().getSimpleName()));
+                            }
                         }
                     }
                 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
@@ -138,14 +138,16 @@ final class LoggingInvoker implements Invoker {
         Class<?> clazz = classOf(lhs);
         maybeRecord(clazz, () -> clazz.getName() + "." + name);
         delegate.setProperty(lhs, name, value);
-        if (value != null) {
-            var owner = findOwner(lhs);
-            if (owner instanceof CpsScript) {
-                var g = CpsThreadGroup.current();
-                if (g != null) {
-                    var e = g.getExecution();
-                    if (e != null) {
-                        e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(owner.getClass().getSimpleName(), name, value.getClass().getSimpleName()));
+        if (SystemProperties.getBoolean(LoggingInvoker.class.getName() + ".fieldSetWarning", true)) {
+            if (value != null) {
+                var owner = findOwner(lhs);
+                if (owner instanceof CpsScript) {
+                    var g = CpsThreadGroup.current();
+                    if (g != null) {
+                        var e = g.getExecution();
+                        if (e != null) {
+                            e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(owner.getClass().getSimpleName(), name, value.getClass().getSimpleName()));
+                        }
                     }
                 }
             }

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
@@ -30,6 +30,7 @@ import com.cloudbees.groovy.cps.sandbox.Invoker;
 import com.cloudbees.groovy.cps.sandbox.SandboxInvoker;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import groovy.lang.Closure;
 import groovy.lang.GroovyClassLoader;
 import hudson.ExtensionList;
 import java.util.Set;
@@ -137,6 +138,18 @@ final class LoggingInvoker implements Invoker {
         Class<?> clazz = classOf(lhs);
         maybeRecord(clazz, () -> clazz.getName() + "." + name);
         delegate.setProperty(lhs, name, value);
+        var g = CpsThreadGroup.current();
+        if (g != null) {
+            var e = g.getExecution();
+            if (e != null) {
+                e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(findOwner(lhs).getClass().getName(), name, value.getClass().getName()));
+                assert false : "TODO look for false positives";
+            }
+        }
+    }
+
+    private Object findOwner(Object o) {
+        return o instanceof Closure<?> c ? findOwner(c.getOwner()) : o;
     }
 
     @Override public Object getAttribute(Object lhs, String name) throws Throwable {

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
@@ -145,7 +145,7 @@ final class LoggingInvoker implements Invoker {
                 if (g != null) {
                     var e = g.getExecution();
                     if (e != null) {
-                        e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(findOwner(lhs).getClass().getName(), name, value.getClass().getName()));
+                        e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(findOwner(lhs).getClass().getName(), name, value.getClass().getSimpleName()));
                     }
                 }
             }

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
@@ -146,7 +146,6 @@ final class LoggingInvoker implements Invoker {
                     var e = g.getExecution();
                     if (e != null) {
                         e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(findOwner(lhs).getClass().getName(), name, value.getClass().getName()));
-                        assert false : "TODO look for false positives";
                     }
                 }
             }

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
@@ -145,7 +145,7 @@ final class LoggingInvoker implements Invoker {
                 if (g != null) {
                     var e = g.getExecution();
                     if (e != null) {
-                        e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(findOwner(lhs).getClass().getName(), name, value.getClass().getSimpleName()));
+                        e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(owner.getClass().getSimpleName(), name, value.getClass().getSimpleName()));
                     }
                 }
             }

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
@@ -7,4 +7,6 @@ SnippetizerLink.ExamplesLink.displayName=Examples Reference
 SnippetizerLink.GDSLLink.displayName=IntelliJ IDEA GDSL
 Pipeline.Syntax=Pipeline Syntax
 # TODO perhaps create a https://jenkins.io/redirect/pipeline-field-set/
-LoggingInvoker.field_set=Apparent field set (did you forget `def`?): {0}.{1}={2}
+LoggingInvoker.field_set=\
+  Did you forget the `def` keyword? {0} seems to be setting a field named {1} (to a value of type {2}) \
+  which could lead to memory leaks or other issues.

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
@@ -6,3 +6,4 @@ SnippetizerLink.OnlineDocsLink.displayName=Online Documentation
 SnippetizerLink.ExamplesLink.displayName=Examples Reference
 SnippetizerLink.GDSLLink.displayName=IntelliJ IDEA GDSL
 Pipeline.Syntax=Pipeline Syntax
+LoggingInvoker.field_set=Apparent field set (did you forget `def`?): {0}.{1}={2}

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
@@ -6,4 +6,5 @@ SnippetizerLink.OnlineDocsLink.displayName=Online Documentation
 SnippetizerLink.ExamplesLink.displayName=Examples Reference
 SnippetizerLink.GDSLLink.displayName=IntelliJ IDEA GDSL
 Pipeline.Syntax=Pipeline Syntax
+# TODO perhaps create a https://jenkins.io/redirect/pipeline-field-set/
 LoggingInvoker.field_set=Apparent field set (did you forget `def`?): {0}.{1}={2}

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Messages.properties
@@ -8,5 +8,6 @@ SnippetizerLink.GDSLLink.displayName=IntelliJ IDEA GDSL
 Pipeline.Syntax=Pipeline Syntax
 # TODO perhaps create a https://jenkins.io/redirect/pipeline-field-set/
 LoggingInvoker.field_set=\
-  Did you forget the `def` keyword? {0} seems to be setting a field named {1} (to a value of type {2}) \
+  Did you forget the `def` keyword? \
+  {0} seems to be setting a field named {1} (to a value of type {2}) \
   which could lead to memory leaks or other issues.

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
@@ -269,7 +269,7 @@ public class CpsBodyExecutionTest {
             }
             r.assertBuildStatusSuccess(r.waitForCompletion(b));
             new DepthFirstScanner().allNodes(b.getExecution()).stream().sorted(Comparator.comparing(n -> Integer.valueOf(n.getId()))).forEach(n -> System.out.println(n.getId() + " " + n.getDisplayName()));
-            r.assertLogContains(Messages.LoggingInvoker_field_set("WorkflowScript", "g", CpsClosure2.class.getSimpleName()), b);
+            r.assertLogContains(Messages.LoggingInvoker_field_set("WorkflowScript", "g", "CpsClosure2"), b);
         });
     }
 

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
@@ -269,7 +269,7 @@ public class CpsBodyExecutionTest {
             }
             r.assertBuildStatusSuccess(r.waitForCompletion(b));
             new DepthFirstScanner().allNodes(b.getExecution()).stream().sorted(Comparator.comparing(n -> Integer.valueOf(n.getId()))).forEach(n -> System.out.println(n.getId() + " " + n.getDisplayName()));
-            r.assertLogContains(Messages.LoggingInvoker_field_set("WorkflowScript", "g", CpsClosure2.class.getName()), b);
+            r.assertLogContains(Messages.LoggingInvoker_field_set("WorkflowScript", "g", CpsClosure2.class.getSimpleName()), b);
         });
     }
 

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecutionTest.java
@@ -269,6 +269,7 @@ public class CpsBodyExecutionTest {
             }
             r.assertBuildStatusSuccess(r.waitForCompletion(b));
             new DepthFirstScanner().allNodes(b.getExecution()).stream().sorted(Comparator.comparing(n -> Integer.valueOf(n.getId()))).forEach(n -> System.out.println(n.getId() + " " + n.getDisplayName()));
+            r.assertLogContains(Messages.LoggingInvoker_field_set("WorkflowScript", "g", CpsClosure2.class.getName()), b);
         });
     }
 

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -495,7 +495,7 @@ public class CpsFlowDefinition2Test {
     @Test
     public void multipleAssignmentFunctionCalledOnce() throws Exception {
         WorkflowJob job = jenkins.createProject(WorkflowJob.class);
-        job.setDefinition(new CpsFlowDefinition("alreadyRun = false\n" +
+        job.setDefinition(new CpsFlowDefinition("def alreadyRun = false\n" +
                 "def getAandB() {\n" +
                 "  if (!alreadyRun) {\n" +
                 "    alreadyRun = true\n" +

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -495,7 +495,7 @@ public class CpsFlowDefinition2Test {
     @Test
     public void multipleAssignmentFunctionCalledOnce() throws Exception {
         WorkflowJob job = jenkins.createProject(WorkflowJob.class);
-        job.setDefinition(new CpsFlowDefinition("def alreadyRun = false\n" +
+        job.setDefinition(new CpsFlowDefinition("alreadyRun = false\n" +
                 "def getAandB() {\n" +
                 "  if (!alreadyRun) {\n" +
                 "    alreadyRun = true\n" +

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorServiceTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsVmExecutorServiceTest.java
@@ -139,7 +139,7 @@ public class CpsVmExecutorServiceTest {
     @Test public void okCatcherMetaClassImpl() throws Exception {
         p.setDefinition(new CpsFlowDefinition(
             "import org.codehaus.groovy.runtime.InvokerHelper \n" + 
-            "c = { println 'doing a thing' } \n" +
+            "def c = { println 'doing a thing' } \n" +
             "InvokerHelper.getMetaClass(c).invokeMethod(c, 'call', null)", false));
         WorkflowRun b = r.buildAndAssertSuccess(p);
         r.assertLogNotContains("MetaClassImpl", b);
@@ -150,7 +150,7 @@ public class CpsVmExecutorServiceTest {
     @Test public void okCatcherExpandoMetaClass() throws Exception {
         p.setDefinition(new CpsFlowDefinition(
             "import org.codehaus.groovy.runtime.InvokerHelper \n" + 
-            "c = { println 'doing a thing' } \n" +
+            "def c = { println 'doing a thing' } \n" +
             "c.getMetaClass().someField = 'r' \n" + 
             "InvokerHelper.getMetaClass(c).invokeMethod(c, 'call', null)", false));
         WorkflowRun b = r.buildAndAssertSuccess(p);

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -351,7 +351,7 @@ public class DSLTest {
     * Tests the ability to execute a user defined closure with one arguments
     */
     @Test public void userDefinedClosure1ArgInvocationExecution() throws Exception {
-        p.setDefinition(new CpsFlowDefinition("my_closure = { String message -> \n" +
+        p.setDefinition(new CpsFlowDefinition("def my_closure = { String message -> \n" +
                                               "  echo message \n" +
                                               "}\n" + 
                                               "my_closure(\"my message!\") ", false));
@@ -363,7 +363,7 @@ public class DSLTest {
     * Tests the ability to execute a user defined closure with 2 arguments
     */
     @Test public void userDefinedClosure2ArgInvocationExecution() throws Exception {
-        p.setDefinition(new CpsFlowDefinition("my_closure = { String message1, String message2 -> \n" +
+        p.setDefinition(new CpsFlowDefinition("def my_closure = { String message1, String message2 -> \n" +
                                               "  echo \"my message is ${message1} and ${message2}\" \n" +
                                               "}\n" + 
                                               "my_closure(\"string1\", \"string2\") ", false));
@@ -375,7 +375,7 @@ public class DSLTest {
     * Tests untyped arguments 
     */
     @Test public void userDefinedClosureUntypedArgInvocationExecution() throws Exception {
-        p.setDefinition(new CpsFlowDefinition("my_closure = { a , b -> \n" +
+        p.setDefinition(new CpsFlowDefinition("def my_closure = { a , b -> \n" +
                                                       "  echo \"my message is ${a} and ${b}\" \n" +
                                                       "}\n" +
                                                       "my_closure(\"string1\" ,2)",false));

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayPipelineCommandTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayPipelineCommandTest.java
@@ -54,6 +54,7 @@ public class  ReplayPipelineCommandTest {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "SECURITY-3362");
         j.jenkins.getWorkspaceFor(p).child("a.groovy").write("echo 'Hello LoadedWorld'", null);
         String script =
+                "def a\n" +
                 "node() {\n" +
                 "    a = load('a.groovy')\n" +
                 "}\n";

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/steps/ParallelStepTest.java
@@ -66,7 +66,7 @@ public class ParallelStepTest extends SingleJobTestBase {
                 p = jenkins().createProject(WorkflowJob.class, "demo");
                 p.setDefinition(new CpsFlowDefinition(join(
                     "node {",
-                    "  x = parallel( a: { echo('echo a'); return 1; }, b: { echo('echo b'); sleep 1; return 2; } )",
+                    "  def x = parallel( a: { echo('echo a'); return 1; }, b: { echo('echo b'); sleep 1; return 2; } )",
                     "  assert x.a==1",
                     "  assert x.b==2",
                     "}"


### PR DESCRIPTION
Following up #925: not only avoiding the symptom, but warning about the mistake. (Though not from `@NonCPS` methods.)

Note that this uses a distinct logging system from either #211 or #280, since in this case at the point at which the warning is printed we have easy access to a `TaskListener` (though `PropertyAccessBlock` would have additional access to a `SourceLocation` which may be helpful).