### PR TITLE
Finalize recovered CPS executions with no threads

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -732,51 +732,54 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
     @GuardedBy("this")
     void createPlaceholderNodes(Throwable failureReason) throws Exception {
         synchronized (this) {
-            this.done = true;
-
-            if (this.owner != null) {
-                // Ensure that the Run is marked as completed (failed) if it isn't already so it won't show as running
-                Queue.Executable ex = owner.getExecutable();
-                if (ex instanceof Run) {
-                    Result res = ((Run) ex).getResult();
-                    setResult(res != null ? res : Result.FAILURE);
+            try {
+                if (this.owner != null) {
+                    // Ensure that the Run is marked as completed (failed) if it isn't already so it won't show as
+                    // running
+                    Queue.Executable ex = owner.getExecutable();
+                    if (ex instanceof Run) {
+                        Result res = ((Run) ex).getResult();
+                        setResult(res != null ? res : Result.FAILURE);
+                    }
                 }
-            }
 
-            programPromise =
-                    Futures.immediateFailedFuture(new IllegalStateException("Failed loading heads", failureReason));
-            LOGGER.log(Level.INFO, "Creating placeholder flownodes for execution: " + this);
-            if (this.owner != null) {
-                try {
-                    owner.getListener()
-                            .getLogger()
-                            .println("Creating placeholder flownodes because failed loading originals.");
-                } catch (Exception ex) {
-                    // It's okay to fail to log
+                programPromise =
+                        Futures.immediateFailedFuture(new IllegalStateException("Failed loading heads", failureReason));
+                LOGGER.log(Level.INFO, "Creating placeholder flownodes for execution: " + this);
+                if (this.owner != null) {
+                    try {
+                        owner.getListener()
+                                .getLogger()
+                                .println("Creating placeholder flownodes because failed loading originals.");
+                    } catch (Exception ex) {
+                        // It's okay to fail to log
+                    }
                 }
+
+                // Switch to fallback storage so we don't delete original node data
+                this.storageDir = (this.storageDir != null) ? this.storageDir + "-fallback" : "workflow-fallback";
+                this.storage = createStorage(); // Empty storage
+
+                // Clear out old start nodes and heads
+                this.startNodes = new Stack<>();
+                FlowHead head = new FlowHead(this);
+                this.heads = new TreeMap<>();
+                heads.put(head.getId(), head);
+                FlowStartNode start = new FlowStartNode(this, iotaStr());
+                head.newStartNode(start);
+
+                // Create end
+                FlowNode end = new FlowEndNode(
+                        this,
+                        iotaStr(),
+                        (FlowStartNode) startNodes.pop(),
+                        result,
+                        getCurrentHeads().toArray(new FlowNode[0]));
+                end.addAction(new ErrorAction(failureReason));
+                head.setNewHead(end);
+            } finally {
+                this.done = true;
             }
-
-            // Switch to fallback storage so we don't delete original node data
-            this.storageDir = (this.storageDir != null) ? this.storageDir + "-fallback" : "workflow-fallback";
-            this.storage = createStorage(); // Empty storage
-
-            // Clear out old start nodes and heads
-            this.startNodes = new Stack<>();
-            FlowHead head = new FlowHead(this);
-            this.heads = new TreeMap<>();
-            heads.put(head.getId(), head);
-            FlowStartNode start = new FlowStartNode(this, iotaStr());
-            head.newStartNode(start);
-
-            // Create end
-            FlowNode end = new FlowEndNode(
-                    this,
-                    iotaStr(),
-                    (FlowStartNode) startNodes.pop(),
-                    result,
-                    getCurrentHeads().toArray(new FlowNode[0]));
-            end.addAction(new ErrorAction(failureReason));
-            head.setNewHead(end);
         }
         saveOwner();
     }
@@ -936,6 +939,11 @@ public class CpsFlowExecution extends FlowExecution implements BlockableResume {
                         PROGRAM_STATE_SERIALIZATION.set(CpsFlowExecution.this);
                         try {
                             CpsThreadGroup g = (CpsThreadGroup) u.readObject();
+                            if (!g.getThreads().iterator().hasNext() && !isComplete()) {
+                                LOGGER.log(Level.WARNING, "Loaded program for {0} contains no CPS threads", owner);
+                                loadProgramFailed(new AbortException("Loaded program contains no CPS threads"), result);
+                                return;
+                            }
                             result.set(g);
                             pausedWhenLoaded = g.isPaused();
                             g.pause(false);

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/PersistenceProblemsTest.java
@@ -9,17 +9,22 @@ import static org.hamcrest.Matchers.isA;
 import com.google.common.util.concurrent.ListenableFuture;
 import hudson.model.Queue;
 import hudson.model.Result;
+import hudson.model.Run;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.io.FileUtils;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
 import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
 import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graph.FlowStartNode;
+import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.job.properties.DurabilityHintJobProperty;
@@ -104,6 +109,12 @@ public class PersistenceProblemsTest {
     static void assertResultMatchExecutionAndRun(WorkflowRun run, Result[] executionAndBuildResult) throws Exception {
         Assert.assertEquals(executionAndBuildResult[0], ((CpsFlowExecution) run.getExecution()).getResult());
         Assert.assertEquals(executionAndBuildResult[1], run.getResult());
+    }
+
+    private static void setField(Object target, Class<?> declaringClass, String name, Object value) throws Exception {
+        Field field = declaringClass.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
     }
 
     /** Create and run a basic build before we mangle its persisted contents.  Stores job number to jobIdNumber index 0. */
@@ -228,6 +239,47 @@ public class PersistenceProblemsTest {
             assertCompletedCleanly(run, true);
             Assert.assertEquals(Result.SUCCESS, run.getResult());
             assertResultMatchExecutionAndRun(run, executionAndBuildResult);
+        });
+    }
+
+    @Test
+    public void inProgressWithStepEndHeadButNoCpsThreads() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown(j -> {
+            WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, DEFAULT_JOBNAME);
+            job.setDefinition(new CpsFlowDefinition("stage('x') { echo 'doSomething' }", true));
+            WorkflowRun run = j.buildAndAssertSuccess(job);
+            build[0] = run.getNumber();
+            assertCompletedCleanly(run, true);
+            CpsFlowExecution cpsExec = (CpsFlowExecution) run.getExecution();
+            FlowNode stepEnd = new DepthFirstScanner().findFirstMatch(cpsExec, n -> n instanceof StepEndNode);
+            Assert.assertNotNull("expected completed build to contain a StepEndNode", stepEnd);
+
+            FlowHead head = cpsExec.getFirstHead();
+            Assert.assertNotNull("expected a persisted FlowHead", head);
+            head.head = stepEnd;
+            cpsExec.done = false;
+            CpsThreadGroup emptyProgram = new CpsThreadGroup(cpsExec);
+            try {
+                emptyProgram
+                        .runner
+                        .submit(() -> {
+                            emptyProgram.saveProgram(cpsExec.getProgramDataFile());
+                            return null;
+                        })
+                        .get();
+            } finally {
+                emptyProgram.shutdown();
+            }
+            setField(run, WorkflowRun.class, "completed", false);
+            setField(run, Run.class, "result", null);
+            run.save();
+        });
+        story.then(j -> {
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run, false);
+            Assert.assertEquals(Result.FAILURE, run.getResult());
         });
     }
 


### PR DESCRIPTION
Handle an unrecoverable Pipeline state where a `CpsFlowExecution` is restored with no CPS threads while its flow graph is still non-terminal.

When this happens, there is nothing for Pipeline to resume or interrupt, but the owning `WorkflowRun` can still remain marked as building. Treat an empty restored `CpsThreadGroup` on a non-complete execution as a program load failure, so the existing recovery path finalizes the run as `FAILURE` instead of leaving it stuck.

This also moves the `done = true` assignment in placeholder node creation until after the fallback nodes/actions are created, avoiding action persistence warnings on that path.

Fixes https://github.com/jenkinsci/workflow-cps-plugin/issues/1792

### Testing done

Added `PersistenceProblemsTest#inProgressWithStepEndHeadButNoCpsThreads`.

The test creates the persisted state directly:

1. Run a simple Pipeline to completion.
2. Move the persisted flow head back to a `StepEndNode`.
3. Clear the `WorkflowRun` completion/result state.
4. Save an empty `CpsThreadGroup` to `program.dat`.
5. Simulate a hard Jenkins restart.
6. Verify the build is recovered as `FAILURE`.

Ran locally:

```bash
export JAVA_HOME=$(/opt/homebrew/bin/brew --prefix openjdk)/libexec/openjdk.jdk/Contents/Home
/opt/homebrew/bin/mvn -ntp -pl plugin -Dtest=PersistenceProblemsTest#inProgressWithStepEndHeadButNoCpsThreads test
```

Result:

```text
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Related pull requests: none.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed