### PR TITLE
[JENKINS-75361] Consider `Closure.resolveStrategy` to reduce false positives

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
@@ -175,7 +175,7 @@ final class LoggingInvoker implements Invoker {
                     }
                     // TODO: Groovy will actually try the delegate first and then the owner if needed, but it is
                     // difficult for us to know what will happen in advance.
-                    yield findReceiver(c.getDelegate());
+                    yield findReceiver(delegate);
                 }
                 default ->
                     // TODO: Groovy will actually try the owner first and then the delegate if needed.

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
@@ -142,17 +142,17 @@ final class LoggingInvoker implements Invoker {
         delegate.setProperty(lhs, name, value);
         if (SystemProperties.getBoolean(LoggingInvoker.class.getName() + ".fieldSetWarning", true)) {
             if (value != null && !CLOSURE_METAPROPS.contains(name)) {
-                var owner = findOwner(lhs);
-                if (owner instanceof CpsScript) {
+                var receiver = findReceiver(lhs);
+                if (receiver instanceof CpsScript) {
                     try {
-                        owner.getClass().getDeclaredField(name);
+                        receiver.getClass().getDeclaredField(name);
                         // OK, @Field, ignore
                     } catch (NoSuchFieldException x) {
                         var g = CpsThreadGroup.current();
                         if (g != null) {
                             var e = g.getExecution();
                             if (e != null) {
-                                e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(owner.getClass().getSimpleName(), name, value.getClass().getSimpleName()));
+                                e.getOwner().getListener().getLogger().println(Messages.LoggingInvoker_field_set(receiver.getClass().getSimpleName(), name, value.getClass().getSimpleName()));
                             }
                         }
                     }
@@ -161,8 +161,28 @@ final class LoggingInvoker implements Invoker {
         }
     }
 
-    private Object findOwner(Object o) {
-        return o instanceof Closure<?> c ? findOwner(c.getOwner()) : o;
+    private Object findReceiver(Object o) {
+        if (o instanceof Closure<?> c) {
+            // c.f. https://github.com/apache/groovy/blob/41b990d0a20e442f29247f0e04cbed900f3dcad4/src/main/groovy/lang/Closure.java#L344
+            return switch (c.getResolveStrategy()) {
+                case Closure.DELEGATE_ONLY -> findReceiver(c.getDelegate());
+                case Closure.OWNER_ONLY -> findReceiver(c.getOwner());
+                case Closure.TO_SELF -> c;
+                case Closure.DELEGATE_FIRST -> {
+                    var delegate = c.getDelegate();
+                    if (delegate == null) {
+                        yield findReceiver(c.getOwner());
+                    }
+                    // TODO: Groovy will actually try the delegate first and then the owner if needed, but it is
+                    // difficult for us to know what will happen in advance.
+                    yield findReceiver(c.getDelegate());
+                }
+                default ->
+                    // TODO: Groovy will actually try the owner first and then the delegate if needed.
+                    findReceiver(c.getOwner());
+            };
+        }
+        return o;
     }
 
     @Override public Object getAttribute(Object lhs, String name) throws Throwable {

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/LoggingInvokerTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/LoggingInvokerTest.java
@@ -82,4 +82,23 @@ public class LoggingInvokerTest {
         r.assertLogNotContains("`def`", r.buildAndAssertSuccess(p));
     }
 
+    @Test public void closureToMapDslPattern() throws Exception {
+        var p = r.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                def closureToMap(body) {
+                  def map = [:]
+                  body.resolveStrategy = Closure.DELEGATE_FIRST
+                  body.delegate = map
+                  body()
+                  map
+                }
+                closureToMap {
+                  key1 = 'value1'
+                  key2 = 'value2'
+                }
+                """, true));
+        r.assertLogNotContains("`def`", r.buildAndAssertSuccess(p));
+    }
+
 }


### PR DESCRIPTION
A user comment in [JENKINS-75361](https://issues.jenkins.io/browse/JENKINS-75361) that has since been edited away, but is replicated in [my comment](https://issues.jenkins.io/browse/JENKINS-75361?focusedId=452863&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-452863) mentioned that #994 causes false positives for a relatively common pattern where assignments in closures are used as a DSL for building a map.

This PR adjusts the logic from that PR to consider `Closure.resolveStrategy` to try to reduce false positives a bit.

<!-- Please describe your pull request here. -->

### Testing done

See new automated test.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
