### PR TITLE
Ignore `__model__*` variables generated by Declarative in script splitting mode

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/LoggingInvoker.java
@@ -141,7 +141,7 @@ final class LoggingInvoker implements Invoker {
         maybeRecord(clazz, () -> clazz.getName() + "." + name);
         delegate.setProperty(lhs, name, value);
         if (SystemProperties.getBoolean(LoggingInvoker.class.getName() + ".fieldSetWarning", true)) {
-            if (value != null && !CLOSURE_METAPROPS.contains(name)) {
+            if (value != null && !CLOSURE_METAPROPS.contains(name) && /* RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION */ !name.startsWith("__model__")) {
                 var receiver = findReceiver(lhs);
                 if (receiver instanceof CpsScript) {
                     try {


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-75445 amending #994. Do not know much about this mode but it looks frightening! If you find the need for it, better switch to Scripted.

To reproduce,

```bash
mvnd -pl pipeline-model-definition test -Dtest=BasicModelDefTest#stages300
```

after

```diff
diff --git pom.xml pom.xml
index 2a014654..00f4c26d 100644
--- pom.xml
+++ pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4228.v0a_71308d905b_</version>
+        <version>4440.v39a_9eb_b_c6b_4d</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
```

Reproduced fix with:

```diff
diff --git pom.xml pom.xml
index 2a014654..a6628e01 100644
--- pom.xml
+++ pom.xml
@@ -75,10 +75,15 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4228.v0a_71308d905b_</version>
+        <version>4488.v7fe26526366e</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-cps</artifactId>
+        <version>999999-SNAPSHOT</version>
+      </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness-tools</artifactId>
```