### PR TITLE
Prevent `NullPointerException` in `CpsBodyExecution.FailureAdapter`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -376,13 +376,13 @@ class CpsBodyExecution extends BodyExecution {
             }
             try {
                 var contextVars = localThread.getContextVariables();
-                if (contextVars == null) {
-                    LOGGER.log(Level.FINE, () -> "Context variables already cleaned up for FlowNode" + sc.getNode().getId() + " and thread " + localThread);
-                    return t;
-                }
-                var handler = contextVars.get(FailureHandler.class, localThread::getExecution, sc::getNode);
-                if (handler != null) {
-                    return handler.handle(sc, t);
+                // CpsFlowExecution.start sets the context variables for the initial CpsThread to null, so context
+                // variables for all subsequent threads remain null until a block step adds a variable to its body.
+                if (contextVars != null) {
+                    var handler = contextVars.get(FailureHandler.class, localThread::getExecution, sc::getNode);
+                    if (handler != null) {
+                        return handler.handle(sc, t);
+                    }
                 }
             } catch (Throwable t2) {
                 t.addSuppressed(t2);

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodyExecution.java
@@ -375,7 +375,12 @@ class CpsBodyExecution extends BodyExecution {
                 localThread = thread;
             }
             try {
-                var handler = localThread.getContextVariables().get(FailureHandler.class, localThread::getExecution, sc::getNode);
+                var contextVars = localThread.getContextVariables();
+                if (contextVars == null) {
+                    LOGGER.log(Level.FINE, () -> "Context variables already cleaned up for FlowNode" + sc.getNode().getId() + " and thread " + localThread);
+                    return t;
+                }
+                var handler = contextVars.get(FailureHandler.class, localThread::getExecution, sc::getNode);
                 if (handler != null) {
                     return handler.handle(sc, t);
                 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodySubContext.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsBodySubContext.java
@@ -35,7 +35,7 @@ final class CpsBodySubContext extends DefaultStepContext {
 
     @NonNull
     @Override
-    protected FlowNode getNode() throws IOException {
+    protected FlowNode getNode() {
         return node;
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -144,6 +144,7 @@ public final class CpsThread implements Serializable {
         }
     }
 
+    @CheckForNull
     public ContextVariableSet getContextVariables() {
         return contextVariables;
     }

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -237,6 +237,7 @@ public final class CpsThread implements Serializable {
      * something is unexpectedly holding a reference directly to it (see JENKINS-63164 for an example scenario).
      */
     void cleanUp() {
+        LOGGER.finest(() -> "Cleaning up " + this);
         program = null;
         resumeValue = null;
         step = null;


### PR DESCRIPTION
@gbhat618 observed this error from code added recently in 5406e29e3c90829fd2981a6ed9077f4827220ba6 in a Pipeline which failed to stop after a hard kill. I will try to reproduce this case in a test.

```
java.lang.NullPointerException: Cannot invoke "org.jenkinsci.plugins.workflow.cps.ContextVariableSet.get(java.lang.Class, org.jenkinsci.plugins.workflow.cps.ContextVariableSet$ThrowingSupplier, org.jenkinsci.plugins.workflow.cps.ContextVariableSet$ThrowingSupplier)" because the return value of "org.jenkinsci.plugins.workflow.cps.CpsThread.getContextVariables()" is null
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsBodyExecution$FailureAdapter.handleError(CpsBodyExecution.java:378)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsBodyExecution$FailureAdapter.receive(CpsBodyExecution.java:352)
	at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.impl.ThrowBlock$1.receive(ThrowBlock.java:66)
	at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21)
	at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.Next.step(Next.java:83)
	at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:147)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:17)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:49)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:180)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:437)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:345)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:298)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService.lambda$wrap$4(CpsVmExecutorService.java:140)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:139)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at jenkins.util.ErrorLoggingExecutorService.lambda$wrap$0(ErrorLoggingExecutorService.java:51)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.call(CpsVmExecutorService.java:53)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.call(CpsVmExecutorService.java:50)
	at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:136)
	at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:275)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService.lambda$categoryThreadFactory$0(CpsVmExecutorService.java:50)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

### Testing done

See new automated test.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
