### PR TITLE
`StackOverflowError` in `CpsStepContext.refersTo`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsStepContext.java
@@ -58,7 +58,10 @@ import net.jcip.annotations.GuardedBy;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -346,14 +349,14 @@ public class CpsStepContext extends DefaultStepContext { // TODO add XStream cla
                     LOGGER.log(Level.FINE, "earlier success: {0}", outcome.getNormal());
                 }
             }
-            if (failure != null && earlierFailure != null && !refersTo(failure, earlierFailure)) {
+            if (failure != null && earlierFailure != null && !refersTo(failure, earlierFailure, Collections.newSetFromMap(new IdentityHashMap<>()))) {
                 earlierFailure.addSuppressed(failure);
             }
         }
     }
 
-    private static boolean refersTo(Throwable t1, Throwable t2) {
-        return t1 == t2 || t1.getCause() != null && refersTo(t1.getCause(), t2) || Stream.of(t1.getSuppressed()).anyMatch(t3 -> refersTo(t3, t2));
+    private static boolean refersTo(Throwable t1, Throwable t2, Set<Throwable> checked) {
+        return checked.add(t1) && (t1 == t2 || t1.getCause() != null && refersTo(t1.getCause(), t2, checked) || Stream.of(t1.getSuppressed()).anyMatch(t3 -> refersTo(t3, t2, checked)));
     }
 
     /**


### PR DESCRIPTION
A build-terminating error (on a build which had anyway become `ABORTED` due to some problems perhaps with agents) was observed to be a `StackOverflowError`

```
…
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsStepContext.refersTo(CpsStepContext.java:356)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsStepContext.lambda$refersTo$1(CpsStepContext.java:356)
	at java.base/java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)
	at java.base/java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:1034)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:632)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsStepContext.refersTo(CpsStepContext.java:356)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsStepContext.lambda$refersTo$1(CpsStepContext.java:356)
…
```

This seems to be a regression from #535, presumably a rare one. The fix is similar in spirit to https://github.com/jenkinsci/workflow-api-plugin/pull/286 or https://github.com/jenkinsci/remoting/pull/645.
