### PR TITLE
Default `initializeStorageFromOnLoad` to false

### DIFF
--- a/consume-incrementals
+++ b/consume-incrementals
@@ -1,0 +1,1 @@
+https://github.com/jenkinsci/workflow-job-plugin/pull/758

--- a/consume-incrementals
+++ b/consume-incrementals
@@ -1,1 +1,0 @@
-https://github.com/jenkinsci/workflow-job-plugin/pull/758

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -60,6 +60,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- TODO until in BOM -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-job</artifactId>
+        <!-- TODO https://github.com/jenkinsci/workflow-job-plugin/pull/758 -->
+        <version>1571.1579.v703855f75573</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -60,12 +60,10 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- TODO until in BOM -->
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-job</artifactId>
-        <!-- TODO https://github.com/jenkinsci/workflow-job-plugin/pull/758 -->
-        <version>1571.1579.v703855f75573</version>
+        <version>1571.1580.v18e46842c125</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -863,7 +863,7 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                 initializeStorage(); // Throws exception and bombs out if we can't load FlowNodes
             } catch (Exception ex) {
                 var propName = CpsFlowExecution.class.getName() + ".initializeStorageFromOnLoad";
-                if (SystemProperties.getBoolean(propName, true)) {
+                if (SystemProperties.getBoolean(propName)) {
                     LOGGER.log(
                             Level.WARNING,
                             ex,

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/FlowDurabilityTest.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.workflow.cps;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
 import static org.junit.Assume.assumeFalse;
 
 import com.google.common.base.Predicate;
@@ -225,7 +227,7 @@ public class FlowDurabilityTest {
         Assert.assertEquals(Result.SUCCESS, run.getResult());
         int outputHash = run.getLog().hashCode();
         FlowExecution exec = run.getExecution();
-        verifyCompletedCleanly(j, run);
+        verifyCompletedCleanly(j, run, true);
 
         // Confirm the flow graph is fully navigable and contains the heads with appropriate ending
         DepthFirstScanner scan = new DepthFirstScanner();
@@ -279,7 +281,7 @@ public class FlowDurabilityTest {
         assertHasTimingAction(run.getExecution());
         rule.waitForCompletion(run);
         Assert.assertEquals(Result.SUCCESS, run.getResult());
-        verifyCompletedCleanly(rule.jenkins, run);
+        verifyCompletedCleanly(rule.jenkins, run, true);
         // no checking nodes
         rule.assertLogContains(logStart, run);
     }
@@ -340,7 +342,8 @@ public class FlowDurabilityTest {
         }
     }
 
-    static void verifyFailedCleanly(Jenkins j, WorkflowRun run) throws Exception {
+    static void verifyFailedCleanly(Jenkins j, WorkflowRun run, Result executionResult, boolean verifyFlowEndNode)
+            throws Exception {
 
         if (run.isBuilding()) { // Give the run a little bit of time to see if it can resume or not
             FlowExecution exec = run.getExecution();
@@ -358,23 +361,23 @@ public class FlowDurabilityTest {
 
         assert !run.isBuilding();
 
-        if (run.getExecution() instanceof CpsFlowExecution) {
-            Assert.assertEquals(Result.FAILURE, ((CpsFlowExecution) run.getExecution()).getResult());
+        if (run.getExecution() instanceof CpsFlowExecution cpsFlowExecution) {
+            Assert.assertEquals(executionResult, cpsFlowExecution.getResult());
         }
 
         Assert.assertEquals(Result.FAILURE, run.getResult());
         assert !run.isBuilding();
-        // TODO verify all blocks cleanly closed out, so Block start and end nodes have same counts
-        // and FlowEndNode is last node
-        verifyCompletedCleanly(j, run);
+        verifyCompletedCleanly(j, run, verifyFlowEndNode);
     }
 
     /** Verifies all the universal post-build cleanup was done, regardless of pass/fail state. */
-    static void verifyCompletedCleanly(Jenkins j, WorkflowRun run) throws Exception {
+    static void verifyCompletedCleanly(Jenkins j, WorkflowRun run, boolean verifyFlowEndNode) throws Exception {
         // Assert that we have the appropriate flow graph entries
         FlowExecution exec = run.getExecution();
-        List<FlowNode> heads = exec.getCurrentHeads();
-        Assert.assertEquals(1, heads.size());
+        if (verifyFlowEndNode) {
+            List<FlowNode> heads = exec.getCurrentHeads();
+            Assert.assertEquals(1, heads.size());
+        }
         verifyNoTasksRunning(j);
         Assert.assertEquals(0, exec.getCurrentExecutions(false).get().size());
 
@@ -386,13 +389,15 @@ public class FlowDurabilityTest {
             Assert.assertNull("We should have no Groovy shell left or that's a memory leak", cpsFlow.getTrustedShell());
             Assert.assertTrue(cpsFlow.done);
             assert cpsFlow.isComplete();
-            assert cpsFlow.heads.size() == 1;
-            Map.Entry<Integer, FlowHead> finalHead =
-                    cpsFlow.heads.entrySet().iterator().next();
-            assert finalHead.getValue().get() instanceof FlowEndNode;
-            Assert.assertEquals(
-                    cpsFlow.storage.getNode(finalHead.getValue().get().getId()),
-                    finalHead.getValue().get());
+            if (verifyFlowEndNode) {
+                assertThat(cpsFlow.heads, aMapWithSize(1));
+                Map.Entry<Integer, FlowHead> finalHead =
+                        cpsFlow.heads.entrySet().iterator().next();
+                assert finalHead.getValue().get() instanceof FlowEndNode;
+                Assert.assertEquals(
+                        cpsFlow.storage.getNode(finalHead.getValue().get().getId()),
+                        finalHead.getValue().get());
+            }
         }
 
         verifyExecutionRemoved(run);
@@ -614,7 +619,9 @@ public class FlowDurabilityTest {
                         story.j
                                 .jenkins
                                 .getItemByFullName(jobName, WorkflowJob.class)
-                                .getLastBuild());
+                                .getLastBuild(),
+                        Result.SUCCESS,
+                        false);
             }
         });
     }
@@ -648,7 +655,7 @@ public class FlowDurabilityTest {
                     // and the run won't load at all
                     return;
                 }
-                verifyFailedCleanly(story.j.jenkins, run);
+                verifyFailedCleanly(story.j.jenkins, run, Result.SUCCESS, false);
                 story.j.assertLogContains(logStart[0], run);
             }
         });
@@ -691,7 +698,7 @@ public class FlowDurabilityTest {
                     // and the run won't load at all
                     return;
                 }
-                verifyFailedCleanly(story.j.jenkins, run);
+                verifyFailedCleanly(story.j.jenkins, run, Result.SUCCESS, false);
                 story.j.assertLogContains(logStart[0], run);
             }
         });
