### PR TITLE
Enable Pipeline editor search shortcut

### DIFF
--- a/plugin/src/main/js/workflow-editor.js
+++ b/plugin/src/main/js/workflow-editor.js
@@ -6,6 +6,7 @@ import { addSamplesWidget } from './samples';
 // Import ACE
 import ace from "ace-builds/src-noconflict/ace";
 import "ace-builds/src-noconflict/ext-language_tools";
+import "ace-builds/src-noconflict/ext-searchbox";
 import "ace-builds/src-noconflict/mode-groovy";
 import "ace-builds/src-noconflict/snippets/javascript";
 

--- a/plugin/src/main/less/workflow-editor.less
+++ b/plugin/src/main/less/workflow-editor.less
@@ -126,6 +126,70 @@
   background: var(--selection-color);
 }
 
+// Ace renders its search box inside the editor wrapper, so keep it aligned with Jenkins theme variables.
+.workflow-editor-wrapper .ace_search {
+  color: var(--text-color);
+  background: var(--card-background);
+  border: 1px solid var(--input-border);
+  border-top: 0;
+  border-radius: 0 0 0 var(--form-input-border-radius);
+  box-shadow: var(--dropdown-box-shadow);
+  animation: workflow-editor-search-slide-down 0.16s ease-out;
+}
+
+.workflow-editor-wrapper .ace_search_form,
+.workflow-editor-wrapper .ace_replace_form {
+  line-height: 1.9;
+}
+
+.workflow-editor-wrapper .ace_search_field {
+  color: var(--text-color);
+  background: var(--input-color);
+  border-color: var(--input-border);
+
+  &:focus {
+    border-color: var(--focus-input-border);
+    box-shadow: var(--form-input-glow--focus);
+  }
+}
+
+.workflow-editor-wrapper .ace_searchbtn,
+.workflow-editor-wrapper .ace_button {
+  color: var(--text-color);
+  background: var(--button-background);
+  border-color: var(--input-border);
+}
+
+.workflow-editor-wrapper .ace_searchbtn:hover,
+.workflow-editor-wrapper .ace_button:hover {
+  background: var(--button-background--hover);
+  border-color: var(--input-border-hover);
+}
+
+.workflow-editor-wrapper .ace_button.checked {
+  border-color: var(--focus-input-border);
+}
+
+.workflow-editor-wrapper .ace_search_counter {
+  color: var(--text-color-secondary);
+}
+
+@keyframes workflow-editor-search-slide-down {
+  from {
+    transform: translateY(calc(-100% - 10px));
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workflow-editor-wrapper .ace_search {
+    animation: none;
+  }
+}
+
 .ace_editor.ace_multiselect .ace_selection.ace_start {
   box-shadow: 0 0 3px 0px #1D1F21;
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
@@ -140,23 +140,40 @@ class WorkflowEditorTest {
             }""";
         p.setDefinition(new CpsFlowDefinition(pipeline, true));
 
+        var consoleMessages = new ArrayList<ConsoleMessage>();
+        page.onConsoleMessage(consoleMessages::add);
+
         page.navigate(p.getAbsoluteUrl() + "configure");
-        page.locator(".ace_content").click();
-        var textbox = page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Cursor at row"));
-        var originalScript = page.locator(".workflow-editor-wrapper .editor").evaluate("el => el.aceEditor.getValue()");
 
-        textbox.press("ControlOrMeta+f");
-        var searchInput = page.locator(".ace_search .ace_search_field").first();
-        searchInput.waitFor();
-        searchInput.fill("FarewellNeedle");
-        page.waitForFunction("() => document.querySelector('.ace_search_counter')?.textContent?.trim() === '1 of 1'");
-        searchInput.press("Enter");
+        assertAll(
+                () -> {
+                    page.locator(".ace_content").click();
+                    var textbox =
+                            page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Cursor at row"));
+                    var originalScript =
+                            page.locator(".workflow-editor-wrapper .editor").evaluate("el => el.aceEditor.getValue()");
 
-        assertThat(page.locator(".ace_search_counter").textContent().trim(), equalTo("1 of 1"));
-        assertThat(
-                page.locator(".workflow-editor-wrapper .editor").evaluate("el => el.aceEditor.getValue()"),
-                equalTo(originalScript));
-        assertThat(page.url(), startsWith(p.getAbsoluteUrl() + "configure"));
+                    textbox.press("ControlOrMeta+f");
+                    var searchInput = page.locator(".ace_search .ace_search_field").first();
+                    searchInput.waitFor();
+                    searchInput.fill("FarewellNeedle");
+                    page.waitForFunction(
+                            "() => document.querySelector('.ace_search_counter')?.textContent?.trim() === '1 of 1'");
+                    searchInput.press("Enter");
+
+                    assertThat(page.locator(".ace_search_counter").textContent().trim(), equalTo("1 of 1"));
+                    assertThat(
+                            page.locator(".workflow-editor-wrapper .editor").evaluate("el => el.aceEditor.getValue()"),
+                            equalTo(originalScript));
+                    assertThat(page.url(), startsWith(p.getAbsoluteUrl() + "configure"));
+                },
+                () -> assertThat(
+                        consoleMessages.stream()
+                                .filter(msg ->
+                                        msg.type().equals("error") || msg.type().equals("warning"))
+                                .map(msg -> "[" + msg.type() + "] " + msg.text() + " at " + msg.location())
+                                .toList(),
+                        empty()));
     }
 
     public static final class HeadlessOptionsFactory implements OptionsFactory {

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/WorkflowEditorTest.java
@@ -92,6 +92,53 @@ class WorkflowEditorTest {
             }"""));
     }
 
