### PR TITLE
Fix tests using removed Groovy file

### DIFF
--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecutionTest.java
@@ -797,9 +797,9 @@ public class CpsFlowExecutionTest {
         logger.record(GroovySourceFileAllowlist.class, Level.INFO).capture(100);
         sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class);
-            p.setDefinition(new CpsFlowDefinition("new hudson.model.View.main()", true));
+            p.setDefinition(new CpsFlowDefinition("new hudson.model.AllView.noJob()", true));
             WorkflowRun b = r.buildAndAssertStatus(Result.FAILURE, p);
-            r.assertLogContains("unable to resolve class hudson.model.View.main", b);
+            r.assertLogContains("unable to resolve class hudson.model.AllView.noJob", b);
             assertThat(
                     logger.getMessages(),
                     hasItem(containsString(
@@ -813,7 +813,7 @@ public class CpsFlowExecutionTest {
         System.setProperty("org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist.DISABLED", "true");
         sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class);
-            p.setDefinition(new CpsFlowDefinition("new hudson.model.View.main()", true));
+            p.setDefinition(new CpsFlowDefinition("new hudson.model.AllView.noJob()", true));
             WorkflowRun b = r.buildAndAssertSuccess(p);
         });
     }
@@ -823,11 +823,11 @@ public class CpsFlowExecutionTest {
     public void groovySourcesCanBeUsedIfAddedToSystemProperty() throws Throwable {
         System.setProperty(
                 "org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist.DefaultAllowlist.ALLOWED_SOURCE_FILES",
-                "/just/an/example.groovy,/hudson/model/View/main.groovy");
+                "/just/an/example.groovy,/hudson/model/AllView/noJob.groovy");
         logger.record(DefaultAllowlist.class, Level.INFO).capture(100);
         sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class);
-            p.setDefinition(new CpsFlowDefinition("new hudson.model.View.main()", true));
+            p.setDefinition(new CpsFlowDefinition("new hudson.model.AllView.noJob()", true));
             WorkflowRun b = r.buildAndAssertSuccess(p);
             assertThat(
                     logger.getMessages(),


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/11208 replaces `main.groovy` with `main.jelly` - inadvertently breaking the tests in this plugin. As a fix I've used another Groovy file in core.

This feels rather brittle - theres a trend of moving away from Groovy to Jelly in core, and it'd be good to avoid this breakage happening again in the future. Not very knowledgeable in this area, but would it be possible to instead point to a Groovy file inside of this plugin?

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
