### PR TITLE
Creates test to show potential memory leak

### DIFF
--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/MemoryUsageTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/MemoryUsageTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MemoryAssert;
 
+import java.lang.ref.WeakReference;
+
 public class MemoryUsageTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
@@ -16,21 +18,11 @@ public class MemoryUsageTest {
         WorkflowJob project = j.createProject(WorkflowJob.class, "test");
         project.setDefinition(new CpsFlowDefinition("""
             def text = 'Hello $name'
-            for(int i=0;i<5000;i++) { // TODO change loop upper limit to trigger the memory leak
-                def engine = new groovy.text.SimpleTemplateEngine()
-                def template = engine.createTemplate(text).make(['name': 'foo ' + i])
-                println template.toString()
-            }
+            def engine = new groovy.text.SimpleTemplateEngine()
+            def template = engine.createTemplate(text).make(['name': 'foo'])
+            println template.toString()
         """, false));
-
-        int additionalMemory = MemoryAssert.increasedMemory(
-                () -> {
-                    j.assertBuildStatusSuccess(project.scheduleBuild2(0));
-                    return null;
-                },
-                (obj, referredFrom, reference) -> !obj.getClass().getName().startsWith("SimpleTemplateEngine")
-        ).stream().mapToInt(value -> value.byteSize).sum();
-
-        assert additionalMemory == 0;
+        j.assertBuildStatusSuccess(project.scheduleBuild2(0));
+        MemoryAssert.assertGC(new WeakReference<>(this.getClass().getClassLoader()), true);
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/MemoryUsageTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/MemoryUsageTest.java
@@ -2,27 +2,49 @@ package org.jenkinsci.plugins.workflow;
 
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MemoryAssert;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MemoryUsageTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
+    @After
+    public void clearLoaders() {
+        LOADERS.clear();
+    }
+
+    private static final List<WeakReference<ClassLoader>> LOADERS = new ArrayList<>();
+
+    public static void register(Object o) {
+        ClassLoader loader = o.getClass().getClassLoader();
+        System.err.println("registering " + o + " from " + loader);
+        LOADERS.add(new WeakReference<>(loader));
+    }
+
     @Test
     public void shouldNotLeakSimpleTemplateEngine() throws Exception {
         WorkflowJob project = j.createProject(WorkflowJob.class, "test");
         project.setDefinition(new CpsFlowDefinition("""
-            def text = 'Hello $name'
-            def engine = new groovy.text.SimpleTemplateEngine()
-            def template = engine.createTemplate(text).make(['name': 'foo'])
-            println template.toString()
-        """, false));
+            %s.register(this);
+            node {
+                def text = 'Hello $name'
+                def engine = new groovy.text.SimpleTemplateEngine()
+                def template = engine.createTemplate(text).make(['name': 'foo'])
+                println template.toString()
+            }
+        """.formatted(MemoryUsageTest.class.getName()), false));
         j.assertBuildStatusSuccess(project.scheduleBuild2(0));
-        MemoryAssert.assertGC(new WeakReference<>(this.getClass().getClassLoader()), true);
+
+        for (WeakReference<ClassLoader> loader : LOADERS) {
+            MemoryAssert.assertGC(loader, false);
+        }
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/MemoryUsageTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/MemoryUsageTest.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.workflow;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MemoryAssert;
+
+public class MemoryUsageTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void shouldNotLeakSimpleTemplateEngine() throws Exception {
+        WorkflowJob project = j.createProject(WorkflowJob.class, "test");
+        project.setDefinition(new CpsFlowDefinition("""
+            def text = 'Hello $name'
+            for(int i=0;i<5000;i++) { // TODO change loop upper limit to trigger the memory leak
+                def engine = new groovy.text.SimpleTemplateEngine()
+                def template = engine.createTemplate(text).make(['name': 'foo ' + i])
+                println template.toString()
+            }
+        """, false));
+
+        int additionalMemory = MemoryAssert.increasedMemory(
+                () -> {
+                    j.assertBuildStatusSuccess(project.scheduleBuild2(0));
+                    return null;
+                },
+                (obj, referredFrom, reference) -> !obj.getClass().getName().startsWith("SimpleTemplateEngine")
+        ).stream().mapToInt(value -> value.byteSize).sum();
+
+        assert additionalMemory == 0;
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

When using `SimpleTemplateEngine`, even with fixes present in 2.524, it seems that it is possible to have a memory leak.
This is trying to demonstrate this.

### Testing done

Created a new test using `SimpleTemplateEngine` in a Pipeline job.

I played with the counter, and at 5000 and more, the problem is not show but a thread issue appears.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
