### PR TITLE
Enable strict bundled artifact checks

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -48,6 +48,8 @@
         <maven.test.failure.ignore>false</maven.test.failure.ignore>
         <frontend.testFailureIgnore>${maven.test.failure.ignore}</frontend.testFailureIgnore>
         <useBeta>true</useBeta> <!-- FailureHandler -->
+        <hpi.bundledArtifacts>diff4j,groovy-cps</hpi.bundledArtifacts>
+        <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.19</version>
+        <version>5.22</version>
         <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Configures the new properties from https://github.com/jenkinsci/maven-hpi-plugin/pull/771.

### Testing done

I updated the parent POM, added `<hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>`, and confirmed that the build failed. I then added `<hpi.bundledArtifacts>diff4j,groovy-cps</hpi.bundledArtifacts>` and confirmed that the build passed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
