### PR TITLE
Remove the confusing second Rebuild button when Rebuilder plugin can do the job (better)

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction.java
@@ -141,12 +141,34 @@ public class ReplayAction implements Action {
         return null;
     }
 
+    /** Offer a fallback Rebuild link if Replay is not permitted? */
     /* accessible to Jelly */ public boolean isRebuildEnabled() {
         if (!run.hasPermission(Item.BUILD)) {
             return false;
         }
         if (!run.getParent().isBuildable()) {
             return false;
+        }
+        if (Jenkins.get().getPlugin("rebuild") != null) {
+            // Go via reflection to avoid a pom.xml (and subsequent
+            // Jenkins controller) dependency on the "competing" plugin:
+            try {
+                Class<?> abstractRebuildAction = Jenkins.get()
+                        .getPluginManager()
+                        .uberClassLoader
+                        .loadClass("com.sonyericsson.rebuild.AbstractRebuildAction");
+                if ((Boolean)
+                        abstractRebuildAction.getMethod("isRebuildAvailable").invoke(null)) {
+                    // THAT plugin will handle the Rebuild link better
+                    // (parameterized if need be), so we here should
+                    // show nothing at all
+                    return false;
+                }
+            } catch (ClassNotFoundException e) {
+                // ignore
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "failed to check for rebuild-plugin", e);
+            }
         }
 
         return true;

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction/index.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/replay/ReplayAction/index.jelly
@@ -29,15 +29,17 @@
                         </f:form>
                     </j:when>
                     <j:otherwise>
-                        <h1>${%Rebuild(it.owner.displayName)}</h1>
-                        <p>
-                            <j:out value="${%blurb.rebuild}"/>
-                        </p>
-                        <f:form action="rebuild" method="POST" name="rebuild">
-                            <f:bottomButtonBar>
-                                <f:submit value="${%Run}"/>
-                            </f:bottomButtonBar>
-                        </f:form>
+                        <j:when test="${it.rebuildEnabled}">
+                            <h1>${%Rebuild(it.owner.displayName)}</h1>
+                            <p>
+                                <j:out value="${%blurb.rebuild}"/>
+                            </p>
+                            <f:form action="rebuild" method="POST" name="rebuild">
+                                <f:bottomButtonBar>
+                                    <f:submit value="${%Run}"/>
+                                </f:bottomButtonBar>
+                            </f:form>
+                        </j:when>
                     </j:otherwise>
                 </j:choose>
             </j:if>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-76292

> Non-admin users see two "Rebuild" buttons on Pipeline builds when the Rebuilder plugin is installed.
> This does not happen for admin users, who instead see Replay + Rebuild, which is expected.

The PR extends `ReplayAction::isRebuildEnabled()` with a check for `rebuild` plugin availability, and a reflection call to see if its `com.sonyericsson.rebuild.AbstractRebuildAction.isRebuildAvailable()` would render the link. 

In this case, the workflow-cps-plugin should not show a duplicate and potentially inferior (no Parameterized Rebuild concept here) fallback link when Replay is not permitted.

### Testing done

Not yet, checking.

Would be visual/interactive on a Jenkins controller with rebuildable pipelines.

Further PRs are welcome to add an automated test case with installed `rebuild` (Rebuilder) plugin, but only for some test cases.
* https://github.com/jenkinsci/rebuild-plugin
* https://plugins.jenkins.io/rebuild/

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
