### PR TITLE
Block `pipeline {…}` when `pipeline-model-definition` not enabled

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/DSL.java
@@ -145,6 +145,11 @@ public class DSL extends GroovyObjectSupport implements Serializable {
         return isKeepStepArguments;
     }
 
+    /** Pending full #1740 impl, particular symbols we know should not be run as functions. */
+    private static final Set<String> BLACKLISTED_SYMBOLS = Set.of(
+            // ignore WorkflowJob.DescriptorImpl; only interpret ModelStepLoader
+            "pipeline");
+
     /**
      * Executes the {@link Step} implementation specified by the name argument.
      *
@@ -193,7 +198,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
             }
             return invokeStep(sd, name, args);
         }
-        if (SymbolLookup.get().findDescriptor(Describable.class, name) != null) {
+        if (!BLACKLISTED_SYMBOLS.contains(name) && SymbolLookup.get().findDescriptor(Describable.class, name) != null) {
             return invokeDescribable(name, args);
         }
 
@@ -206,6 +211,7 @@ public class DSL extends GroovyObjectSupport implements Serializable {
                     symbols.addAll(SymbolLookup.getSymbolValue(e));
                 }
             }
+            symbols.removeAll(BLACKLISTED_SYMBOLS);
             Queue.Executable executable = exec.getOwner().getExecutable();
             for (GlobalVariable var : GlobalVariable.forRun(executable instanceof Run ? (Run) executable : null)) {
                 globals.add(var.getName());

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/DSLTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -724,6 +725,15 @@ public class DSLTest {
     public void standardStage() throws Exception {
         p.setDefinition(new CpsFlowDefinition("stage('Build'){\n" + "  echo('building')\n" + "}\n", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Issue("https://github.com/jenkinsci/workflow-cps-plugin/issues/1740")
+    @Test
+    public void declarativeMissing() throws Exception {
+        assertThat(r.jenkins.getPlugin("pipeline-model-definition"), nullValue());
+        p.setDefinition(new CpsFlowDefinition("pipeline {stages {stage('x') {steps {echo 'hi'}}}}", true));
+        var b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        r.assertLogContains("No such DSL method 'pipeline'", b);
     }
 
     @Issue("JENKINS-47101")

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
@@ -473,23 +473,15 @@ public class ReplayActionTest {
                         .to("dev1"));
 
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "SECURITY-3362");
-                String script = "pipeline {\n" + "  agent any\n"
-                        + "  stages {\n"
-                        + "    stage('List Jobs') {\n"
-                        + "      steps {\n"
-                        + "        script {\n"
-                        + "           println \"Jobs: ${jenkins.model.Jenkins.instance.getItemByFullName(env.JOB_NAME)?.parent?.items*.fullName.join(', ')}!\""
-                        + "        }\n"
-                        + "      }\n"
-                        + "    }\n"
-                        + "  }\n"
-                        + "}\n";
+                String script = """
+                    println "Jobs: ${Jenkins.instance.getItemByFullName(env.JOB_NAME)?.parent?.items*.fullName.join(', ')}!"
+                    """;
                 p.setDefinition(new CpsFlowDefinition(script, false));
 
                 ScriptApproval.get().preapprove(script, GroovyLanguage.get());
 
-                WorkflowRun b1 = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b1));
+                WorkflowRun b1 = story.j.buildAndAssertSuccess(p);
+                story.j.assertLogContains("Jobs: SECURITY-3362!", b1);
 
                 ScriptApproval.get().clearApprovedScripts();
 

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayActionTest.java
@@ -473,15 +473,13 @@ public class ReplayActionTest {
                         .to("dev1"));
 
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "SECURITY-3362");
-                String script = """
-                    println "Jobs: ${Jenkins.instance.getItemByFullName(env.JOB_NAME)?.parent?.items*.fullName.join(', ')}!"
-                    """;
+                String script = "echo(/Jobs: ${Jenkins.instance.items*.fullName}!/)";
                 p.setDefinition(new CpsFlowDefinition(script, false));
 
                 ScriptApproval.get().preapprove(script, GroovyLanguage.get());
 
                 WorkflowRun b1 = story.j.buildAndAssertSuccess(p);
-                story.j.assertLogContains("Jobs: SECURITY-3362!", b1);
+                story.j.assertLogContains("Jobs: [SECURITY-3362]!", b1);
 
                 ScriptApproval.get().clearApprovedScripts();
 


### PR DESCRIPTION
Addresses the most complaint about #1740 without handling the general case.

[CloudBees-internal issue](https://cloudbees.atlassian.net/browse/BEE-31174)