### PR TITLE
Playwright test of `workflow-editor.js`

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -156,6 +156,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>playwright</artifactId>
+      <version>1.59.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <scope>test</scope>

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition.java
@@ -26,9 +26,11 @@ package org.jenkinsci.plugins.workflow.cps;
 
 import static org.jenkinsci.plugins.workflow.cps.persistence.PersistenceContext.JOB;
 
+import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.Main;
 import hudson.model.Action;
 import hudson.model.Descriptor;
 import hudson.model.Item;
@@ -56,6 +58,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -139,6 +142,11 @@ public class CpsFlowDefinition extends FlowDefinition {
 
     @Extension
     public static class DescriptorImpl extends FlowDefinitionDescriptor {
+
+        /** HtmlUnit and ACE do not seem to mix. */
+        @VisibleForTesting
+        @Restricted(DoNotUse.class)
+        public boolean enableWorkflowEditor = !Main.isUnitTest;
 
         /* In order to fix SECURITY-2450 without causing significant UX regressions, we decided to continue to
          * automatically approve scripts on save if the script was modified by an administrator. To make this possible,

--- a/plugin/src/main/js/samples.js
+++ b/plugin/src/main/js/samples.js
@@ -3,13 +3,13 @@ import $ from 'jquery';
 export function addSamplesWidget(editor, editorId, samplesUrl) {
     var samples = [];
 
-    if ($('#workflow-editor-wrapper .samples').length) {
+    if ($('#workflow-editor-samples').length) {
         // Already there.
         return;
     }
 
     var $aceEditor = $('#' + editorId);
-    var sampleSelect = $('<select></select>');
+    var sampleSelect = $('<select id="workflow-editor-samples"></select>');
 
     sampleSelect.append('<option >try sample Pipeline...</option>');
     fetch(samplesUrl, {
@@ -26,11 +26,8 @@ export function addSamplesWidget(editor, editorId, samplesUrl) {
         }
     });
 
-    var samplesDiv = $('<div class="samples"></div>');
-    samplesDiv.append(sampleSelect);
-
-    samplesDiv.insertBefore($aceEditor);
-    samplesDiv.css({
+    sampleSelect.insertBefore($aceEditor);
+    sampleSelect.css({
         'position': 'absolute',
         'right': '1px',
         'z-index': 100,

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/editor/workflow-editor.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/editor/workflow-editor.jelly
@@ -7,16 +7,15 @@
         </st:attribute>
     </st:documentation>
     <j:choose>
-        <j:when test="${h.isUnitTest}">
-            <!-- HtmlUnit and ACE do not seem to mix. -->
-            <f:textarea value="${script}" checkMethod="post" checkUrl="${attrs.checkUrl}" checkDependsOn="${attrs.checkDependsOn}"/>
-        </j:when>
-        <j:otherwise>
+        <j:when test="${app.getDescriptor('org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition').enableWorkflowEditor}">
             <div class="workflow-editor-wrapper" style="display: none; position: relative">
                 <f:textarea value="${script}" checkMethod="post" checkUrl="${attrs.checkUrl}" checkDependsOn="${attrs.checkDependsOn}"/>
                 <div class="editor" style="height: 350px;" samplesUrl="${rootURL}/workflow-cps-samples/" />
             </div>
             <st:adjunct includes="org.jenkinsci.plugins.workflow.cps.workflow-editor"/>
+        </j:when>
+        <j:otherwise>
+            <f:textarea value="${script}" checkMethod="post" checkUrl="${attrs.checkUrl}" checkDependsOn="${attrs.checkDependsOn}"/>
         </j:otherwise>
     </j:choose>
 </j:jelly>

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
@@ -95,7 +95,7 @@ class WorkflowEditorTest {
     public static final class HeadlessOptionsFactory implements OptionsFactory {
         @Override
         public Options getOptions() {
-            return new Options().setHeadless(Boolean.valueOf(System.getenv("CI")));
+            return new Options().setHeadless(!Boolean.parseBoolean(System.getenv("PLAYWRIGHT_HEADED")));
         }
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
@@ -39,6 +39,8 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.GroovySample;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -46,6 +48,7 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 @WithJenkins
 class WorkflowEditorTest {
 
+    @DisabledOnOs(OS.WINDOWS) // TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/1775#discussion_r3220669617
     @Test
     void smokes(JenkinsRule r, Page page) throws Exception {
         ExtensionList.lookupSingleton(CpsFlowDefinition.DescriptorImpl.class).enableWorkflowEditor = true;

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
@@ -28,6 +28,7 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.junit.Options;
 import com.microsoft.playwright.junit.OptionsFactory;
 import com.microsoft.playwright.junit.UsePlaywright;
+import hudson.ExtensionList;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,7 @@ class WorkflowEditorTest {
 
     @Test
     void xxx(JenkinsRule r, Page page) throws Exception {
+        ExtensionList.lookupSingleton(CpsFlowDefinition.DescriptorImpl.class).enableWorkflowEditor = true;
         var p = r.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("", true));
         page.navigate(p.getAbsoluteUrl() + "configure");

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
@@ -36,6 +36,7 @@ import com.microsoft.playwright.options.AriaRole;
 import hudson.ExtensionList;
 import java.util.List;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.GroovySample;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -46,25 +47,30 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 class WorkflowEditorTest {
 
     @Test
-    void xxx(JenkinsRule r, Page page) throws Exception {
-        page.context().grantPermissions(List.of("clipboard-read", "clipboard-write"));
+    void smokes(JenkinsRule r, Page page) throws Exception {
         ExtensionList.lookupSingleton(CpsFlowDefinition.DescriptorImpl.class).enableWorkflowEditor = true;
         var p = r.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("", true));
-        page.navigate(p.getAbsoluteUrl() + "configure");
-        page.getByRole(AriaRole.COMBOBOX).nth(1).selectOption("scripted");
-        page.locator(".ace_content").click();
-        page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Cursor at row"))
-                .press("ControlOrMeta+a");
-        page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Cursor at row"))
-                .press("ControlOrMeta+x");
 
-        // Assert that clipboard starts with "node {"
-        String clipboard1 = (String) page.evaluate("navigator.clipboard.readText()");
-        assertThat(clipboard1, startsWith("node {"));
+        // Configure project, select sample, focus editor
+        page.context().grantPermissions(List.of("clipboard-read", "clipboard-write"));
+        page.navigate(p.getAbsoluteUrl() + "configure");
+        page.getByRole(AriaRole.COMBOBOX)
+                .nth(1)
+                .selectOption(ExtensionList.lookupSingleton(GroovySample.Scripted.class)
+                        .name());
+        page.locator(".ace_content").click();
+        var textbox = page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Cursor at row"));
+
+        // Cut the sample to clipboard
+        textbox.press("ControlOrMeta+a");
+        textbox.press("ControlOrMeta+x");
+        assertThat(
+                "looks like scripted.groovy",
+                (String) page.evaluate("navigator.clipboard.readText()"),
+                startsWith("node {"));
 
         // Type "node {\n" again (character by character, not .fill())
-        var textbox = page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Cursor at row"));
         textbox.pressSequentially("node {");
         textbox.press("Enter");
 
@@ -75,12 +81,13 @@ class WorkflowEditorTest {
         textbox.press("ControlOrMeta+a");
         textbox.press("ControlOrMeta+c");
 
-        // Assert clipboard contains the formatted code with proper indentation
-        String clipboard2 = (String) page.evaluate("navigator.clipboard.readText()");
-        assertThat(clipboard2, equalTo("""
-                node {
-                    sh 'echo hello'
-                }"""));
+        assertThat(
+                "clipboard contains the formatted code with proper indentation",
+                (String) page.evaluate("navigator.clipboard.readText()"),
+                equalTo("""
+            node {
+                sh 'echo hello'
+            }"""));
     }
 
     public static final class HeadlessOptionsFactory implements OptionsFactory {

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
@@ -58,8 +58,7 @@ class WorkflowEditorTest {
         // Configure project, select sample, focus editor
         page.context().grantPermissions(List.of("clipboard-read", "clipboard-write"));
         page.navigate(p.getAbsoluteUrl() + "configure");
-        page.getByRole(AriaRole.COMBOBOX)
-                .nth(1)
+        page.locator("#workflow-editor-samples")
                 .selectOption(ExtensionList.lookupSingleton(GroovySample.Scripted.class)
                         .name());
         page.locator(".ace_content").click();

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
@@ -28,6 +28,7 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.junit.Options;
 import com.microsoft.playwright.junit.OptionsFactory;
 import com.microsoft.playwright.junit.UsePlaywright;
+import com.microsoft.playwright.options.AriaRole;
 import hudson.ExtensionList;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -45,8 +46,15 @@ class WorkflowEditorTest {
         var p = r.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("", true));
         page.navigate(p.getAbsoluteUrl() + "configure");
-        Thread.sleep(5_000);
-        // TODO check some workflow-editor.js functionality
+        page.getByRole(AriaRole.COMBOBOX).nth(1).selectOption("scripted");
+        page.locator(".ace_content").click();
+        page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Cursor at row"))
+                .press("ControlOrMeta+a");
+        page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Cursor at row"))
+                .press("ControlOrMeta+x");
+        // TODO assert that clipboard starts with "node {"
+        // TODO now type "node {\n" again (do *not* use .fill(String)), then "sh 'echo hello",
+        // and C-A C-C assert clipboard contains "node {\n    sh 'echo hello'\n}"
     }
 
     public static final class HeadlessOptionsFactory implements OptionsFactory {

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
@@ -24,12 +24,17 @@
 
 package org.jenkinsci.plugins.workflow;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.junit.Options;
 import com.microsoft.playwright.junit.OptionsFactory;
 import com.microsoft.playwright.junit.UsePlaywright;
 import com.microsoft.playwright.options.AriaRole;
 import hudson.ExtensionList;
+import java.util.List;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.jupiter.api.Test;
@@ -42,6 +47,7 @@ class WorkflowEditorTest {
 
     @Test
     void xxx(JenkinsRule r, Page page) throws Exception {
+        page.context().grantPermissions(List.of("clipboard-read", "clipboard-write"));
         ExtensionList.lookupSingleton(CpsFlowDefinition.DescriptorImpl.class).enableWorkflowEditor = true;
         var p = r.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("", true));
@@ -52,9 +58,29 @@ class WorkflowEditorTest {
                 .press("ControlOrMeta+a");
         page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Cursor at row"))
                 .press("ControlOrMeta+x");
-        // TODO assert that clipboard starts with "node {"
-        // TODO now type "node {\n" again (do *not* use .fill(String)), then "sh 'echo hello",
-        // and C-A C-C assert clipboard contains "node {\n    sh 'echo hello'\n}"
+
+        // Assert that clipboard starts with "node {"
+        String clipboard1 = (String) page.evaluate("navigator.clipboard.readText()");
+        assertThat(clipboard1, startsWith("node {"));
+
+        // Type "node {\n" again (character by character, not .fill())
+        var textbox = page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Cursor at row"));
+        textbox.pressSequentially("node {");
+        textbox.press("Enter");
+
+        // Type "sh 'echo hello" (without closing quote to test auto-completion)
+        textbox.pressSequentially("sh 'echo hello");
+
+        // Select all and copy
+        textbox.press("ControlOrMeta+a");
+        textbox.press("ControlOrMeta+c");
+
+        // Assert clipboard contains the formatted code with proper indentation
+        String clipboard2 = (String) page.evaluate("navigator.clipboard.readText()");
+        assertThat(clipboard2, equalTo("""
+                node {
+                    sh 'echo hello'
+                }"""));
     }
 
     public static final class HeadlessOptionsFactory implements OptionsFactory {

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.junit.Options;
+import com.microsoft.playwright.junit.OptionsFactory;
+import com.microsoft.playwright.junit.UsePlaywright;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@UsePlaywright(WorkflowEditorTest.HeadlessOptionsFactory.class)
+@WithJenkins
+class WorkflowEditorTest {
+
+    @Test
+    void xxx(JenkinsRule r, Page page) throws Exception {
+        var p = r.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("", true));
+        page.navigate(p.getAbsoluteUrl() + "configure");
+        Thread.sleep(5_000);
+        // TODO check some workflow-editor.js functionality
+    }
+
+    public static final class HeadlessOptionsFactory implements OptionsFactory {
+        @Override
+        public Options getOptions() {
+            return new Options().setHeadless(Boolean.valueOf(System.getenv("CI")));
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-cps-plugin/pull/1738#pullrequestreview-4221129000

[CloudBees-internal link](https://cloudbees.atlassian.net/browse/BEE-71824)

----

My first concern is how to run Playwright itself in CI. I do not really want it [downloading Chrome from Microsoft’s CDN](https://playwright.dev/java/docs/browsers#install-behind-a-firewall-or-a-proxy) on every build. I thought about [running in Docker instead](https://playwright.dev/java/docs/ci#jenkins), though this introduces its own problems: using Testcontainers does not seem practical since `RealJenkinsRule` does not support running in a container yet, and `JenkinsRule` does not let you listen on anything other than 127.0.0.1, which would not allow the Docker host to be exposed to the Playwright container; I could run this test directly using Maven inside that image, but `pipeline-library` does not support that, so I would need to run this test in its own CI branch and collect test results manually.