### PR TITLE
[JENKINS-75447] Fix Snippetizer rendering of "properties" step

### DIFF
--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/Snippetizer/index.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
                 </f:block>
                 <f:section title="${%Steps}"/>
                 <!-- Similar to f:dropdownDescriptorSelector, but adds fallback content to block, and JENKINS-25130 adds per-selection help: -->
-                <j:set var="item" value="${it.getItem(request)}"/>
+                <j:set var="item" value="${it.getItem(request2)}"/>
                 <d:taglib uri="local">
                     <d:tag name="listSteps">
                         <j:forEach var="quasiDescriptor" items="${quasiDescriptors}">


### PR DESCRIPTION
This should address https://issues.jenkins.io/browse/JENKINS-75447

There is no longer a `getItem()` that accepts a plain `StaplerRequest`.  In #972 the signature was changed to accept a `StaplerRequest2`.  Rather than maintain two variants, [it was preferred](https://issues.jenkins.io/browse/JENKINS-75447?focusedId=453247&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-453247) to modify the jelly to use the  new signature.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

There are no additional automated tests; there were no existing tests around this and there wasn't much precedence for tests specific to the EE migration.

This was manually validated via running in a debugger (against Jenkins 2.502), but also with the same setup from ticket's reproduction:
```Dockerfile
FROM jenkins/jenkins:2.487
RUN echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state

COPY workflow-cps.hpi /tmp/
RUN jenkins-plugin-cli --latest=true --verbose  -p \
    workflow-cps:custom:file:///tmp/workflow-cps.hpi
RUN jenkins-plugin-cli --latest=false -p \
    workflow-multibranch:795.ve0cb_1f45ca_9a_
```
Following the steps from the ticket resulted in the same (favorable) behavior from `4009.v0089238351a_9`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
