### PR TITLE
Update agent image to latest-jdk21 default has jdk17

### DIFF
--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/SerialFormTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/SerialFormTest.java
@@ -83,7 +83,7 @@ public class SerialFormTest {
         rr.startJenkins();
         URL u = rr.getUrl();
         Testcontainers.exposeHostPorts(u.getPort());
-        agentContainer = new GenericContainer<>("jenkins/inbound-agent")
+        agentContainer = new GenericContainer<>("jenkins/inbound-agent:latest-jdk21")
                 .withEnv(
                         "JENKINS_URL",
                         new URL(u.getProtocol(), "host.testcontainers.internal", u.getPort(), u.getFile()).toString())


### PR DESCRIPTION
When running the PCT with controller compiled for Java 21, this test is not working - although not throwing a specific error, but just keeps printing, then times out.

```
2026-01-13 07:24:41.044+0000 [id=123]	INFO	o.jvnet.hudson.test.JenkinsRule#waitOnline: Waiting for remote to come online…
2026-01-13 07:24:41.406+0000 [id=127]	INFO	j.s.DefaultJnlpSlaveReceiver#channelClosed: Jetty (winstone)-127 for remote terminated: java.nio.channels.ClosedChannelException
2026-01-13 07:24:41.406+0000 [id=127]	INFO	j.s.DefaultJnlpSlaveReceiver#channelClosed: Jetty (winstone)-127 for remote terminated: java.nio.channels.ClosedChannelException
2026-01-13 07:24:41.408+0000 [id=131]	INFO	hudson.remoting.Request$2#run: Failed to send back a reply to the request UserRequest:RPCRequest:hudson.remoting.IChannel.waitForProperty[java.lang.Object](1): hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@4346b84a:remote": channel is already closed
2026-01-13 07:24:41.472+0000 [id=133]	INFO	j.s.DefaultJnlpSlaveReceiver#channelClosed: Jetty (winstone)-133 for remote terminated: java.nio.channels.ClosedChannelException
2026-01-13 07:24:41.472+0000 [id=133]	INFO	j.s.DefaultJnlpSlaveReceiver#channelClosed: Jetty (winstone)-133 for remote terminated: java.nio.channels.ClosedChannelException
2026-01-13 07:24:41.473+0000 [id=132]	INFO	hudson.remoting.Request$2#run: Failed to send back a reply to the request UserRequest:RPCRequest:hudson.remoting.IChannel.waitForProperty[java.lang.Object](1): hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@1bd9063d:remote": channel is already closed
```

Noticed the image used was (also as in the test logs)
```
→ docker run --rm -it --entrypoint java jenkins/inbound-agent:latest -version
openjdk version "17.0.17" 2025-10-21
OpenJDK Runtime Environment Temurin-17.0.17+10 (build 17.0.17+10)
OpenJDK 64-Bit Server VM Temurin-17.0.17+10 (build 17.0.17+10, mixed mode)
```
(also in dockerhub the digest for latest and latest-jdk17 are same)

Proposing to switch to `jenkins/inbound-agent:latest-jdk21` so the `SerialFormTest` works in Java 21 compiled controller version.

Verified only 1 test is using this docker image, so expecting this is the only update required.

### Testing done

Executed test in local, it passes.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
