### PR TITLE
Add ext-searchbox in workflow-editor

### DIFF
--- a/plugin/src/main/js/workflow-editor.js
+++ b/plugin/src/main/js/workflow-editor.js
@@ -8,6 +8,7 @@ import ace from "ace-builds/src-noconflict/ace";
 import "ace-builds/src-noconflict/ext-language_tools";
 import "ace-builds/src-noconflict/mode-groovy";
 import "ace-builds/src-noconflict/snippets/javascript";
+import "ace-builds/src-noconflict/ext-searchbox";
 
 // Import custom snippets
 import "./snippets/workflow";
@@ -103,6 +104,7 @@ $(function() {
                         // can be used to get them going.
                         if (editor.getValue() === '') {
                             addSamplesWidget(editor, editorId, aceContainer.attr('samplesUrl'));
+                            editor.searchBox.hide();
                         }
                     }
                     showSamplesWidget();

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/editor/workflow-editor.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/editor/workflow-editor.jelly
@@ -17,6 +17,7 @@
                 <div class="editor" style="height: 350px;" samplesUrl="${rootURL}/workflow-cps-samples/" />
             </div>
             <st:adjunct includes="org.jenkinsci.plugins.workflow.cps.workflow-editor"/>
+            <st:adjunct includes="org.jenkinsci.plugins.workflow.cps.ext-searchbox"/>
         </j:otherwise>
     </j:choose>
 </j:jelly>

--- a/plugin/webpack.common.js
+++ b/plugin/webpack.common.js
@@ -9,6 +9,9 @@ module.exports = {
       path.join(__dirname, 'src/main/js/workflow-editor.js'),
       path.join(__dirname, 'src/main/less/workflow-editor.less'),
     ],
+    "ext-searchbox": [
+      path.join(__dirname, 'node_modules/ace-builds/src-noconflict/ext-searchbox.js'),
+    ],
   },
   output: {
     path: path.join(


### PR DESCRIPTION
Add a way to search inside workflow editor

<img width="1274" height="463" alt="image" src="https://github.com/user-attachments/assets/cfc31269-694a-4090-b6be-48ba17835f4b" />

There are some problem to solve, like that now as soon the select is enabled, there is no way to hide it so I can arrive to this problem

<img width="1274" height="463" alt="image" src="https://github.com/user-attachments/assets/1f58f0f5-5ab6-4844-9658-e40bc2a28a9d" />

The problem that I'm not an expert on it. The test is a bit tricky. I usually deploy using:

mvn install -DskipTests

This generate the hpi that I upload using another session
that execute
mvn hpi:run

To test it I need to install a bit of plugin to have pipeline support with groovy


