### PR TITLE
Add debug information on which run we're locking on.

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1994,7 +1994,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             try (var ignored = new WithThreadName(" acquiring read lock on storage of " + CpsFlowExecution.this)) {
                 readWriteLock.readLock().lock();
             }
-            try {
+            try (var ignored = new WithThreadName(" with read lock on storage of " + CpsFlowExecution.this)) {
                 return supplier.get();
             } finally {
                 readWriteLock.readLock().unlock();
@@ -2005,7 +2005,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             try (var ignored = new WithThreadName(" acquiring write lock on storage of " + CpsFlowExecution.this)) {
                 readWriteLock.writeLock().lock();
             }
-            try {
+            try (var ignored = new WithThreadName(" with write lock on storage of " + CpsFlowExecution.this)) {
                 runnable.run();
             } finally {
                 readWriteLock.writeLock().unlock();


### PR DESCRIPTION
Since there is one rwlock per CpsFlowExecution storage, it can be hard to follow which instance of the lock is being waited on if we're not in the Run thread itself. This provides better context in such case.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
