### PR TITLE
Flake in `Workflow2Test`

### DIFF
--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/Workflow2Test.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/Workflow2Test.java
@@ -88,6 +88,7 @@ public class Workflow2Test {
         inputStepExecution.proceed(null);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         var b2 = await().until(() -> p.getBuildByNumber(2), Matchers.notNullValue());
-        assertThat("Expecting the replayed build to use sandbox", ((CpsFlowExecution) b2.getExecution()).isSandbox(), is(true));
+        var execution = await().until(b2::getExecution, Matchers.notNullValue());
+        assertThat("Expecting the replayed build to use sandbox", ((CpsFlowExecution) execution).isSandbox(), is(true));
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/Workflow2Test.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/Workflow2Test.java
@@ -90,5 +90,7 @@ public class Workflow2Test {
         var b2 = await().until(() -> p.getBuildByNumber(2), Matchers.notNullValue());
         var execution = await().until(b2::getExecution, Matchers.notNullValue());
         assertThat("Expecting the replayed build to use sandbox", ((CpsFlowExecution) execution).isSandbox(), is(true));
+        b2.doStop();
+        r.waitForCompletion(b2);
     }
 }


### PR DESCRIPTION
Amending #968. https://github.com/jenkinsci/bom/pull/4622#issuecomment-2694978606

```
java.lang.NullPointerException: Cannot invoke "org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.isSandbox()" because the return value of "org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution()" is null
	at org.jenkinsci.plugins.workflow.Workflow2Test.stage2(Workflow2Test.java:91)
```

Not reproduced locally—speculative.
