### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -256,6 +256,11 @@
             <artifactId>test-harness</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition.java
@@ -41,7 +41,6 @@ import hudson.util.FormValidation;
 import hudson.util.StreamTaskListener;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
 import org.jenkinsci.plugins.workflow.flow.DurabilityHintProvider;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
@@ -56,6 +55,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
@@ -170,7 +170,7 @@ public class CpsFlowDefinition extends FlowDefinition {
         private FlowDefinition newInstanceImpl(CpsFlowDefinition cpsFlowDefinition, @NonNull StaplerRequest2 req, @NonNull JSONObject formData) {
             if (!cpsFlowDefinition.sandbox && formData.get("oldScript") != null) {
                 String oldScript = formData.getString("oldScript");
-                boolean approveIfAdmin = !StringUtils.equals(oldScript, cpsFlowDefinition.script);
+                boolean approveIfAdmin = !Objects.equals(oldScript, cpsFlowDefinition.script);
                 if (approveIfAdmin) {
                     ScriptApproval.get().configuring(cpsFlowDefinition.script, GroovyLanguage.get(),
                             ApprovalContext.create().withCurrentUser().withItemAsKey(req.findAncestorObject(Item.class)), true);
@@ -188,7 +188,7 @@ public class CpsFlowDefinition extends FlowDefinition {
         public FormValidation doCheckScript(@QueryParameter String value, @QueryParameter String oldScript,
                                             @QueryParameter boolean sandbox) {
             return sandbox ? FormValidation.ok() :
-                    ScriptApproval.get().checking(value, GroovyLanguage.get(), !StringUtils.equals(oldScript, value));
+                    ScriptApproval.get().checking(value, GroovyLanguage.get(), !Objects.equals(oldScript, value));
         }
 
         @RequirePOST

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -60,7 +60,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.codehaus.groovy.reflection.CachedClass;
 import org.codehaus.groovy.reflection.ReflectionCache;
 import org.jenkinsci.Symbol;
@@ -138,7 +137,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
 
     private static final String KEEP_STEP_ARGUMENTS_PROPERTYNAME = (DSL.class.getName()+".keepStepArguments");
 
-    private static boolean isKeepStepArguments = StringUtils.isEmpty(System.getProperty(KEEP_STEP_ARGUMENTS_PROPERTYNAME))
+    private static boolean isKeepStepArguments = System.getProperty(KEEP_STEP_ARGUMENTS_PROPERTYNAME) == null || System.getProperty(KEEP_STEP_ARGUMENTS_PROPERTYNAME).isEmpty()
             || Boolean.parseBoolean(System.getProperty(KEEP_STEP_ARGUMENTS_PROPERTYNAME));
 
     /** Tell us if we should store {@link Step} arguments in an {@link org.jenkinsci.plugins.workflow.actions.ArgumentsAction}

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/GroovySourceFileAllowlist.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/GroovySourceFileAllowlist.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.util.SystemProperties;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Determines what Groovy source files can be loaded in Pipelines.
@@ -175,8 +174,8 @@ public abstract class GroovySourceFileAllowlist implements ExtensionPoint {
             // We load custom entries first to improve performance in case .groovy is used for the property.
             String propertyValue = SystemProperties.getString(ALLOWED_SOURCE_FILES_PROPERTY, "");
             for (String groovyFile : propertyValue.split(",")) {
-                groovyFile = StringUtils.trimToNull(groovyFile);
-                if (groovyFile != null) {
+                groovyFile = groovyFile.trim();
+                if (!groovyFile.isEmpty()) {
                     if (groovyFile.endsWith(".groovy")) {
                         ALLOWED_SOURCE_FILES.add(groovyFile);
                         LOGGER.log(Level.INFO, "Allowing Pipelines to access {0}", groovyFile);

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/SingleJobTestBase.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/SingleJobTestBase.java
@@ -27,7 +27,7 @@ package org.jenkinsci.plugins.workflow;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.slaves.DumbSlave;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadDumpTest.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import hudson.model.queue.QueueTaskFuture;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsThreadDump.ThreadInfo;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -10,7 +10,7 @@ import hudson.model.Executor;
 import hudson.model.Item;
 import hudson.model.Result;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.TestDurabilityHintProvider;
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
 import org.jenkinsci.plugins.workflow.actions.LogAction;

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImplTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/actions/ArgumentsActionImplTest.java
@@ -12,7 +12,7 @@ import hudson.Functions;
 import hudson.XmlFile;
 import hudson.model.Action;
 import hudson.tasks.ArtifactArchiver;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsMapContaining;
 import org.jenkinsci.plugins.credentialsbinding.impl.BindingStep;

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNodeTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/nodes/StepNodeTest.java
@@ -31,7 +31,7 @@ import hudson.tasks.ArtifactArchiver;
 import hudson.tasks.junit.JUnitResultArchiver;
 import java.util.List;
 import java.util.logging.Level;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3. This library wasn't used very much in this plugin (mostly in tests), so in `src/main` I simply rewrote usages to use standard Java Platform functionality.