### PR TITLE
`CpsThread.stop` mishandles a completed step

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -44,7 +44,6 @@ import java.util.logging.Logger;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
-import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.support.concurrent.Futures;
 import org.jenkinsci.plugins.workflow.support.concurrent.Timeout;
@@ -314,7 +313,7 @@ public final class CpsThread implements Serializable {
         // that case s.stop(t) would fall through to CpsStepContext.completed() and be silently
         // dropped as a redundant outcome. Such a step should be treated as absent for the
         // purpose of interruption.
-        if (s == null || isAlreadyCompleted(s)) {
+        if (s == null || s.getContext() instanceof CpsStepContext c && c.isCompleted()) {
             // if it's not running inside a StepExecution, we need to set an interrupt flag
             // and interrupt at an earliest convenience
             Outcome o = new Outcome(null, t);
@@ -333,11 +332,6 @@ public final class CpsThread implements Serializable {
             t.addSuppressed(e);
             s.getContext().onFailure(t);
         }
-    }
-
-    private static boolean isAlreadyCompleted(StepExecution s) {
-        StepContext c = s.getContext();
-        return c instanceof CpsStepContext && ((CpsStepContext) c).isCompleted();
     }
 
     public List<StackTraceElement> getStackTrace() {

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -313,7 +313,7 @@ public final class CpsThread implements Serializable {
         // that case s.stop(t) would fall through to CpsStepContext.completed() and be silently
         // dropped as a redundant outcome. Such a step should be treated as absent for the
         // purpose of interruption.
-        if (s == null || s.getContext() instanceof CpsStepContext c && c.isCompleted()) {
+        if (s == null || (s.getContext() instanceof CpsStepContext c && c.isCompleted())) {
             // if it's not running inside a StepExecution, we need to set an interrupt flag
             // and interrupt at an earliest convenience
             Outcome o = new Outcome(null, t);

--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsThread.java
@@ -44,6 +44,7 @@ import java.util.logging.Logger;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.support.concurrent.Futures;
 import org.jenkinsci.plugins.workflow.support.concurrent.Timeout;
@@ -308,7 +309,12 @@ public final class CpsThread implements Serializable {
     @CpsVmThreadOnly
     public void stop(Throwable t) {
         StepExecution s = getStep(); // this is the part that should run in CpsVmThread
-        if (s == null) {
+        // The step may have already recorded its outcome (e.g. sh responded in time), while
+        // the task that processes its completion is still queued on the CPS VM thread. In
+        // that case s.stop(t) would fall through to CpsStepContext.completed() and be silently
+        // dropped as a redundant outcome. Such a step should be treated as absent for the
+        // purpose of interruption.
+        if (s == null || isAlreadyCompleted(s)) {
             // if it's not running inside a StepExecution, we need to set an interrupt flag
             // and interrupt at an earliest convenience
             Outcome o = new Outcome(null, t);
@@ -327,6 +333,11 @@ public final class CpsThread implements Serializable {
             t.addSuppressed(e);
             s.getContext().onFailure(t);
         }
+    }
+
+    private static boolean isAlreadyCompleted(StepExecution s) {
+        StepContext c = s.getContext();
+        return c instanceof CpsStepContext && ((CpsStepContext) c).isCompleted();
     }
 
     public List<StackTraceElement> getStackTrace() {

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadTest.java
@@ -34,6 +34,7 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.InterruptedBuildAction;
 import jenkins.model.Jenkins;
@@ -49,6 +50,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -98,24 +100,21 @@ public class CpsThreadTest {
      * step completion are queued behind it in the order that reproduces the race, and
      * finally the latch is released.
      */
+    @Issue("https://github.com/jenkinsci/workflow-cps-plugin/issues/1333")
     @Test
     public void interruptNotLostWhenStepAlreadyCompleted() throws Exception {
-        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+        var p = r.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("semaphore 'victim'", true));
-        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        var b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("victim/1", b);
 
-        final SemaphoreStep.Execution[] victim = new SemaphoreStep.Execution[1];
-        StepExecution.acceptAll(SemaphoreStep.Execution.class, exec -> {
-                    if (exec.getContext() != null) {
-                        victim[0] = exec;
-                    }
-                })
+        var victim = new AtomicReference<SemaphoreStep.Execution>();
+        StepExecution.acceptAll(SemaphoreStep.Execution.class, exec -> victim.set(exec))
                 .get();
-        assertNotNull(victim[0]);
+        assertNotNull(victim.get());
 
-        CpsFlowExecution execution = (CpsFlowExecution) b.getExecution();
-        CountDownLatch hold = new CountDownLatch(1);
+        var execution = (CpsFlowExecution) b.getExecution();
+        var hold = new CountDownLatch(1);
 
         // Occupy the single CPS VM thread so the cancellation (queued next) and the
         // processing of the step completion (queued after that) pile up behind it.
@@ -136,7 +135,7 @@ public class CpsThreadTest {
         // Queue the cancellation while the CPS VM thread is still occupied - this
         // mirrors what ParallelStepExecution.stop() (failFast) or
         // TimeoutStepExecution.cancel() do under the hood.
-        FlowInterruptedException cause = new FlowInterruptedException(Result.ABORTED);
+        var cause = new FlowInterruptedException(Result.ABORTED);
         execution.runInCpsVmThread(new FutureCallback<CpsThreadGroup>() {
             @Override
             public void onSuccess(CpsThreadGroup g) {
@@ -153,7 +152,7 @@ public class CpsThreadTest {
         // remote sh step would: the outcome is recorded synchronously here on the live
         // step context, while the task that clears getStep() and resumes the thread is
         // only queued now - after the cancellation above.
-        victim[0].getContext().onSuccess(null);
+        victim.get().getContext().onSuccess(null);
 
         // Let the CPS VM thread process the queued cancellation and completion tasks.
         hold.countDown();

--- a/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsThreadTest.java
@@ -27,11 +27,13 @@ package org.jenkinsci.plugins.workflow.cps;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import com.google.common.util.concurrent.FutureCallback;
 import hudson.AbortException;
 import hudson.model.Result;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.InterruptedBuildAction;
 import jenkins.model.Jenkins;
@@ -40,6 +42,9 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -76,6 +81,85 @@ public class CpsThreadTest {
         r.waitForMessage("Finished: ABORTED", b);
         r.assertLogContains("never going to stop", b);
         r.assertLogNotContains("\tat ", b);
+    }
+
+    /**
+     * Reproduces the race where a step has already recorded its outcome (e.g. a remote
+     * step just responded), but the queued task that clears {@link CpsThread#getStep()}
+     * and resumes the thread has not run yet, because the CPS VM thread was busy with
+     * other work. If an interrupt (from {@code failFast}, {@code timeout}, or a manual
+     * abort) is queued behind that busy period, {@link CpsThread#stop} used to see
+     * {@code getStep() != null} and delegate to the step, whose
+     * {@link CpsStepContext#onFailure} then silently discarded the interrupt as a
+     * duplicate outcome - the step resumed with its original success and kept running.
+     *
+     * <p>The ordering here is controlled directly rather than via timing: the CPS VM
+     * thread is occupied by a task that blocks on a latch, then the cancellation and the
+     * step completion are queued behind it in the order that reproduces the race, and
+     * finally the latch is released.
+     */
+    @Test
+    public void interruptNotLostWhenStepAlreadyCompleted() throws Exception {
+        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("semaphore 'victim'", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("victim/1", b);
+
+        final SemaphoreStep.Execution[] victim = new SemaphoreStep.Execution[1];
+        StepExecution.acceptAll(SemaphoreStep.Execution.class, exec -> {
+                    if (exec.getContext() != null) {
+                        victim[0] = exec;
+                    }
+                })
+                .get();
+        assertNotNull(victim[0]);
+
+        CpsFlowExecution execution = (CpsFlowExecution) b.getExecution();
+        CountDownLatch hold = new CountDownLatch(1);
+
+        // Occupy the single CPS VM thread so the cancellation (queued next) and the
+        // processing of the step completion (queued after that) pile up behind it.
+        execution.runInCpsVmThread(new FutureCallback<CpsThreadGroup>() {
+            @Override
+            public void onSuccess(CpsThreadGroup g) {
+                try {
+                    hold.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {}
+        });
+
+        // Queue the cancellation while the CPS VM thread is still occupied - this
+        // mirrors what ParallelStepExecution.stop() (failFast) or
+        // TimeoutStepExecution.cancel() do under the hood.
+        FlowInterruptedException cause = new FlowInterruptedException(Result.ABORTED);
+        execution.runInCpsVmThread(new FutureCallback<CpsThreadGroup>() {
+            @Override
+            public void onSuccess(CpsThreadGroup g) {
+                for (CpsThread t : g.getThreads()) {
+                    t.stop(cause);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {}
+        });
+
+        // The step "responds" now, from outside the CPS VM thread, exactly like a
+        // remote sh step would: the outcome is recorded synchronously here on the live
+        // step context, while the task that clears getStep() and resumes the thread is
+        // only queued now - after the cancellation above.
+        victim[0].getContext().onSuccess(null);
+
+        // Let the CPS VM thread process the queued cancellation and completion tasks.
+        hold.countDown();
+
+        r.waitForCompletion(b);
+        r.assertBuildStatus(Result.ABORTED, b);
     }
 
     public static class UnkillableStep extends AbstractStepImpl {


### PR DESCRIPTION
Fixes #1333. Subsumes #1822. Checked that test passes 30× in a row (also that it fails without fix).