+    @DisabledOnOs(OS.WINDOWS) // Matches smokes: browser automation setup is not stable on Windows yet.
+    @Test
+    void searchShortcutOpensAceSearchBox(JenkinsRule r, Page page) throws Exception {
+        ExtensionList.lookupSingleton(CpsFlowDefinition.DescriptorImpl.class).enableWorkflowEditor = true;
+        var p = r.createProject(WorkflowJob.class, "p");
+        var pipeline = """
+            pipeline {
+                agent any
+                stages {
+                    stage('Hello') {
+                        steps {
+                            echo 'Hello World'
+                        }
+                    }
+                    stage('Middle') {
+                        steps {
+                            echo 'Still here'
+                        }
+                    }
+                    stage('Goodbye') {
+                        steps {
+                            echo 'FarewellNeedle World'
+                        }
+                    }
+                }
+            }""";
+        p.setDefinition(new CpsFlowDefinition(pipeline, true));
+
+        page.navigate(p.getAbsoluteUrl() + "configure");
+        page.locator(".ace_content").click();
+        var textbox = page.getByRole(AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("Cursor at row"));
+        var originalScript = page.locator(".workflow-editor-wrapper .editor").evaluate("el => el.aceEditor.getValue()");
+
+        textbox.press("ControlOrMeta+f");
+        var searchInput = page.locator(".ace_search .ace_search_field").first();
+        searchInput.waitFor();
+        searchInput.fill("FarewellNeedle");
+        page.waitForFunction("() => document.querySelector('.ace_search_counter')?.textContent?.trim() === '1 of 1'");
+        searchInput.press("Enter");
+
+        assertThat(page.locator(".ace_search_counter").textContent().trim(), equalTo("1 of 1"));
+        assertThat(
+                page.locator(".workflow-editor-wrapper .editor").evaluate("el => el.aceEditor.getValue()"),
+                equalTo(originalScript));
+        assertThat(page.url(), startsWith(p.getAbsoluteUrl() + "configure"));
+    }
+
     public static final class HeadlessOptionsFactory implements OptionsFactory {
         @Override
         public Options getOptions() {


### PR DESCRIPTION
Fixes jenkinsci/workflow-cps-plugin#1781

The Jenkins issue is reported against the Pipeline script editor. That editor is provided by this plugin through Ace, not by the Jenkins core CodeMirror widgets. Browser find can miss editor-owned/virtualized text, and when the Ace editor has focus, Ctrl-F/Cmd-F should open the editor search UI instead of being ignored or inserting the search text into the Pipeline definition.

This change imports Ace's built-in searchbox extension for the workflow editor and adds Jenkins-theme-aware styles for that search UI. The styles use the existing Jenkins CSS variables, so the searchbox follows light mode and dark mode, and it uses a short top-down entrance animation with a reduced-motion opt-out.

Testing done

- `git diff --check`
- `mvn -pl dgm-builder -DskipTests -Dlicense.skip=true -Dspotbugs.skip=true -Dspotless.check.skip=true install`
- `YARN_ENABLE_STRICT_SSL=false NODE_TLS_REJECT_UNAUTHORIZED=0 mvn -ntp -pl plugin -am -Dtest=org.jenkinsci.plugins.workflow.WorkflowEditorTest#searchShortcutOpensAceSearchBox -Dlicense.skip=true -Dspotbugs.skip=true -Dspotless.check.skip=true test`
- `YARN_ENABLE_STRICT_SSL=false NODE_TLS_REJECT_UNAUTHORIZED=0 mvn -ntp -pl plugin -am -DskipTests -Dlicense.skip=true -Dspotbugs.skip=true -Dspotless.check.skip=true package`
- Loaded the built `workflow-cps.hpi` into a local Jenkins image on top of the Jenkins core PR used for initial testing.
- Verified Ctrl-F/Cmd-F opens Ace search in the Pipeline editor, `FarewellNeedle` reports `1 of 1`, Enter stays on the job configure page and does not activate Save/Apply or modify the Pipeline script.

Note: the TLS environment variables were only needed in the isolated Docker environment because Corepack/Yarn/npm hit local certificate-chain validation errors while downloading dependencies.

Screenshots

Light mode:
![Pipeline editor searchbox in Jenkins light mode](https://raw.githubusercontent.com/amarkdotdev/workflow-cps-plugin/workflow-cps-search-screenshots/screenshots/workflow-cps-search-light.png)

Dark mode:
![Pipeline editor searchbox in Jenkins dark mode](https://raw.githubusercontent.com/amarkdotdev/workflow-cps-plugin/workflow-cps-search-screenshots/screenshots/workflow-cps-search-dark.png)