@@ -743,7 +750,7 @@ public class FlowDurabilityTest {
                         .jenkins
                         .getItemByFullName("durableAgainstClean", WorkflowJob.class)
                         .getLastBuild();
-                verifyFailedCleanly(story.j.jenkins, run);
+                verifyFailedCleanly(story.j.jenkins, run, Result.FAILURE, true);
                 story.j.assertLogContains(logStart[0], run);
                 assertIncludesNodes(nodesOut, run);
             }
@@ -866,7 +873,7 @@ public class FlowDurabilityTest {
                         .jenkins
                         .getItemByFullName(jobName, WorkflowJob.class)
                         .getLastBuild();
-                verifyFailedCleanly(story.j.jenkins, run);
+                verifyFailedCleanly(story.j.jenkins, run, Result.FAILURE, true);
             }
         });
     }
@@ -900,7 +907,7 @@ public class FlowDurabilityTest {
                         .jenkins
                         .getItemByFullName(jobName, WorkflowJob.class)
                         .getLastBuild();
-                verifyFailedCleanly(story.j.jenkins, run);
+                verifyFailedCleanly(story.j.jenkins, run, Result.FAILURE, true);
             }
         });
     }
@@ -1005,7 +1012,7 @@ public class FlowDurabilityTest {
                     assertBuildNotHung(story, run, 30_000);
                     Assert.assertEquals(Result.SUCCESS, run.getResult());
                 }
-                verifyCompletedCleanly(story.j.jenkins, run);
+                verifyCompletedCleanly(story.j.jenkins, run, true);
                 assertIncludesNodes(nodesOut, run);
                 story.j.assertLogContains(logStart[0], run);
             }
@@ -1056,7 +1063,7 @@ public class FlowDurabilityTest {
                             run.getExecution().getDurabilityHint());
                 }
                 assertBuildNotHung(story, run, 30_000);
-                verifyCompletedCleanly(story.j.jenkins, run);
+                verifyCompletedCleanly(story.j.jenkins, run, true);
                 story.j.assertLogContains(logStart[0], run);
             }
         });
