### PR TITLE
[JENKINS-62410] Do not render the rich script editor for read-only viewers

### DIFF
--- a/plugin/src/main/resources/org/jenkinsci/plugins/workflow/editor/workflow-editor.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/workflow/editor/workflow-editor.jelly
@@ -7,7 +7,7 @@
         </st:attribute>
     </st:documentation>
     <j:choose>
-        <j:when test="${app.getDescriptor('org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition').enableWorkflowEditor}">
+        <j:when test="${app.getDescriptor('org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition').enableWorkflowEditor and !readOnlyMode}">
             <div class="workflow-editor-wrapper" style="display: none; position: relative">
                 <f:textarea value="${script}" checkMethod="post" checkUrl="${attrs.checkUrl}" checkDependsOn="${attrs.checkDependsOn}"/>
                 <div class="editor" style="height: 350px;" samplesUrl="${rootURL}/workflow-cps-samples/" />

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinitionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinitionTest.java
@@ -156,7 +156,10 @@ public class CpsFlowDefinitionTest {
         jenkins.jenkins.setSecurityRealm(jenkins.createDummySecurityRealm());
 
         MockAuthorizationStrategy mockStrategy = new MockAuthorizationStrategy();
-        mockStrategy.grant(Jenkins.READ, Item.READ, Item.EXTENDED_READ).everywhere().to("viewer");
+        mockStrategy
+                .grant(Jenkins.READ, Item.READ, Item.EXTENDED_READ)
+                .everywhere()
+                .to("viewer");
         mockStrategy.grant(Jenkins.ADMINISTER).everywhere().to("admin");
         jenkins.jenkins.setAuthorizationStrategy(mockStrategy);
 

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinitionTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinitionTest.java
@@ -25,15 +25,19 @@
 package org.jenkinsci.plugins.workflow.cps;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import hudson.ExtensionList;
 import hudson.cli.CLICommand;
 import hudson.cli.CLICommandInvoker;
 import hudson.cli.UpdateJobCommand;
@@ -51,9 +55,11 @@ import org.apache.tools.ant.filters.StringInputStream;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
+import org.htmlunit.html.DomNode;
 import org.htmlunit.html.HtmlCheckBoxInput;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlInput;
+import org.htmlunit.html.HtmlPage;
 import org.htmlunit.html.HtmlTextArea;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.scriptsecurity.scripts.languages.GroovyLanguage;
@@ -141,6 +147,41 @@ public class CpsFlowDefinitionTest {
 
         assertThat(ScriptApproval.get().getPendingScripts(), hasSize(1));
         assertFalse(ScriptApproval.get().isScriptApproved(groovy, GroovyLanguage.get()));
+    }
+
+    @Issue("JENKINS-62410")
+    @Test
+    public void readOnlyViewerSeesPlainScriptNotEditor() throws Exception {
+        ExtensionList.lookupSingleton(CpsFlowDefinition.DescriptorImpl.class).enableWorkflowEditor = true;
+        jenkins.jenkins.setSecurityRealm(jenkins.createDummySecurityRealm());
+
+        MockAuthorizationStrategy mockStrategy = new MockAuthorizationStrategy();
+        mockStrategy.grant(Jenkins.READ, Item.READ, Item.EXTENDED_READ).everywhere().to("viewer");
+        mockStrategy.grant(Jenkins.ADMINISTER).everywhere().to("admin");
+        jenkins.jenkins.setAuthorizationStrategy(mockStrategy);
+
+        String groovy = "echo 'hi from readOnlyViewerSeesPlainScriptNotEditor'";
+        WorkflowJob p = jenkins.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition(groovy, true));
+
+        JenkinsRule.WebClient viewer = jenkins.createWebClient();
+        viewer.login("viewer");
+        HtmlPage viewerConfigure = viewer.getPage(p, "configure");
+        assertThat(
+                "the rich script editor must not be rendered for a viewer without Job/Configure",
+                viewerConfigure.querySelector(".workflow-editor-wrapper"),
+                nullValue());
+        DomNode readonlyScript = viewerConfigure.querySelector("pre.jenkins-readonly");
+        assertThat("the script must still be visible as plain read-only text", readonlyScript, notNullValue());
+        assertThat(readonlyScript.asNormalizedText(), containsString(groovy));
+
+        JenkinsRule.WebClient admin = jenkins.createWebClient();
+        admin.login("admin");
+        HtmlPage adminConfigure = admin.getPage(p, "configure");
+        assertThat(
+                "the rich script editor must still be rendered for a user who can configure the job",
+                adminConfigure.querySelector(".workflow-editor-wrapper"),
+                notNullValue());
     }
 
     @Issue({"SECURITY-2450", "SECURITY-3103"})


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/workflow-cps-plugin/issues/1810

# [JENKINS-62410] Do not render the rich script editor for read-only viewers

## Problem

`workflow-editor.jelly` rendered the rich ACE-based script editor for any user who could reach a job's `configure` page, regardless of whether they actually held `Item/Configure`. A user granted only `Item/Read` + `Item/ExtendedRead` (i.e. allowed to view, but not edit, the pipeline definition) still got a fully interactive editor widget, even though any edit they made could never be saved.

Reported in [JENKINS-62410](https://issues.jenkins.io/browse/JENKINS-62410), and confirmed by a maintainer in [jenkinsci/workflow-aggregator-plugin#1173](https://github.com/jenkinsci/workflow-aggregator-plugin/issues/1173):

> when showing the page to a user that only has read privileges, the script should be visible but not presented in an editor

Jenkins core already has a convention for this case: pages that set the ambient `readOnlyMode` Jelly variable (e.g. `Job/configure.jelly` sets it based on `Item.CONFIGURE`) expect form controls to render read-only via `lib/form/possibleReadOnlyField.jelly`. `workflow-editor.jelly` never checked this variable, so it always rendered the editor whenever `enableWorkflowEditor` was on.

## Changes

- `workflow-editor.jelly`: extend the existing `j:when` condition that decides whether to render the ACE editor to also require `!readOnlyMode`. When `readOnlyMode` is true, the `j:otherwise` branch is used instead, which already renders a plain `f:textarea` — respected by core's read-only rendering machinery, so the script shows as plain text instead of the ACE editor. One line changed, no other files touched.

## Testing

- **New unit test**: `CpsFlowDefinitionTest.readOnlyViewerSeesPlainScriptNotEditor`, which uses `MockAuthorizationStrategy` + `JenkinsRule.WebClient` to verify that:
  - a viewer with `Item.READ`/`Item.EXTENDED_READ` but not `Item.CONFIGURE` never gets the `.workflow-editor-wrapper`, and instead sees the script as plain read-only text (`pre.jenkins-readonly`) containing the original script content.
  - a user with `Item.CONFIGURE` still gets the rich editor as before (no regression for the normal case).
- Targeted test run (`mvn test -Dtest=CpsFlowDefinitionTest`): 11/11 passing, no regressions in the rest of the class.
- **Manual verification** on a local `mvn hpi:run` Jenkins instance: compared an admin user (Item/Configure granted) against a read-only viewer (Item/Read + Item/ExtendedRead only, `-Dhudson.security.ExtendedReadPermission=true`) opening the same job's configure page. Confirmed the admin still sees the ACE editor, while the viewer sees the script as inert read-only text with no editor widget.

## Checklist

- [x] Referenced the Jira issue (JENKINS-62410) in the commit messages
- [x] Added a test that verifies the change
- [x] Unit tests pass locally
- [x] Interactively tested the change on a local Jenkins instance