### PR TITLE
Stop proposing to use Maven tool installer in samples

### DIFF
--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/samples/github-maven.groovy
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/samples/github-maven.groovy
@@ -1,11 +1,6 @@
 pipeline {
     agent any
 
-    tools {
-        // Install the Maven version configured as "M3" and add it to the path.
-        maven "M3"
-    }
-
     stages {
         stage('Build') {
             steps {
@@ -13,10 +8,10 @@ pipeline {
                 git 'https://github.com/jglick/simple-maven-project-with-tests.git'
 
                 // Run Maven on a Unix agent.
-                sh "mvn -Dmaven.test.failure.ignore=true clean package"
+                sh 'mvn -Dmaven.test.failure.ignore=true clean package'
 
                 // To run Maven on a Windows agent, use
-                // bat "mvn -Dmaven.test.failure.ignore=true clean package"
+                // bat 'mvn -Dmaven.test.failure.ignore=true clean package'
             }
 
             post {

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/samples/github-maven.groovy
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/samples/github-maven.groovy
@@ -7,7 +7,7 @@ pipeline {
                 // Get some code from a GitHub repository
                 git 'https://github.com/jglick/simple-maven-project-with-tests.git'
 
-                // Run Maven on a Unix agent.
+                // Run the build on a Unix agent. You must have Maven installed.
                 sh 'mvn -Dmaven.test.failure.ignore=true clean package'
 
                 // To run Maven on a Windows agent, use

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/samples/scripted.groovy
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/samples/scripted.groovy
@@ -3,19 +3,13 @@ node {
     stage('Preparation') { // for display purposes
         // Get some code from a GitHub repository
         git 'https://github.com/jglick/simple-maven-project-with-tests.git'
-        // Get the Maven tool.
-        // ** NOTE: This 'M3' Maven tool must be configured
-        // **       in the global configuration.
-        mvnHome = tool 'M3'
     }
     stage('Build') {
         // Run the maven build
-        withEnv(["MVN_HOME=$mvnHome"]) {
-            if (isUnix()) {
-                sh '"$MVN_HOME/bin/mvn" -Dmaven.test.failure.ignore clean package'
-            } else {
-                bat(/"%MVN_HOME%\bin\mvn" -Dmaven.test.failure.ignore clean package/)
-            }
+        if (isUnix()) {
+            sh 'mvn -Dmaven.test.failure.ignore clean package'
+        } else {
+            bat 'mvn -Dmaven.test.failure.ignore clean package'
         }
     }
     stage('Results') {

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/samples/scripted.groovy
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/samples/scripted.groovy
@@ -4,7 +4,7 @@ node {
         git 'https://github.com/jglick/simple-maven-project-with-tests.git'
     }
     stage('Build') {
-        // Run the maven build
+        // Run the build. You must have Maven installed.
         if (isUnix()) {
             sh 'mvn -Dmaven.test.failure.ignore clean package'
         } else {

--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/samples/scripted.groovy
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/cps/samples/scripted.groovy
@@ -1,5 +1,4 @@
 node {
-    def mvnHome
     stage('Preparation') { // for display purposes
         // Get some code from a GitHub repository
         git 'https://github.com/jglick/simple-maven-project-with-tests.git'


### PR DESCRIPTION
We do not generally want to encourage use of tool installers these days, especially something downloading from a public (non-Jenkins) server. Made samples not run out of the box. Predates #350. Not addressing #1772 at this time.