@@ -1125,7 +1132,7 @@ public class FlowDurabilityTest {
                 if (run.isBuilding()) {
                     assertBuildNotHung(story, run, 30_000);
                 }
-                verifyCompletedCleanly(story.j.jenkins, run);
+                verifyCompletedCleanly(story.j.jenkins, run, true);
                 story.j.assertLogContains(logStart[0], run);
                 if (run.isBuilding()) {
                     try {

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -1,5 +1,11 @@
 package org.jenkinsci.plugins.workflow.cps;
 
+import static jenkins.test.RunMatchers.completed;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
+
 import com.google.common.util.concurrent.ListenableFuture;
 import hudson.model.Queue;
 import hudson.model.Result;
@@ -48,9 +54,7 @@ public class PersistenceProblemsTest {
 
     /** Verifies all the assumptions about a cleanly finished build. */
     static void assertCompletedCleanly(WorkflowRun run) throws Exception {
-        while (run.isBuilding()) {
-            Thread.sleep(100); // TODO seems to be unpredictable
-        }
+        await().until(() -> run, completed());
         Assert.assertNotNull(run.getResult());
         FlowExecution fe = run.getExecution();
         FlowExecutionList.get().forEach(f -> {
@@ -61,17 +65,14 @@ public class PersistenceProblemsTest {
         Assert.assertTrue(
                 "Queue not empty after completion!", Queue.getInstance().isEmpty());
 
-        if (fe instanceof CpsFlowExecution) {
-            CpsFlowExecution cpsExec = (CpsFlowExecution) fe;
+        if (fe instanceof CpsFlowExecution cpsExec) {
             Assert.assertTrue(cpsExec.isComplete());
             Assert.assertEquals(Boolean.TRUE, cpsExec.done);
             Assert.assertEquals(1, cpsExec.getCurrentHeads().size());
             Assert.assertTrue(cpsExec.isComplete());
-            Assert.assertTrue(cpsExec.getCurrentHeads().get(0) instanceof FlowEndNode);
+            assertThat(cpsExec.getCurrentHeads().get(0), isA(FlowEndNode.class));
             Assert.assertTrue(cpsExec.startNodes == null || cpsExec.startNodes.isEmpty());
-            while (cpsExec.blocksRestart()) {
-                Thread.sleep(100); // TODO ditto
-            }
+            await().until(cpsExec::blocksRestart, is(false));
         } else {
             System.out.println("WARNING: no FlowExecutionForBuild");
         }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -53,7 +53,7 @@ public class PersistenceProblemsTest {
             });
 
     /** Verifies all the assumptions about a cleanly finished build. */
-    static void assertCompletedCleanly(WorkflowRun run, boolean verifyFlowEndNode) throws Exception {
+    private static void assertCompletedCleanly(WorkflowRun run, boolean verifyFlowEndNode) throws Exception {
         await().until(() -> run, completed());
         Assert.assertNotNull(run.getResult());
         FlowExecution fe = run.getExecution();
@@ -67,7 +67,7 @@ public class PersistenceProblemsTest {
 
         if (fe instanceof CpsFlowExecution cpsExec) {
             Assert.assertTrue(cpsExec.isComplete());
-            Assert.assertEquals(Boolean.TRUE, cpsExec.done);
+            Assert.assertTrue(cpsExec.done);
             Assert.assertTrue(cpsExec.isComplete());
             if (verifyFlowEndNode) {
                 Assert.assertEquals(1, cpsExec.getCurrentHeads().size());
@@ -76,6 +76,7 @@ public class PersistenceProblemsTest {
             }
             await().until(cpsExec::blocksRestart, is(false));
         } else {
+            Assert.assertFalse("did not need to verify FlowEndNode when there is no FlowExecution", verifyFlowEndNode);
             System.out.println("WARNING: no FlowExecutionForBuild");
         }
     }
@@ -185,7 +186,7 @@ public class PersistenceProblemsTest {
         story.then(j -> {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
-            assertCompletedCleanly(run, true);
+            assertCompletedCleanly(run, false);
             Assert.assertEquals(Result.FAILURE, run.getResult());
         });
     }
@@ -200,7 +201,7 @@ public class PersistenceProblemsTest {
         story.then(j -> {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
-            assertCompletedCleanly(run, true);
+            assertCompletedCleanly(run, false);
             Assert.assertEquals(Result.FAILURE, run.getResult());
         });
     }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -192,18 +192,14 @@ public class PersistenceProblemsTest {
     @Test
     public void completedNoNodesPersisted() throws Exception {
         final int[] build = new int[1];
-        final Result[] executionAndBuildResult = new Result[2];
         story.thenWithHardShutdown(j -> {
             WorkflowRun run = runBasicBuild(j, DEFAULT_JOBNAME, build);
             FileUtils.deleteDirectory(((CpsFlowExecution) run.getExecution()).getStorageDir());
-            executionAndBuildResult[0] = ((CpsFlowExecution) run.getExecution()).getResult();
-            executionAndBuildResult[1] = run.getResult();
         });
         story.then(j -> {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
             assertCompletedCleanly(run, true);
-            // assertNulledExecution(run);
             Assert.assertEquals(Result.FAILURE, run.getResult());
         });
     }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -173,7 +173,6 @@ public class PersistenceProblemsTest {
     public void completedFinalFlowNodeNotPersisted() throws Exception {
         CpsFlowExecution.OPTIMIZE_STORAGE_UPON_COMPLETION = false;
         final int[] build = new int[1];
-        final Result[] executionAndBuildResult = new Result[2];
         story.thenWithHardShutdown(j -> {
             WorkflowRun run = runBasicBuild(j, DEFAULT_JOBNAME, build);
             String finalId = run.getExecution().getCurrentHeads().get(0).getId();
@@ -181,14 +180,11 @@ public class PersistenceProblemsTest {
             // Hack but deletes the file from disk
             CpsFlowExecution cpsExec = (CpsFlowExecution) run.getExecution();
             Files.delete(cpsExec.getStorageDir().toPath().resolve(finalId + ".xml"));
-            executionAndBuildResult[0] = ((CpsFlowExecution) run.getExecution()).getResult();
-            executionAndBuildResult[1] = run.getResult();
         });
         story.then(j -> {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
             assertCompletedCleanly(run, true);
-            //            assertNulledExecution(run);
             Assert.assertEquals(Result.FAILURE, run.getResult());
         });
     }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -2,8 +2,8 @@ package org.jenkinsci.plugins.workflow.cps;
 
 import static jenkins.test.RunMatchers.completed;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 
 import com.google.common.util.concurrent.ListenableFuture;

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -171,6 +171,7 @@ public class PersistenceProblemsTest {
     /** Simulates something happening badly during final shutdown, which may cause build to not appear done. */
     @Test
     public void completedFinalFlowNodeNotPersisted() throws Exception {
+        // TODO is this test even useful after #807, since it relies on separate flow nodes?
         CpsFlowExecution.OPTIMIZE_STORAGE_UPON_COMPLETION = false;
         final int[] build = new int[1];
         story.thenWithHardShutdown(j -> {

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -53,7 +53,7 @@ public class PersistenceProblemsTest {
             });
 
     /** Verifies all the assumptions about a cleanly finished build. */
-    static void assertCompletedCleanly(WorkflowRun run) throws Exception {
+    static void assertCompletedCleanly(WorkflowRun run, boolean verifyFlowEndNode) throws Exception {
         await().until(() -> run, completed());
         Assert.assertNotNull(run.getResult());
         FlowExecution fe = run.getExecution();
@@ -68,10 +68,12 @@ public class PersistenceProblemsTest {
         if (fe instanceof CpsFlowExecution cpsExec) {
             Assert.assertTrue(cpsExec.isComplete());
             Assert.assertEquals(Boolean.TRUE, cpsExec.done);
-            Assert.assertEquals(1, cpsExec.getCurrentHeads().size());
             Assert.assertTrue(cpsExec.isComplete());
-            assertThat(cpsExec.getCurrentHeads().get(0), isA(FlowEndNode.class));
-            Assert.assertTrue(cpsExec.startNodes == null || cpsExec.startNodes.isEmpty());
+            if (verifyFlowEndNode) {
+                Assert.assertEquals(1, cpsExec.getCurrentHeads().size());
+                assertThat(cpsExec.getCurrentHeads().get(0), isA(FlowEndNode.class));
+                Assert.assertTrue(cpsExec.startNodes == null || cpsExec.startNodes.isEmpty());
+            }
             await().until(cpsExec::blocksRestart, is(false));
         } else {
             System.out.println("WARNING: no FlowExecutionForBuild");
@@ -111,7 +113,7 @@ public class PersistenceProblemsTest {
         job.addProperty(new DurabilityHintJobProperty(hint));
         WorkflowRun run = j.buildAndAssertSuccess(job);
         jobIdNumber[0] = run.getNumber();
-        assertCompletedCleanly(run);
+        assertCompletedCleanly(run, true);
         return run;
     }
 
@@ -185,10 +187,9 @@ public class PersistenceProblemsTest {
         story.then(j -> {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
-            assertCompletedCleanly(run);
+            assertCompletedCleanly(run, true);
             //            assertNulledExecution(run);
-            Assert.assertEquals(Result.SUCCESS, run.getResult());
-            assertResultMatchExecutionAndRun(run, executionAndBuildResult);
+            Assert.assertEquals(Result.FAILURE, run.getResult());
         });
     }
     /** Perhaps there was a serialization error breaking the FlowGraph persistence for non-durable mode. */
@@ -205,10 +206,9 @@ public class PersistenceProblemsTest {
         story.then(j -> {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
-            assertCompletedCleanly(run);
+            assertCompletedCleanly(run, true);
             // assertNulledExecution(run);
-            Assert.assertEquals(Result.SUCCESS, run.getResult());
-            assertResultMatchExecutionAndRun(run, executionAndBuildResult);
+            Assert.assertEquals(Result.FAILURE, run.getResult());
         });
     }
 
@@ -231,7 +231,7 @@ public class PersistenceProblemsTest {
         story.then(j -> {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
-            assertCompletedCleanly(run);
+            assertCompletedCleanly(run, true);
             Assert.assertEquals(Result.SUCCESS, run.getResult());
             assertResultMatchExecutionAndRun(run, executionAndBuildResult);
         });
@@ -250,7 +250,7 @@ public class PersistenceProblemsTest {
             InputStepExecution exec = getInputStepExecution(run, "pause");
             exec.doProceedEmpty();
             j.waitForCompletion(run);
-            assertCompletedCleanly(run);
+            assertCompletedCleanly(run, true);
             Assert.assertEquals(Result.SUCCESS, run.getResult());
         });
     }
@@ -269,7 +269,7 @@ public class PersistenceProblemsTest {
             InputStepExecution exec = getInputStepExecution(run, "pause");
             exec.doProceedEmpty();
             j.waitForCompletion(run);
-            assertCompletedCleanly(run);
+            assertCompletedCleanly(run, true);
             Assert.assertEquals(Result.SUCCESS, run.getResult());
         });
     }
@@ -277,7 +277,6 @@ public class PersistenceProblemsTest {
     @Test
     public void inProgressMaxPerfDirtyShutdown() throws Exception {
         final int[] build = new int[1];
-        final String[] finalNodeId = new String[1];
         story.thenWithHardShutdown(j -> {
             runBasicPauseOnInput(j, DEFAULT_JOBNAME, build, FlowDurabilityHint.PERFORMANCE_OPTIMIZED);
             // SHOULD still save at end via persist-at-shutdown hooks
@@ -287,16 +286,13 @@ public class PersistenceProblemsTest {
             WorkflowRun run = r.getBuildByNumber(build[0]);
             Thread.sleep(1000);
             j.waitForCompletion(run);
-            assertCompletedCleanly(run);
+            assertCompletedCleanly(run, false);
             Assert.assertEquals(Result.FAILURE, run.getResult());
-            finalNodeId[0] = run.getExecution().getCurrentHeads().get(0).getId();
         });
         story.then(j -> {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
-            assertCompletedCleanly(run);
-            Assert.assertEquals(
-                    finalNodeId[0], run.getExecution().getCurrentHeads().get(0).getId());
+            assertCompletedCleanly(run, false);
             // JENKINS-50199, verify it doesn't try to resume again
         });
     }
@@ -315,7 +311,7 @@ public class PersistenceProblemsTest {
         story.then(j -> {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
-            assertCompletedCleanly(run);
+            assertCompletedCleanly(run, false);
         });
     }
 
@@ -335,7 +331,7 @@ public class PersistenceProblemsTest {
         story.then(j -> {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
-            assertCompletedCleanly(run);
+            assertCompletedCleanly(run, true);
             j.assertLogContains("FileNotFoundException", run);
         });
     }
@@ -353,7 +349,7 @@ public class PersistenceProblemsTest {
         story.then(j -> {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
-            assertCompletedCleanly(run);
+            assertCompletedCleanly(run, false);
         });
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.baseline>2.516</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <!-- TODO: Add org.codehaus.groovy:groovy and org.codehaus.groovy:groovy:sources to Jenkins core BOM so this can be deleted? (currently it only specifies groovy-all) -->
     <groovy.version>2.4.21</groovy.version>


### PR DESCRIPTION
Switching the default for the option introduced in #1008. CloudBees CI has been running in this mode in HA controllers for most of a year now and I am unaware of any resulting problems. In the meantime, the deadlock that can result from `createPlaceholderNodes` from `onLoad` has been observed in non-HA controllers (https://github.com/jenkinsci/workflow-job-plugin/pull/747) so I think it is best to just deprecate this trick for everyone.

Also bumping the Jenkins baseline from 2.504.x to 2.516.x, to match that of `workflow-job`.