### PR TITLE
Handle missing FlowExecutionOwner

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/EnvActionImpl.java
@@ -122,12 +122,12 @@ public class EnvActionImpl extends GroovyObjectSupport implements EnvironmentAct
 
     private FlowExecution getExecution() throws IOException {
         if (owner instanceof FlowExecutionOwner.Executable) {
-            return ((FlowExecutionOwner.Executable) owner)
-                    .asFlowExecutionOwner()
-                    .get();
-        } else {
-            throw new IOException("no FlowExecution");
+            FlowExecutionOwner executionOwner = ((FlowExecutionOwner.Executable) owner).asFlowExecutionOwner();
+            if (executionOwner != null) {
+                return executionOwner.get();
+            }
         }
+        throw new IOException("no FlowExecution");
     }
 
     private FlowNode getNode() throws IOException {


### PR DESCRIPTION
Companion fix for Dependabot PR #1824, based directly on bot head `50649e5e23ee42f6e2d62aadcf01ad1045baf527`.

The plugin-parent update enables SpotBugs 4.10.3.0, which reports `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE` in `EnvActionImpl.getExecution()`. `FlowExecutionOwner.Executable.asFlowExecutionOwner()` is nullable during lifecycle transitions, but this path dereferenced it unconditionally.

This change follows the null handling already used by `getListener()` in the same class. When the execution owner is unavailable, `getExecution()` now uses its declared `IOException` failure path instead of throwing an accidental `NullPointerException`; its caller already handles that failure and returns no environment property.

Verification on Java 21:

- Exact Dependabot head: `mvn --batch-mode --no-transfer-progress -DskipTests verify` reproduced the single SpotBugs failure in `EnvActionImpl`.
- Candidate: the same verification completed successfully across all four reactor modules; SpotBugs reported 0 bugs and 0 errors.
- Focused Pipeline coverage: `WorkflowTest#env`, all three `DynamicEnvironmentExpanderTest` cases, and `CpsFlowExecutionTest#envActionImplPickle` passed (5 tests, including a Jenkins restart/pickle path).

The change is one production file and does not suppress or reconfigure SpotBugs.
