### PR TITLE
Do not let `CpsFlowExecution.onLoad` recurse

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -809,7 +809,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     @Override
     public void onLoad(FlowExecutionOwner owner) throws IOException {
         if (this.owner != null) {
-            LOGGER.log(Level.FINE, new Throwable(), () -> this + " was already loaded");
+            LOGGER.log(Level.WARNING, new Throwable(), () -> this + " was already loaded");
             return;
         }
 
@@ -1555,6 +1555,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                     for (GraphListener listener : toRun) {
                         if (listener instanceof GraphListener.Synchronous == synchronous) {
                             try {
+                                LOGGER.fine(() -> "notifying " + listener + " of " + node);
                                 listener.onNewHead(node);
                             } catch (Throwable x) {
                                 LOGGER.log(Level.WARNING, null, x);

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -808,6 +808,11 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
 
     @Override
     public void onLoad(FlowExecutionOwner owner) throws IOException {
+        if (this.owner != null) {
+            LOGGER.log(Level.FINE, new Throwable(), () -> this + " was already loaded");
+            return;
+        }
+
         this.owner = owner;
 
         try {

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThreadGroup.java
@@ -587,7 +587,7 @@ public final class CpsThreadGroup implements Serializable {
             }
             serializedOK = true;
             Files.move(tmpFile.toPath(), f.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-            LOGGER.log(Level.FINE, "program state saved");
+            LOGGER.fine(() -> f + " saved");
         } catch (RuntimeException e) {
             propagateErrorToWorkflow(e);
             throw new IOException("Failed to persist "+f,e);


### PR DESCRIPTION
Found a case where Declarative `RuntimeASTTransformer.transform` calls `WorkflowRun.save` which can then result in `getExecution` being called and trying to initialize `CpsFlowExecution` again, exploding because by this point `headsSerial` has already been reset to null. [CloudBees-internal issue](https://cloudbees.atlassian.net/browse/BEE-59737)