### PR TITLE
Label `javascript-security` updates as `bug`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,5 +24,3 @@ updates:
       javascript-security:
         applies-to: security-updates
         dependency-type: production
-        labels:
-          - "bug"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,5 @@ updates:
       javascript-security:
         applies-to: security-updates
         dependency-type: production
+        labels:
+          - "bug"

--- a/.github/workflows/label-dependabot-security.yml
+++ b/.github/workflows/label-dependabot-security.yml
@@ -1,0 +1,21 @@
+name: Label Dependabot security updates
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches:
+      - 'dependabot/npm_and_yarn/plugin/javascript-security-*'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label-security-updates:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && contains(github.head_ref, 'javascript-security')
+    steps:
+      - name: Replace dependencies label with bug
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --remove-label dependencies --add-label bug

--- a/.github/workflows/label-dependabot-security.yml
+++ b/.github/workflows/label-dependabot-security.yml
@@ -3,8 +3,6 @@ name: Label Dependabot security updates
 on:
   pull_request_target:
     types: [opened]
-    branches:
-      - 'dependabot/npm_and_yarn/plugin/javascript-security-*'
 
 permissions:
   pull-requests: write
@@ -12,7 +10,7 @@ permissions:
 jobs:
   label-security-updates:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && contains(github.head_ref, 'javascript-security')
+    if: github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/npm_and_yarn/plugin/javascript-security-')
     steps:
       - name: Replace dependencies label with bug
         env:


### PR DESCRIPTION
Amends #1011 to apply the `bug` label to security updates in the `javascript-security` group (e.g. #1773), rather than the default `dependencies` label applied to all other Dependabot PRs.

[CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-71826)

🤖 Generated with [Claude Code](https://claude.com/claude-code)