### PR TITLE
Adding in OAUTH login

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -101,6 +101,10 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>plain-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
     </dependency>
     <dependency>

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/GitOAuthTokenCredentialsProvider.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/GitOAuthTokenCredentialsProvider.java
@@ -1,0 +1,143 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.domains.SchemeRequirement;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.util.Secret;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Exposes secret-text OAuth tokens as Git-compatible username/password credentials.
+ *
+ * <p>The git plugin asks the credentials subsystem for {@link StandardUsernameCredentials} when authenticating
+ * HTTP(S) remotes. OAuth/PAT credentials are commonly stored in Jenkins as {@link StringCredentials}, so without this
+ * small adapter those token credentials are invisible to Pipeline jobs using {@link CpsScmFlowDefinition}.
+ */
+@Extension
+public class GitOAuthTokenCredentialsProvider extends CredentialsProvider {
+
+    static final String OAUTH_USERNAME = "oauth2";
+
+    @Override
+    public <C extends com.cloudbees.plugins.credentials.Credentials> List<C> getCredentialsInItem(
+            Class<C> type, Item item, Authentication authentication, List<DomainRequirement> domainRequirements) {
+        return getCredentials(type, item, authentication, domainRequirements);
+    }
+
+    @Override
+    public <C extends com.cloudbees.plugins.credentials.Credentials> List<C> getCredentialsInItemGroup(
+            Class<C> type,
+            ItemGroup itemGroup,
+            Authentication authentication,
+            List<DomainRequirement> domainRequirements) {
+        return getCredentials(type, itemGroup, authentication, domainRequirements);
+    }
+
+    private <C extends com.cloudbees.plugins.credentials.Credentials> List<C> getCredentials(
+            Class<C> type,
+            Object context,
+            Authentication authentication,
+            List<DomainRequirement> domainRequirements) {
+        if (!isGitHttpCredentialLookup(type, domainRequirements)) {
+            return Collections.emptyList();
+        }
+
+        List<StringCredentials> tokens;
+        if (context instanceof Item item) {
+            tokens = CredentialsProvider.lookupCredentialsInItem(
+                    StringCredentials.class, item, authentication, domainRequirements);
+        } else if (context instanceof ItemGroup itemGroup) {
+            tokens = CredentialsProvider.lookupCredentialsInItemGroup(
+                    StringCredentials.class, itemGroup, authentication, domainRequirements);
+        } else {
+            return Collections.emptyList();
+        }
+
+        List<C> adapted = new ArrayList<>(tokens.size());
+        for (StringCredentials token : tokens) {
+            adapted.add(type.cast(new OAuthTokenUsernamePasswordCredentials(token)));
+        }
+        return adapted;
+    }
+
+    private static boolean isGitHttpCredentialLookup(
+            Class<? extends com.cloudbees.plugins.credentials.Credentials> type,
+            List<DomainRequirement> domainRequirements) {
+        return StandardUsernameCredentials.class.isAssignableFrom(type)
+                && type.isAssignableFrom(OAuthTokenUsernamePasswordCredentials.class)
+                && hasHttpScheme(domainRequirements);
+    }
+
+    private static boolean hasHttpScheme(List<DomainRequirement> domainRequirements) {
+        if (domainRequirements == null) {
+            return false;
+        }
+        for (DomainRequirement requirement : domainRequirements) {
+            if (requirement instanceof SchemeRequirement schemeRequirement) {
+                String scheme = schemeRequirement.getScheme();
+                return "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
+            }
+        }
+        return false;
+    }
+
+    private static final class OAuthTokenUsernamePasswordCredentials extends BaseStandardCredentials
+            implements StandardUsernamePasswordCredentials {
+
+        private final StringCredentials delegate;
+
+        OAuthTokenUsernamePasswordCredentials(StringCredentials delegate) {
+            super(delegate.getScope(), delegate.getId(), delegate.getDescription());
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String getUsername() {
+            return OAUTH_USERNAME;
+        }
+
+        @Override
+        public boolean isUsernameSecret() {
+            return false;
+        }
+
+        @Override
+        public Secret getPassword() {
+            return delegate.getSecret();
+        }
+    }
+}

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/GitOAuthTokenCredentialsProviderTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/GitOAuthTokenCredentialsProviderTest.java
@@ -1,0 +1,131 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.cps;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.SchemeRequirement;
+import hudson.security.ACL;
+import hudson.util.Secret;
+import java.util.List;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class GitOAuthTokenCredentialsProviderTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void exposesSecretTextTokenAsGitHttpCredentials() throws Exception {
+        addOAuthToken();
+        WorkflowJob job = r.createProject(WorkflowJob.class);
+
+        List<StandardUsernamePasswordCredentials> credentials = CredentialsProvider.lookupCredentialsInItem(
+                StandardUsernamePasswordCredentials.class,
+                job,
+                ACL.SYSTEM2,
+                List.of(new SchemeRequirement("https")));
+
+        StandardUsernamePasswordCredentials token = credentials.stream()
+                .filter(c -> "oauth-token".equals(c.getId()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(GitOAuthTokenCredentialsProvider.OAUTH_USERNAME, token.getUsername());
+        assertEquals("token-value", token.getPassword().getPlainText());
+    }
+
+    @Test
+    public void findsSecretTextTokenByCredentialsIdForGitHttpCredentials() throws Exception {
+        addOAuthToken();
+        WorkflowJob job = r.createProject(WorkflowJob.class);
+
+        List<StandardUsernamePasswordCredentials> credentials = CredentialsProvider.lookupCredentialsInItem(
+                StandardUsernamePasswordCredentials.class,
+                job,
+                ACL.SYSTEM2,
+                List.of(new SchemeRequirement("https")));
+        StandardUsernamePasswordCredentials token =
+                CredentialsMatchers.firstOrNull(credentials, CredentialsMatchers.withId("oauth-token"));
+
+        assertNotNull(token);
+        assertEquals(GitOAuthTokenCredentialsProvider.OAUTH_USERNAME, token.getUsername());
+        assertEquals("token-value", token.getPassword().getPlainText());
+    }
+
+    @Test
+    public void doesNotExposeOAuthTokensForSshGitCredentials() throws Exception {
+        addOAuthToken();
+        WorkflowJob job = r.createProject(WorkflowJob.class);
+
+        List<String> ids = CredentialsProvider.lookupCredentialsInItem(
+                        StandardUsernamePasswordCredentials.class,
+                        job,
+                        ACL.SYSTEM2,
+                        List.of(new SchemeRequirement("ssh")))
+                .stream()
+                .map(StandardUsernamePasswordCredentials::getId)
+                .toList();
+
+        assertThat(ids, not(hasItem("oauth-token")));
+    }
+
+    @Test
+    public void doesNotExposeOAuthTokensForBroadCredentialLookups() throws Exception {
+        addOAuthToken();
+        WorkflowJob job = r.createProject(WorkflowJob.class);
+
+        List<Credentials> credentials = CredentialsProvider.lookupCredentialsInItem(
+                Credentials.class, job, ACL.SYSTEM2, List.of(new SchemeRequirement("https")));
+        List<String> adaptedIds = credentials.stream()
+                .filter(StandardUsernamePasswordCredentials.class::isInstance)
+                .map(StandardUsernamePasswordCredentials.class::cast)
+                .map(StandardUsernamePasswordCredentials::getId)
+                .toList();
+
+        assertThat(adaptedIds, not(hasItem("oauth-token")));
+    }
+
+    private static void addOAuthToken() throws Exception {
+        SystemCredentialsProvider.getInstance()
+                .getCredentials()
+                .add(new StringCredentialsImpl(
+                        CredentialsScope.GLOBAL, "oauth-token", "OAuth token for Git", Secret.fromString("token-value")));
+        SystemCredentialsProvider.getInstance().save();
+    }
+}


### PR DESCRIPTION
Adds Git OAuth/PAT support for Pipeline SCM credential lookups by adapting Jenkins secret-text credentials into Git-compatible username/password credentials for HTTP/HTTPS remotes.

The Git credential flow asks Jenkins for `StandardUsernameCredentials`, while OAuth/PAT values are commonly stored as `StringCredentials` from the plain credentials plugin. This change adds a credentials provider that exposes those secret-text tokens as username/password credentials using the token as the password and `oauth2` as the username, scoped only to HTTP/HTTPS Git credential lookups.

### Testing done

Ran the focused automated test suite:

```bash
mvn -pl plugin -am -Dtest=GitOAuthTokenCredentialsProviderTest test
Result: BUILD SUCCESS
Covered scenarios:
Secret-text OAuth token is exposed as Git-compatible HTTPS username/password credentials.
Token can be selected by credential id.
Token is not exposed for SSH Git credential lookups.
Adapter is not exposed during broad credential lookups.
Submitter checklist

Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!

Ensure that the pull request title represents the desired changelog entry

Please describe what you did

Link to relevant issues in GitHub or Jira

Link to relevant pull requests, esp. upstream and downstream changes

Ensure you have provided tests that demonstrate the feature works or the issue is fixed