### PR TITLE
Remove call stack from `runInCpsVmThread`

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -1002,8 +1002,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         }
         // first we need to wait for programPromise to fullfil CpsThreadGroup, then we need to run in its runner, phew!
         Futures.addCallback(programPromise, new FutureCallback<>() {
-            final Exception source = new Exception();   // call stack of this object captures who called this. useful during debugging.
-
             @Override
             public void onSuccess(final CpsThreadGroup g) {
                 g.runner.submit(new Runnable() {


### PR DESCRIPTION
I am not sure exactly what this was for—it dates to https://github.com/jenkinsci/pipeline-plugin/commit/dc6631192748eaa0534e2145b1fd7eafdd14ffe5 during the prototype days—but I noticed it adding overhead to a bunch of threads in an overloaded controller ([CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-61521)):

```
   java.lang.Thread.State: RUNNABLE
	at java.lang.Throwable.fillInStackTrace(java.base@21.0.8/Native Method)
	at java.lang.Throwable.fillInStackTrace(java.base@21.0.8/Throwable.java:820)
	- locked <0x00000000fff9ba58> (a java.lang.Exception)
	at java.lang.Throwable.<init>(java.base@21.0.8/Throwable.java:258)
	at java.lang.Exception.<init>(java.base@21.0.8/Exception.java:55)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4.<init>(CpsFlowExecution.java:1005)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.runInCpsVmThread(CpsFlowExecution.java:1004)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.getCurrentExecutions(CpsFlowExecution.java:1096)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.blocksRestart(CpsFlowExecution.java:1045)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$2.blocksRestart(WorkflowRun.java:413)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$2.displayCell(WorkflowRun.java:416)
	at hudson.model.Executor.isDisplayCell(Executor.java:687)
	at hudson.model.Computer.getDisplayExecutors(Computer.java:988)
	at …
```

Does not seem like something we want on in production code at least.
