### PR TITLE
Ensure Java classes loaded by a Pipeline's `GroovyClassLoader` are cleaned up when the Pipeline completes

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -82,6 +82,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -1446,20 +1447,23 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
         cleanUpLoader(loader.getParent(), encounteredLoaders, encounteredClasses);
         LOGGER.finer(() -> "found " + loader);
         SerializableClassRegistry.getInstance().release(loader);
-        cleanUpGlobalClassValue(loader);
         GroovyClassLoader gcl = (GroovyClassLoader) loader;
-        for (Class<?> clazz : gcl.getLoadedClasses()) {
+        Set<Class<?>> loadedClasses = new HashSet<>(Arrays.asList((Class<?>[]) gcl.getLoadedClasses()));
+        // GroovyClassLoader.getLoadedClasses() only returns Groovy classes, not Java classes loaded when using `@Grab`
+        cleanUpGlobalClassValue(loader, loadedClasses);
+        cleanUpClassHelperCache(loader, loadedClasses);
+        for (Class<?> clazz : loadedClasses) {
             if (encounteredClasses.add(clazz)) {
                 LOGGER.finer(() -> "found " + clazz.getName());
+                // TODO: Do we also need to do a reverse lookup on the Introspector caches in case they have unique entries?
                 Introspector.flushFromCaches(clazz);
-                cleanUpClassHelperCache(clazz);
                 cleanUpLoader(clazz.getClassLoader(), encounteredLoaders, encounteredClasses);
             }
         }
         gcl.clearCache();
     }
 
-    private static void cleanUpGlobalClassValue(@NonNull ClassLoader loader) throws Exception {
+    private static void cleanUpGlobalClassValue(@NonNull ClassLoader loader, Set<Class<?>> loadedClasses) throws Exception {
         Class<?> classInfoC = Class.forName("org.codehaus.groovy.reflection.ClassInfo");
         // TODO switch to MethodHandle for speed
         Field globalClassValueF = classInfoC.getDeclaredField("globalClassValue");
@@ -1490,6 +1494,40 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
             }
         }
         Iterator<Class<?>> it = toRemove.iterator();
+        removeClassesFromOtherClassLoaders(it, loader);
+        LOGGER.fine(() -> "cleaning up " + toRemove + " associated with " + loader);
+        for (Class<?> klazz : toRemove) {
+            loadedClasses.add(klazz);
+            removeM.invoke(map, klazz);
+        }
+    }
+
+    private static void cleanUpClassHelperCache(@NonNull ClassLoader loader, Set<Class<?>> loadedClasses) throws Exception {
+        Field classCacheF = Class.forName("org.codehaus.groovy.ast.ClassHelper$ClassHelperCache").getDeclaredField("classCache");
+        classCacheF.setAccessible(true);
+        Object classCache = classCacheF.get(null);
+        Class<?> classCacheC = classCache.getClass();
+        Collection entries = (Collection) classCacheC.getMethod("values").invoke(classCache);
+        Class<?> managedRefC = Class.forName("org.codehaus.groovy.util.ManagedReference");
+        var getRefM = managedRefC.getMethod("get");
+        List<Class<?>> toRemove = new ArrayList<>(); // not sure if it is safe against ConcurrentModificationException or not
+        for (Object entry : entries) {
+            Class<?> clazz = (Class<?>) getRefM.invoke(entry);
+            if (clazz != null) {
+                toRemove.add(clazz);
+            }
+        }
+        Iterator<Class<?>> it = toRemove.iterator();
+        removeClassesFromOtherClassLoaders(it, loader);
+        LOGGER.fine(() -> "cleaning up " + toRemove + " associated with " + loader);
+        Method removeM = classCache.getClass().getMethod("remove", Object.class);
+        for (Class<?> klazz : toRemove) {
+            loadedClasses.add(klazz);
+            removeM.invoke(classCache, klazz);
+        }
+    }
+
+    private static void removeClassesFromOtherClassLoaders(Iterator<Class<?>> it, ClassLoader loader) {
         while (it.hasNext()) {
             Class<?> klazz = it.next();
             ClassLoader encounteredLoader = klazz.getClassLoader();
@@ -1500,20 +1538,6 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                 }
             }
         }
-        LOGGER.fine(() -> "cleaning up " + toRemove + " associated with " + loader);
-        for (Class<?> klazz : toRemove) {
-            removeM.invoke(map, klazz);
-        }
-    }
-
-    private static void cleanUpClassHelperCache(@NonNull Class<?> clazz) throws Exception {
-        Field classCacheF = Class.forName("org.codehaus.groovy.ast.ClassHelper$ClassHelperCache").getDeclaredField("classCache");
-        classCacheF.setAccessible(true);
-        Object classCache = classCacheF.get(null);
-        if (LOGGER.isLoggable(Level.FINER)) {
-            LOGGER.log(Level.FINER, "cleaning up {0} from ClassHelperCache? {1}", new Object[] {clazz.getName(), classCache.getClass().getMethod("get", Object.class).invoke(classCache, clazz) != null});
-        }
-        classCache.getClass().getMethod("remove", Object.class).invoke(classCache, clazz);
     }
 
     synchronized @CheckForNull FlowHead getFirstHead() {


### PR DESCRIPTION
When using `@Grab`, the `GroovyClassLoader` for the Pipeline can load not only Groovy classes, but also Java classes. `CpsFlowExecution.cleanUpHeap` has some logic that uses `GroovyClassLoader.getLoadedClasses`, which only returns Groovy classes, not Java classes, and so that cleanup logic is incomplete.

I am not aware of any equivalent to `GroovyClassLoader.getLoadedClasses` that would provide access to loaded Java classes, so this PR switches to a reverse lookup on `ClassHelper$ClassHelperCache.classCache`, which is similar to what we already do in `cleanUpGlobalClassValue`. 

### Testing done

TODO: Downstream PR against `pipeline-groovy-lib`

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
